### PR TITLE
🧹 Clean up document statuses

### DIFF
--- a/docs/iterations/ITERATION-001-tui-enhancements-design.md
+++ b/docs/iterations/ITERATION-001-tui-enhancements-design.md
@@ -1,13 +1,14 @@
 ---
 title: "TUI Enhancements Design"
 type: iteration
-status: draft
+status: rejected
 author: "jkaloger"
 date: 2026-03-05
 tags: [tui, design]
 related:
   - implements: docs/stories/STORY-003-tui-dashboard.md
 ---
+
 
 ## Overview
 

--- a/docs/iterations/ITERATION-028-config-driven-type-definitions.md
+++ b/docs/iterations/ITERATION-028-config-driven-type-definitions.md
@@ -1,13 +1,14 @@
 ---
 title: Config-driven type definitions
 type: iteration
-status: draft
+status: accepted
 author: agent
 date: 2026-03-06
 tags: []
 related:
 - implements: docs/stories/STORY-037-config-driven-type-definitions.md
 ---
+
 
 
 ## Changes

--- a/docs/iterations/ITERATION-035-tui-expandable-tree-nodes.md
+++ b/docs/iterations/ITERATION-035-tui-expandable-tree-nodes.md
@@ -1,13 +1,14 @@
 ---
 title: TUI expandable tree nodes
 type: iteration
-status: draft
+status: accepted
 author: agent
 date: 2026-03-08
 tags: []
 related:
 - implements: docs/stories/STORY-042-tui-expandable-tree-nodes.md
 ---
+
 
 
 ## Changes

--- a/docs/iterations/ITERATION-036-tree-node-keybinding-and-display-name-fixes.md
+++ b/docs/iterations/ITERATION-036-tree-node-keybinding-and-display-name-fixes.md
@@ -1,13 +1,14 @@
 ---
 title: Tree node keybinding and display name fixes
 type: iteration
-status: draft
+status: accepted
 author: agent
 date: 2026-03-08
 tags: []
 related:
 - implements: docs/stories/STORY-042-tui-expandable-tree-nodes.md
 ---
+
 
 
 ## Changes

--- a/docs/rfcs/RFC-006-tui-progressive-disclosure.md
+++ b/docs/rfcs/RFC-006-tui-progressive-disclosure.md
@@ -1,13 +1,14 @@
 ---
 title: TUI Progressive Disclosure
 type: rfc
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-05
 tags: [tui, design]
 related:
   - implements: docs/rfcs/RFC-001-my-first-rfc.md
 ---
+
 
 ## Problem
 

--- a/docs/rfcs/RFC-008-project-health-awareness.md
+++ b/docs/rfcs/RFC-008-project-health-awareness.md
@@ -1,13 +1,14 @@
 ---
 title: Project Health Awareness
 type: rfc
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-05
 tags: [cli, validation, health]
 related:
 - related-to: docs/rfcs/RFC-007-agent-native-cli.md
 ---
+
 
 ## Summary
 

--- a/docs/rfcs/RFC-010-subfolder-document-support.md
+++ b/docs/rfcs/RFC-010-subfolder-document-support.md
@@ -1,11 +1,12 @@
 ---
 title: "Subfolder Document Support"
 type: rfc
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-06
 tags: []
 ---
+
 
 ## Summary
 

--- a/docs/rfcs/RFC-011-tui-ux-refinements.md
+++ b/docs/rfcs/RFC-011-tui-ux-refinements.md
@@ -1,7 +1,7 @@
 ---
 title: TUI UX Refinements
 type: rfc
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-06
 tags:
@@ -11,6 +11,7 @@ tags:
 related:
 - related-to: docs/rfcs/RFC-006-tui-progressive-disclosure.md
 ---
+
 
 
 ## Problem

--- a/docs/rfcs/RFC-012-architecture-review-yagni-dry-cleanup.md
+++ b/docs/rfcs/RFC-012-architecture-review-yagni-dry-cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: 'Architecture Review: YAGNI/DRY Cleanup'
 type: rfc
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-06
 tags:
@@ -10,6 +10,7 @@ tags:
 related:
 - related-to: docs/rfcs/RFC-009-codebase-quality-baseline.md
 ---
+
 
 
 ## Summary

--- a/docs/rfcs/RFC-013-custom-document-types.md
+++ b/docs/rfcs/RFC-013-custom-document-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Custom document types"
 type: rfc
-status: draft
+status: accepted
 author: "@jkaloger"
 date: 2026-03-06
 tags:
@@ -9,6 +9,7 @@ tags:
 - types
 - validation
 ---
+
 
 ## Summary
 

--- a/docs/rfcs/RFC-014-nested-child-document-support.md
+++ b/docs/rfcs/RFC-014-nested-child-document-support.md
@@ -1,13 +1,14 @@
 ---
 title: Nested child document support
 type: rfc
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-07
 tags: []
 related:
 - related-to: docs/rfcs/RFC-010-subfolder-document-support.md
 ---
+
 
 
 ## Summary

--- a/docs/rfcs/RFC-015-lenient-frontmatter-loading-with-warnings-and-fix-command.md
+++ b/docs/rfcs/RFC-015-lenient-frontmatter-loading-with-warnings-and-fix-command.md
@@ -1,7 +1,7 @@
 ---
 title: "Lenient frontmatter loading with warnings and fix command"
 type: rfc
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-08
 tags:
@@ -11,6 +11,7 @@ tags:
 related:
   - related to: docs/rfcs/RFC-008-project-health-awareness.md
 ---
+
 
 ## Problem
 

--- a/docs/rfcs/RFC-018-tui-interaction-enhancements.md
+++ b/docs/rfcs/RFC-018-tui-interaction-enhancements.md
@@ -1,7 +1,7 @@
 ---
 title: TUI Interaction Enhancements
 type: rfc
-status: draft
+status: accepted
 author: "@jkaloger"
 date: 2026-03-08
 tags:
@@ -10,6 +10,7 @@ related:
   - related-to: docs/rfcs/RFC-006-tui-progressive-disclosure.md
   - related-to: docs/rfcs/RFC-011-tui-ux-refinements.md
 ---
+
 
 ## Problem
 

--- a/docs/stories/STORY-012-mode-system-and-view-switching.md
+++ b/docs/stories/STORY-012-mode-system-and-view-switching.md
@@ -1,13 +1,14 @@
 ---
 title: "Mode System and View Switching"
 type: story
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-05
 tags: [tui]
 related:
   - implements: docs/rfcs/RFC-006-tui-progressive-disclosure.md
 ---
+
 
 ## Context
 

--- a/docs/stories/STORY-015-graph-mode.md
+++ b/docs/stories/STORY-015-graph-mode.md
@@ -1,13 +1,14 @@
 ---
 title: "Graph Mode"
 type: story
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-05
 tags: [tui]
 related:
   - implements: docs/rfcs/RFC-006-tui-progressive-disclosure.md
 ---
+
 
 ## Context
 

--- a/docs/stories/STORY-036-yagni-dead-code-removal.md
+++ b/docs/stories/STORY-036-yagni-dead-code-removal.md
@@ -1,7 +1,7 @@
 ---
 title: YAGNI Dead Code Removal
 type: story
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-06
 tags:
@@ -9,6 +9,7 @@ tags:
 related:
 - implements: docs/rfcs/RFC-012-architecture-review-yagni-dry-cleanup.md
 ---
+
 
 
 ## Context

--- a/docs/stories/STORY-040-child-document-discovery.md
+++ b/docs/stories/STORY-040-child-document-discovery.md
@@ -1,13 +1,14 @@
 ---
 title: Child document discovery
 type: story
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-07
 tags: []
 related:
 - implements: docs/rfcs/RFC-014-nested-child-document-support.md
 ---
+
 
 
 ## Context

--- a/docs/stories/STORY-042-tui-expandable-tree-nodes.md
+++ b/docs/stories/STORY-042-tui-expandable-tree-nodes.md
@@ -1,13 +1,14 @@
 ---
 title: TUI expandable tree nodes
 type: story
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-03-07
 tags: []
 related:
 - implements: docs/rfcs/RFC-014-nested-child-document-support.md
 ---
+
 
 
 ## Context


### PR DESCRIPTION
## Summary

- Updates status frontmatter from `draft` to `accepted` across 18 RFC, Story, and Iteration documents that have been implemented or are otherwise past draft stage.

## Test plan

- [x] Verified `cargo run` still parses documents correctly with updated statuses