### PR TITLE
✨ Inline status picker overlay for TUI

### DIFF
--- a/docs/iterations/ITERATION-044-status-picker-overlay.md
+++ b/docs/iterations/ITERATION-044-status-picker-overlay.md
@@ -1,0 +1,155 @@
+---
+title: Status picker overlay
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-08
+tags: []
+related:
+- implements: docs/stories/STORY-016-status-picker.md
+---
+
+
+
+## Changes
+
+### Task 1: StatusPicker struct and App integration
+
+**ACs addressed:** AC1, AC5
+
+**Files:**
+- Modify: `src/tui/app.rs`
+
+**What to implement:**
+
+Add a `StatusPicker` struct following the `DeleteConfirm` pattern:
+
+```rust
+pub struct StatusPicker {
+    pub active: bool,
+    pub selected: usize,
+    pub doc_path: PathBuf,
+}
+```
+
+With a `new()` that defaults to `active: false, selected: 0, doc_path: PathBuf::new()`.
+
+Add `pub status_picker: StatusPicker` to the `App` struct. Initialise it in `App::new()`.
+
+Add three methods on `App`:
+
+- `open_status_picker()` -- guard on `selected_doc_meta()` returning `Some`. Read the doc's current status, map it to an index (Draft=0, Review=1, Accepted=2, Rejected=3, Superseded=4), set `status_picker.selected` to that index, store the doc path, set `active = true`.
+- `close_status_picker()` -- reset to defaults.
+- `confirm_status_change(&mut self, root: &Path)` -- read `status_picker.selected`, map index back to a `Status` variant, call `cli::update::run(root, doc_path_str, &[("status", &status.to_string())])`, then `store.reload_file(root, &relative_path)`, then `rebuild_doc_tree(config)`, then `close_status_picker()`. Return `Result<()>`.
+
+Also add `open_status_picker` for Filters mode: use `selected_filtered_doc()` instead of `selected_doc_meta()` to get the doc path when in Filters mode. The simplest approach is a single method that checks `self.view_mode` to pick the right accessor.
+
+**How to verify:**
+`cargo test` -- unit tests in Task 3 cover this.
+
+---
+
+### Task 2: Key handling and overlay dispatch
+
+**ACs addressed:** AC1, AC2, AC4, AC5, AC6
+
+**Files:**
+- Modify: `src/tui/app.rs`
+
+**What to implement:**
+
+In `handle_key()`, add a check for `self.status_picker.active` in the overlay priority chain, after `delete_confirm` and before `search_mode`:
+
+```rust
+if self.status_picker.active {
+    return self.handle_status_picker_key(code, root);
+}
+```
+
+Implement `handle_status_picker_key(&mut self, code: KeyCode, root: &Path)`:
+- `KeyCode::Char('j') | KeyCode::Down` -- increment `selected`, clamp to 4 (five statuses).
+- `KeyCode::Char('k') | KeyCode::Up` -- decrement `selected`, clamp to 0.
+- `KeyCode::Enter` -- call `self.confirm_status_change(root)`.
+- `KeyCode::Esc` -- call `self.close_status_picker()`.
+
+In `handle_normal_key()`, add `KeyCode::Char('s')` for both Types mode (the default match arm) and Filters mode (the Filters match arm). Both call `self.open_status_picker()`.
+
+**How to verify:**
+`cargo test` -- unit tests in Task 3 cover this.
+
+---
+
+### Task 3: Tests
+
+**ACs addressed:** AC1, AC2, AC3, AC4, AC5, AC6
+
+**Files:**
+- Create: `tests/tui_status_picker_test.rs`
+
+**What to implement:**
+
+Follow the `tui_delete_dialog_test.rs` pattern. Use `TestFixture` and `App::new`.
+
+Planned tests:
+
+1. **`test_open_status_picker_populates_from_selected_doc`** (AC1) -- Select an RFC with status "draft". Call `open_status_picker()`. Assert `status_picker.active == true`, `status_picker.selected == 0` (draft index), `status_picker.doc_path` matches the doc.
+
+2. **`test_open_status_picker_preselects_current_status`** (AC1) -- Write an RFC with status "accepted". Call `open_status_picker()`. Assert `status_picker.selected == 2` (accepted index).
+
+3. **`test_status_picker_navigation`** (AC2) -- Open picker on a draft doc (selected=0). Send `j` key. Assert selected == 1. Send `k` key. Assert selected == 0. Send `k` again. Assert selected == 0 (clamped).
+
+4. **`test_confirm_status_change_updates_frontmatter`** (AC4) -- Open picker on a draft doc. Set `status_picker.selected = 2` (accepted). Call `confirm_status_change(root)`. Read the file from disk, assert frontmatter contains `status: accepted`. Assert `store.get()` returns the doc with `Status::Accepted`. Assert `status_picker.active == false`.
+
+5. **`test_cancel_status_picker_no_changes`** (AC5) -- Open picker on a draft doc. Call `close_status_picker()`. Assert file still has `status: draft`. Assert `status_picker.active == false`.
+
+6. **`test_status_picker_on_empty_list_noop`** (AC1) -- No docs. Call `open_status_picker()`. Assert `status_picker.active == false`.
+
+7. **`test_status_picker_in_filters_mode`** (AC6) -- Switch to `ViewMode::Filters`. Select a doc. Call `open_status_picker()`. Assert picker opens correctly.
+
+8. **`test_handle_key_s_opens_picker`** (AC1, AC6) -- In Types mode with a doc selected, send `s` key via `handle_key()`. Assert `status_picker.active == true`.
+
+**How to verify:**
+`cargo test tui_status_picker`
+
+---
+
+### Task 4: Overlay rendering
+
+**ACs addressed:** AC1, AC3
+
+**Files:**
+- Modify: `src/tui/ui.rs`
+
+**What to implement:**
+
+Add a `draw_status_picker(f: &mut Frame, app: &App)` function following the `draw_delete_confirm` pattern.
+
+Render a centered popup (width ~25, height ~9). Use `Clear` widget, rounded borders, border colour cyan (to match selection highlighting).
+
+List all five statuses as lines. Each status line is coloured using the existing `status_color()` function (Draft=Yellow, Review=Blue, Accepted=Green, Rejected=Red, Superseded=DarkGray). The line at index `app.status_picker.selected` gets a `> ` prefix and bold styling.
+
+Add a help line at the bottom: `[j/k: select] [Enter: confirm] [Esc: cancel]` in DarkGray.
+
+Call this function from the main `draw()` function, guarded by `if app.status_picker.active`, after the existing delete confirm draw call.
+
+**How to verify:**
+`cargo run` then press `s` on a document. Visual check: popup appears with coloured statuses, selection moves with j/k, Enter changes the status, Esc dismisses.
+
+## Test Plan
+
+| Test | AC | Properties traded |
+|------|----|-------------------|
+| open populates from selected doc | AC1 | -- |
+| preselects current status | AC1 | -- |
+| j/k navigation with clamping | AC2 | -- |
+| confirm writes frontmatter + reloads store | AC4 | Trades Fast slightly (disk I/O via TestFixture) for Predictive |
+| cancel preserves file | AC5 | -- |
+| empty list is noop | AC1 | -- |
+| works in Filters mode | AC6 | -- |
+| handle_key 's' opens picker | AC1, AC6 | -- |
+
+AC3 (status colours) is covered visually. The colour mapping is already tested implicitly via `status_color()` being a pure function with no branching complexity worth unit testing in isolation. The rendering test would require a frame buffer assertion, which trades Writable for marginal confidence.
+
+## Notes
+
+The `cli::update::run` function takes a `&str` doc path relative to root. The `StatusPicker` stores a `PathBuf`. The confirm method needs to convert via `doc_path.to_str()` or strip the root prefix, depending on whether the stored path is relative or absolute. Match the pattern used by `confirm_delete` which stores relative paths.

--- a/docs/stories/STORY-016-status-picker.md
+++ b/docs/stories/STORY-016-status-picker.md
@@ -1,13 +1,14 @@
 ---
 title: "Status Picker"
 type: story
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-05
 tags: [tui]
 related:
   - implements: docs/rfcs/RFC-006-tui-progressive-disclosure.md
 ---
+
 
 ## Context
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -175,6 +175,22 @@ impl DeleteConfirm {
     }
 }
 
+pub struct StatusPicker {
+    pub active: bool,
+    pub selected: usize,
+    pub doc_path: PathBuf,
+}
+
+impl StatusPicker {
+    pub fn new() -> Self {
+        StatusPicker {
+            active: false,
+            selected: 0,
+            doc_path: PathBuf::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ViewMode {
     Types,
@@ -228,6 +244,7 @@ pub struct App {
     pub selected_relation: usize,
     pub create_form: CreateForm,
     pub delete_confirm: DeleteConfirm,
+    pub status_picker: StatusPicker,
     pub view_mode: ViewMode,
     pub graph_nodes: Vec<GraphNode>,
     pub graph_selected: usize,
@@ -277,6 +294,7 @@ impl App {
             selected_relation: 0,
             create_form: CreateForm::new(),
             delete_confirm: DeleteConfirm::new(),
+            status_picker: StatusPicker::new(),
             view_mode: ViewMode::Types,
             graph_nodes: Vec::new(),
             graph_selected: 0,
@@ -921,6 +939,58 @@ impl App {
         Ok(())
     }
 
+    pub fn open_status_picker(&mut self) {
+        let doc = if self.view_mode == ViewMode::Filters {
+            match self.selected_filtered_doc() {
+                Some(d) => d,
+                None => return,
+            }
+        } else {
+            match self.selected_doc_meta() {
+                Some(d) => d,
+                None => return,
+            }
+        };
+
+        let index = match &doc.status {
+            Status::Draft => 0,
+            Status::Review => 1,
+            Status::Accepted => 2,
+            Status::Rejected => 3,
+            Status::Superseded => 4,
+        };
+        let path = doc.path.clone();
+
+        self.status_picker.selected = index;
+        self.status_picker.doc_path = path;
+        self.status_picker.active = true;
+    }
+
+    pub fn close_status_picker(&mut self) {
+        self.status_picker.active = false;
+        self.status_picker.selected = 0;
+        self.status_picker.doc_path = PathBuf::new();
+    }
+
+    pub fn confirm_status_change(&mut self, root: &Path, _config: &Config) -> Result<()> {
+        let status = match self.status_picker.selected {
+            0 => Status::Draft,
+            1 => Status::Review,
+            2 => Status::Accepted,
+            3 => Status::Rejected,
+            4 => Status::Superseded,
+            _ => return Err(anyhow!("invalid status index")),
+        };
+        let doc_path = self.status_picker.doc_path.clone();
+        let doc_path_str = doc_path.to_string_lossy().to_string();
+
+        crate::cli::update::run(root, &doc_path_str, &[("status", &status.to_string())])?;
+        self.store.reload_file(root, &doc_path)?;
+        self.build_doc_tree();
+        self.close_status_picker();
+        Ok(())
+    }
+
     pub fn open_warnings(&mut self) {
         self.show_warnings = true;
         self.warnings_selected = 0;
@@ -971,6 +1041,9 @@ impl App {
         if self.delete_confirm.active {
             return self.handle_delete_confirm_key(code, root);
         }
+        if self.status_picker.active {
+            return self.handle_status_picker_key(code, root, config);
+        }
         if self.search_mode {
             return self.handle_search_key(code, modifiers);
         }
@@ -998,6 +1071,26 @@ impl App {
         match code {
             KeyCode::Enter => { let _ = self.confirm_delete(root); }
             KeyCode::Esc => self.close_delete_confirm(),
+            _ => {}
+        }
+    }
+
+    fn handle_status_picker_key(&mut self, code: KeyCode, root: &Path, config: &Config) {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.status_picker.selected < 4 {
+                    self.status_picker.selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.status_picker.selected > 0 {
+                    self.status_picker.selected -= 1;
+                }
+            }
+            KeyCode::Enter => {
+                let _ = self.confirm_status_change(root, config);
+            }
+            KeyCode::Esc => self.close_status_picker(),
             _ => {}
         }
     }
@@ -1130,6 +1223,9 @@ impl App {
                 }
                 KeyCode::Char('w') => {
                     self.open_warnings();
+                }
+                KeyCode::Char('s') => {
+                    self.open_status_picker();
                 }
                 _ => {}
             }
@@ -1266,6 +1362,7 @@ impl App {
             (KeyCode::Char('G'), _) => self.move_to_bottom(),
             (KeyCode::Char('`'), _) => self.cycle_mode(),
             (KeyCode::Char('w'), _) => self.open_warnings(),
+            (KeyCode::Char('s'), _) => self.open_status_picker(),
             _ => {}
         }
     }
@@ -1351,6 +1448,7 @@ mod tests {
             selected_relation: 0,
             create_form: CreateForm::new(),
             delete_confirm: DeleteConfirm::new(),
+            status_picker: StatusPicker::new(),
             view_mode: ViewMode::Types,
             graph_nodes: Vec::new(),
             graph_selected: 0,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -139,6 +139,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_delete_confirm(f, app);
     }
 
+    if app.status_picker.active {
+        draw_status_picker(f, app);
+    }
+
     if app.show_warnings {
         draw_warnings_panel(f, app);
     }
@@ -737,6 +741,54 @@ fn draw_delete_confirm(f: &mut Frame, app: &App) {
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Red))
             .title(" Delete? "),
+    );
+    f.render_widget(paragraph, popup_area);
+}
+
+fn draw_status_picker(f: &mut Frame, app: &App) {
+    let area = f.area();
+
+    let popup_width = 25u16.min(area.width.saturating_sub(4));
+    let popup_height = 9u16.min(area.height.saturating_sub(4));
+    let x = (area.width.saturating_sub(popup_width)) / 2;
+    let y = (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    f.render_widget(Clear, popup_area);
+
+    let statuses = [
+        Status::Draft,
+        Status::Review,
+        Status::Accepted,
+        Status::Rejected,
+        Status::Superseded,
+    ];
+
+    let mut lines: Vec<Line> = statuses
+        .iter()
+        .enumerate()
+        .map(|(i, status)| {
+            let prefix = if i == app.status_picker.selected { "> " } else { "  " };
+            let mut style = Style::default().fg(status_color(status));
+            if i == app.status_picker.selected {
+                style = style.add_modifier(Modifier::BOLD);
+            }
+            Line::from(Span::styled(format!("{}{}", prefix, status), style))
+        })
+        .collect();
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "[j/k] [Enter] [Esc]",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Status "),
     );
     f.render_widget(paragraph, popup_area);
 }

--- a/tests/tui_status_picker_test.rs
+++ b/tests/tui_status_picker_test.rs
@@ -1,0 +1,197 @@
+mod common;
+
+use common::TestFixture;
+use crossterm::event::{KeyCode, KeyModifiers};
+use lazyspec::engine::document::Status;
+use lazyspec::tui::app::{App, ViewMode};
+
+fn setup_app_with_rfc(title: &str, status: &str) -> (TestFixture, App) {
+    let fixture = TestFixture::new();
+    fixture.write_rfc("RFC-001-test.md", title, status);
+    let store = fixture.store();
+    let app = App::new(store, &fixture.config());
+    (fixture, app)
+}
+
+fn enter_filters_mode(app: &mut App, fixture: &TestFixture) {
+    while app.view_mode != ViewMode::Filters {
+        app.handle_key(
+            KeyCode::Char('`'),
+            KeyModifiers::NONE,
+            fixture.root(),
+            &fixture.config(),
+        );
+    }
+}
+
+// AC1: opening the picker populates fields from the selected doc
+#[test]
+fn test_open_status_picker_populates_from_selected_doc() {
+    let (_fixture, mut app) = setup_app_with_rfc("Draft RFC", "draft");
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.open_status_picker();
+
+    assert!(app.status_picker.active);
+    assert_eq!(app.status_picker.selected, 0); // draft index
+    assert_eq!(
+        app.status_picker.doc_path,
+        std::path::PathBuf::from("docs/rfcs/RFC-001-test.md")
+    );
+}
+
+// AC1: picker pre-selects the current status
+#[test]
+fn test_open_status_picker_preselects_current_status() {
+    let (_fixture, mut app) = setup_app_with_rfc("Accepted RFC", "accepted");
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.open_status_picker();
+
+    assert!(app.status_picker.active);
+    assert_eq!(app.status_picker.selected, 2); // accepted index
+}
+
+// AC2: j/k navigates, clamped at boundaries
+#[test]
+fn test_status_picker_navigation() {
+    let (fixture, mut app) = setup_app_with_rfc("Nav RFC", "draft");
+    let root = fixture.root();
+    let config = fixture.config();
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.open_status_picker();
+    assert_eq!(app.status_picker.selected, 0);
+
+    // j moves down
+    app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE, root, &config);
+    assert_eq!(app.status_picker.selected, 1);
+
+    // k moves back up
+    app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE, root, &config);
+    assert_eq!(app.status_picker.selected, 0);
+
+    // k at 0 stays clamped
+    app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE, root, &config);
+    assert_eq!(app.status_picker.selected, 0);
+
+    // navigate to max (4 = superseded)
+    for _ in 0..10 {
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE, root, &config);
+    }
+    assert_eq!(app.status_picker.selected, 4);
+
+    // j at 4 stays clamped
+    app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE, root, &config);
+    assert_eq!(app.status_picker.selected, 4);
+}
+
+// AC4: confirming writes new status to frontmatter and reloads store
+#[test]
+fn test_confirm_status_change_updates_frontmatter() {
+    let (fixture, mut app) = setup_app_with_rfc("Update RFC", "draft");
+    let root = fixture.root();
+    let config = fixture.config();
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.open_status_picker();
+
+    // Select "accepted" (index 2)
+    app.status_picker.selected = 2;
+    app.confirm_status_change(root, &config).unwrap();
+
+    // Verify file on disk
+    let content = std::fs::read_to_string(root.join("docs/rfcs/RFC-001-test.md")).unwrap();
+    assert!(
+        content.contains("status: accepted"),
+        "frontmatter should contain 'status: accepted', got:\n{}",
+        content
+    );
+
+    // Verify store updated
+    let doc = app
+        .store
+        .get(std::path::Path::new("docs/rfcs/RFC-001-test.md"))
+        .expect("doc should still exist in store");
+    assert_eq!(doc.status, Status::Accepted);
+
+    // Picker should be closed
+    assert!(!app.status_picker.active);
+}
+
+// AC5: cancelling preserves original status
+#[test]
+fn test_cancel_status_picker_no_changes() {
+    let (fixture, mut app) = setup_app_with_rfc("Safe RFC", "draft");
+    let root = fixture.root();
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.open_status_picker();
+    app.close_status_picker();
+
+    assert!(!app.status_picker.active);
+
+    let content = std::fs::read_to_string(root.join("docs/rfcs/RFC-001-test.md")).unwrap();
+    assert!(
+        content.contains("status: draft"),
+        "file should still have 'status: draft'"
+    );
+}
+
+// AC1: opening picker on empty list is a no-op
+#[test]
+fn test_status_picker_on_empty_list_noop() {
+    let fixture = TestFixture::new();
+    let store = fixture.store();
+    let mut app = App::new(store, &fixture.config());
+
+    app.selected_type = 0;
+    app.open_status_picker();
+
+    assert!(!app.status_picker.active);
+}
+
+// AC6: picker works in Filters mode
+#[test]
+fn test_status_picker_in_filters_mode() {
+    let fixture = TestFixture::new();
+    fixture.write_rfc("RFC-001-filtered.md", "Filtered RFC", "review");
+    let store = fixture.store();
+    let mut app = App::new(store, &fixture.config());
+
+    enter_filters_mode(&mut app, &fixture);
+    assert_eq!(app.view_mode, ViewMode::Filters);
+
+    app.selected_doc = 0;
+    app.open_status_picker();
+
+    assert!(app.status_picker.active);
+    assert_eq!(app.status_picker.selected, 1); // review index
+    assert_eq!(
+        app.status_picker.doc_path,
+        std::path::PathBuf::from("docs/rfcs/RFC-001-filtered.md")
+    );
+}
+
+// AC1, AC6: pressing 's' key opens the picker via handle_key
+#[test]
+fn test_handle_key_s_opens_picker() {
+    let (fixture, mut app) = setup_app_with_rfc("Key RFC", "draft");
+
+    app.selected_type = 0;
+    app.selected_doc = 0;
+    app.handle_key(
+        KeyCode::Char('s'),
+        KeyModifiers::NONE,
+        fixture.root(),
+        &fixture.config(),
+    );
+
+    assert!(app.status_picker.active);
+    assert_eq!(app.status_picker.selected, 0);
+}


### PR DESCRIPTION
## Summary

- Add inline status picker overlay triggered by `s` key on a selected document
- Picker lists all five statuses (draft, review, accepted, rejected, superseded) with colour coding
- Navigate with `j/k`, confirm with Enter, cancel with Esc
- On confirm, writes the new status to frontmatter on disk and reloads the store
- Works in both Types and Filters modes

## Story

Implements [STORY-016: Status Picker](docs/stories/STORY-016-status-picker.md) from [RFC-006: TUI Progressive Disclosure](docs/rfcs/RFC-006-tui-progressive-disclosure.md).