### PR TITLE
Spec-driven workflow examples 📝

### DIFF
--- a/examples/spec/.lazyspec.toml
+++ b/examples/spec/.lazyspec.toml
@@ -1,0 +1,30 @@
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+icon = "●"
+
+[[types]]
+name = "spec"
+plural = "specs"
+dir = "docs/specs"
+prefix = "SPEC"
+icon = "◆"
+
+[[types]]
+name = "plan"
+plural = "plans"
+dir = "docs/plans"
+prefix = "PLAN"
+icon = "▲"
+
+[[types]]
+name = "adr"
+plural = "adrs"
+dir = "docs/adrs"
+prefix = "ADR"
+icon = "■"
+
+[templates]
+dir = ".lazyspec/templates"

--- a/examples/spec/.lazyspec/templates/adr.md
+++ b/examples/spec/.lazyspec/templates/adr.md
@@ -1,0 +1,21 @@
+---
+title: "{title}"
+type: adr
+status: draft
+author: "{author}"
+date: {date}
+tags: []
+related: []
+---
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/examples/spec/.lazyspec/templates/plan.md
+++ b/examples/spec/.lazyspec/templates/plan.md
@@ -1,0 +1,35 @@
+---
+title: "{title}"
+type: plan
+status: draft
+author: "{author}"
+date: {date}
+tags: []
+related: []
+---
+
+## Changes
+
+Numbered task breakdown. Each task should be self-contained enough for a zero-context subagent.
+
+### Task 1: [descriptive name]
+
+**Contracts addressed:** [which spec contracts this implements]
+
+**Files:**
+- Create/Modify: `exact/path/to/file`
+- Test: `tests/exact/path/to/test`
+
+**What to implement:**
+[Complete description of the work]
+
+**How to verify:**
+[Test commands and expected output]
+
+## Test Plan
+
+For each spec contract this plan covers, describe the test that will verify it.
+
+## Notes
+
+Discoveries, decisions, or context gathered during planning.

--- a/examples/spec/.lazyspec/templates/rfc.md
+++ b/examples/spec/.lazyspec/templates/rfc.md
@@ -1,0 +1,32 @@
+---
+title: "{title}"
+type: rfc
+status: draft
+author: "{author}"
+date: {date}
+tags: []
+related: []
+---
+
+## Summary
+
+One paragraph describing the proposal and its motivation.
+
+## Problem
+
+What problem does this solve? Why does it matter now?
+
+## Proposal
+
+The proposed design. Include interface sketches, data flow, and key decisions.
+
+## Alternatives
+
+What else was considered and why it was rejected.
+
+## Specs
+
+Vertical slices that fall out of this RFC. Each spec locks down the contracts for one slice.
+
+- **Spec 1:** [title and scope]
+- **Spec 2:** [title and scope]

--- a/examples/spec/.lazyspec/templates/spec.md
+++ b/examples/spec/.lazyspec/templates/spec.md
@@ -1,0 +1,50 @@
+---
+title: "{title}"
+type: spec
+status: draft
+author: "{author}"
+date: {date}
+tags: []
+related: []
+---
+
+## Summary
+
+One paragraph describing what this spec locks down and why.
+
+## Data Models
+
+Types, schemas, and structures. Use `@draft` for new types and `@ref` for existing ones.
+
+## API Surface
+
+Endpoints, function signatures, message formats. Include request/response shapes.
+
+## Validation Rules
+
+Input constraints, business rules, invariants that must hold.
+
+## Error Handling
+
+Error types, codes, messages. How failures propagate and what callers see.
+
+## Edge Cases
+
+Boundary conditions, race conditions, unusual inputs. Document expected behavior.
+
+<!-- Optional: use for user-story-style specs -->
+<!-- ## Acceptance Criteria
+
+Given [precondition]
+When [action]
+Then [expected outcome] -->
+
+## Scope
+
+### In Scope
+
+What this spec covers.
+
+### Out of Scope
+
+What this spec explicitly does not cover.

--- a/examples/spec/skills/README.md
+++ b/examples/spec/skills/README.md
@@ -1,0 +1,75 @@
+## Skills
+
+These skills define a spec-driven workflow using lazyspec. They guide an AI agent through a structured documentation lifecycle: propose a design, lock down contracts in specs, plan implementation, build, and review.
+
+### Workflow
+
+`lazy` is the entry point. It inspects existing documents and routes to the right skill.
+
+A typical flow looks like:
+
+```
+/lazy -> create-spec -> create-plan -> build -> review-plan
+```
+
+For heavy or cross-cutting work, an RFC precedes the spec:
+
+```
+/lazy -> write-rfc -> create-spec -> create-plan -> build -> review-plan
+```
+
+`/resolve-context` can be used at any point to gather the full document chain (plan -> spec -> RFC if linked) before starting work. When continuing in the same session (e.g. after `/create-spec`), you already have context and can skip directly to `/create-plan`.
+
+`create-audit` runs independently of the main pipeline. It produces findings that the user can triage into plans.
+
+### Hierarchy
+
+| Document | Purpose |
+| -------- | ------- |
+| RFC | Design intent and motivation (optional, for heavy/cross-cutting work) |
+| Spec | Technical contracts: data models, API surface, validation, error handling, edge cases |
+| Plan | Task breakdown and test plan for implementing a spec |
+| ADR | Architectural decisions, linked to any document |
+
+### Reference
+
+| Skill | Description |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `lazy` | Detect existing RFCs, Specs, and Plans to determine the right starting point |
+| `write-rfc` | Create an RFC with design intent, interface sketches, and derived Specs |
+| `create-spec` | Create a Spec with contract sections, standalone or linked to an RFC |
+| `create-plan` | Create a Plan with task breakdown and test plan against a Spec |
+| `build` | Execute a Plan's task breakdown, dispatching per-task with review gates |
+| `review-plan` | Two-stage review: spec contract compliance first, code quality second |
+| `resolve-context` | Gather the full document chain for an agent before it begins work |
+| `create-audit` | Run a criteria-based review and document findings for user triage |
+
+### Usage
+
+Add the skills directory to your Claude Code settings or copy individual skills into your project's `.claude/skills/` directory. The `lazy` skill will handle routing from there.
+
+## License
+
+Some skills adapted from [obra/superpowers](https://github.com/obra/superpowers).
+
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/spec/skills/_common.md
+++ b/examples/spec/skills/_common.md
@@ -1,0 +1,50 @@
+# Shared Skill Rules
+
+These rules apply to all skills in this workflow. Read this before proceeding.
+
+## CLI Usage
+
+Use `lazyspec` for all document operations.
+
+- Run `lazyspec help <subcommand>` to verify flags and arguments before any command
+- Always pass `--json` for structured output (omit only when presenting directly to the user)
+- If a command fails, check `lazyspec help <subcommand>` before retrying
+
+## Universal Forbidden Actions
+
+<NEVER>
+- Do NOT write document files directly. Use `lazyspec create` and `lazyspec link`.
+- Do NOT edit a document you haven't read. Use `lazyspec show <id> --json` or the Read tool first.
+- Do NOT skip the workflow pipeline. Features need Spec -> Plan (RFC optional for heavy work). Bug fixes need Plan.
+</NEVER>
+
+## Subagent Tiers
+
+| Tier   | Model  | Use for                                                |
+| ------ | ------ | ------------------------------------------------------ |
+| Light  | Haiku  | Parsing, extracting structured data, simple validation |
+| Medium | Sonnet | Codebase exploration, searching, summarizing documents |
+| Heavy  | Opus   | Implementation, complex reasoning, multi-file changes  |
+
+## Subagent Preamble
+
+Include this block at the start of every subagent prompt:
+
+```
+IMPORTANT: You are working within the lazyspec workflow.
+- Use `lazyspec` CLI commands for document operations. Do NOT write document files directly.
+- Read files before editing them. Use the Read tool or `lazyspec show --json` before any modification.
+- Implement ONLY what the task specifies. Do not add features, refactor surrounding code, or "improve" things not in the task.
+- Before using any `lazyspec` command, run `lazyspec help <subcommand>` to verify usage.
+- Always pass `--json` when the command supports it.
+```
+
+## Status Promotion
+
+After completing work, promote document statuses up the chain. Run `lazyspec help update` to confirm usage.
+
+1. Mark plan as accepted: `lazyspec update <plan-path> --status accepted`
+2. If all plans under a Spec are accepted, mark the Spec as accepted
+3. If an RFC exists and all Specs under it are accepted, mark the RFC as accepted
+
+Run `lazyspec validate --json` after updates.

--- a/examples/spec/skills/build/SKILL.md
+++ b/examples/spec/skills/build/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: build
+description: Use when a Plan has a task breakdown and is ready for implementation. Dispatches subagent per task with review between tasks.
+---
+
+```
+NO IMPLEMENTATION WITHOUT A PLAN
+```
+
+If the Plan doesn't have a numbered task breakdown in `## Changes`, you can't build yet. Use the `/create-plan` skill first.
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<HARD-GATE>
+Do NOT begin implementation without a complete Plan document with numbered
+task breakdown. Each task must have enough detail for a zero-context subagent.
+ALWAYS use subagents for development.
+</HARD-GATE>
+
+<NEVER>
+- Do NOT implement tasks yourself. Dispatch a subagent per task. Do NOT dispatch parallel implementers.
+</NEVER>
+
+# Build
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+build.style.fill: "#4A9EFF"
+build.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+write-rfc.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+create-lazy.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Read plan -> Extract all tasks -> Create task tracking
+
+Per task {
+  Dispatch implementer subagent -> Questions? -> Answer, re-dispatch: yes
+  Questions? -> Implementer works + self-reviews: no
+  Implementer works + self-reviews -> Dispatch reviewer subagent
+  Dispatch reviewer subagent -> Contract compliance passes?
+  Contract compliance passes? -> Implementer fixes -> Dispatch reviewer subagent: no
+  Contract compliance passes? -> Code quality passes?: yes
+  Code quality passes? -> Implementer fixes quality -> Dispatch reviewer subagent: no
+  Code quality passes? -> Mark task complete: yes
+}
+
+Mark task complete -> More tasks?
+
+More tasks?.shape: diamond
+More tasks? -> Per task: yes
+More tasks? -> Final full review: no
+
+Final full review -> All Spec contracts met?
+
+All Spec contracts met?.shape: diamond
+All Spec contracts met? -> Done: yes
+All Spec contracts met? -> Fix gaps: no
+
+Done.shape: double_circle
+```
+
+## Preflight
+
+1. Resolve the full chain with `lazyspec context <plan-id> --json` to see the document chain
+2. Read the plan body with `lazyspec show <plan-id> --json` to get the task breakdown
+3. Read the parent Spec body with `lazyspec show <spec-id> --json` to get the contracts
+4. If an RFC exists in the chain, read it with `lazyspec show <rfc-id> --json` for design intent
+5. Extract all tasks from `## Changes` before dispatching any subagent
+
+## Subagent Dispatch
+
+| Operation                        | Agent Type      | Tier   | Context to provide                                       |
+| -------------------------------- | --------------- | ------ | -------------------------------------------------------- |
+| Implement task                   | general-purpose | Heavy  | Full task text, RFC intent, Spec contracts, prior task results |
+| Review task (contract compliance)| general-purpose | Heavy  | Task text, Spec contracts, implementer report            |
+| Review task (code quality)       | general-purpose | Medium | Changed files, test output, quality criteria             |
+| Final review                     | general-purpose | Heavy  | All Spec contracts, full implementation summary          |
+
+> This skill follows the [obra/superpowers](https://github.com/obra/superpowers) subagent-driven development pattern: dispatch a fresh subagent per task, with two-stage review (spec compliance first, code quality second). Each subagent starts with zero prior context to prevent pollution. The reviewer is always a separate agent from the implementer.
+
+## Setup
+
+1. **Resolve the chain:** Run `lazyspec context <plan-id> --json` to see the full document chain at a glance.
+2. **Read the documents:** Run `lazyspec show <plan-id> --json` and `lazyspec show <spec-id> --json` to get the full bodies (task breakdown, contracts). If an RFC exists in the chain, also run `lazyspec show <rfc-id> --json` for design intent.
+3. **Extract all tasks** from the plan's `## Changes` section. Copy the full text of each task -- subagents receive text, not file references.
+4. **Create task tracking** using TodoWrite with one entry per task.
+
+## Per-Task Loop
+
+For each task in the plan:
+
+### 6. Dispatch implementer subagent
+
+Use the Agent tool with `subagent_type: "general-purpose"`. Provide:
+
+- **Full task text** (copied from plan, not a reference to the file)
+- **Scene-setting context:** RFC intent (1-2 sentences), Spec contracts relevant to this task, what prior tasks accomplished
+- **Self-review checklist:** Completeness, quality, discipline, testing
+- **Working directory**
+
+Read the prompt template from `prompts/implementer.md` (relative to this skill directory) and include it in the subagent prompt.
+
+### 7. Handle implementer questions
+
+If the implementer asks questions, answer them. Provide additional context if needed. Don't rush them into implementation.
+
+### 8. Dispatch reviewer subagent
+
+After the implementer reports back, dispatch a **separate** reviewer subagent using the Agent tool with `subagent_type: "general-purpose"`.
+
+Read the prompt template from `prompts/reviewer.md` (relative to this skill directory) and include it in the subagent prompt, filling in the placeholders with the actual task text, spec contracts, and implementer report.
+
+### 9. Handle review failures
+
+If the reviewer reports issues:
+
+- Dispatch a fresh implementer subagent with the specific issues to fix
+- After fixes, dispatch reviewer again
+- Repeat until both stages pass
+
+### 10. Mark task complete
+
+Update task tracking. Proceed to next task.
+
+### 10a. Context refresh (every 2 tasks)
+
+After completing tasks 2, 4, 6, etc., re-read the chain to prevent context drift:
+
+1. Run `lazyspec context <plan-id> --json` to verify the chain is intact
+2. Run `lazyspec show <plan-id> --json` to refresh the task list and status
+3. Run `lazyspec show <spec-id> --json` to refresh the contracts
+4. Verify you are still following the task breakdown as written (not improvising)
+
+## Final Review
+
+### 10b. Pipeline checkpoint
+
+Before the final review, verify the workflow is intact:
+
+1. Re-read the plan document: `lazyspec show <plan-id> --json`
+2. Confirm all tasks in `## Changes` have been completed
+3. Check that no work was done outside the task breakdown
+4. Run `lazyspec validate --json` to check document integrity
+
+If anything is out of alignment, fix it before proceeding to final review.
+
+### 11. Dispatch final reviewer
+
+After all tasks complete, dispatch a reviewer subagent. Read the prompt template from `prompts/final-reviewer.md` and include it in the subagent prompt, filling in the spec contracts and task summary.
+
+### 12. Update document statuses
+
+If final review passes, follow the status promotion steps in `_common.md`.
+
+## Red Flags
+
+| Red Flag                                                 | Reality                                                                                       |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| "I'll review all tasks at the end"                       | Per-task review catches issues early. Fixing one task is cheaper than fixing five.            |
+| "The implementer self-reviewed, that's enough"           | Self-review is necessary but not sufficient. The reviewer is a separate subagent.             |
+| "I'll skip contract compliance and just do code quality" | Contract compliance FIRST. Beautiful code that doesn't meet the spec is wrong code.           |
+| "Let me implement two tasks before reviewing"            | One task, one review. No batching.                                                            |
+| "I'll provide a file reference instead of the full text" | Subagents receive full text. File references require them to read and parse, wasting context. |
+
+## Checklist
+
+Before dispatching any implementer subagent:
+
+- [ ] Does a Plan document exist with a numbered task breakdown?
+- [ ] Have you read the Plan and Spec documents? (and RFC if one exists)
+- [ ] Are you dispatching tasks sequentially (not in parallel)?
+- [ ] Is the subagent receiving full task text (not a file reference)?
+
+Before claiming build is complete:
+
+- [ ] All tasks reviewed and passing (both stages)
+- [ ] Final review dispatched and passing
+- [ ] Document statuses updated per `_common.md`
+- [ ] `lazyspec validate --json` passes

--- a/examples/spec/skills/build/prompts/final-reviewer.md
+++ b/examples/spec/skills/build/prompts/final-reviewer.md
@@ -1,0 +1,26 @@
+# Final Reviewer Subagent Prompt
+
+Include the subagent preamble from `_common.md`, then append:
+
+```
+You are performing a final review of the complete implementation.
+
+## Full Spec Contracts
+[All contracts from the parent Spec]
+
+## Plan Task Summary
+[Summary of all tasks and what was implemented]
+
+## Stage 1: Contract Compliance
+- Run the FULL test suite fresh. Show output.
+- For EVERY Spec contract: verify a passing test exists.
+- Any unmet contract = FAIL.
+
+## Stage 2: Code Quality
+- Review the full implementation holistically
+- Check for consistency across tasks
+- Verify no duplication or conflicting patterns (DRY)
+- Verify no unnecessary abstractions or features (YAGNI)
+- Evaluate test quality: behavioral, structure-insensitive, isolated,
+  deterministic, readable, specific. Flag unjustified property tradeoffs.
+```

--- a/examples/spec/skills/build/prompts/implementer.md
+++ b/examples/spec/skills/build/prompts/implementer.md
@@ -1,0 +1,32 @@
+# Implementer Subagent Prompt
+
+Include the subagent preamble from `_common.md`, then append:
+
+```
+Before you begin: if you have questions about requirements, approach,
+dependencies, or anything unclear -- ask them now. Don't guess.
+
+To find relevant files and prior work, use the lazyspec CLI:
+- `lazyspec context <id> --json` to see the full document chain
+- `lazyspec search "<query>" --json` to find documents by keyword
+- `lazyspec show <id> --json` to read a document's full body
+- `lazyspec status --json` to get all documents and validation at once
+
+Use lazyspec to discover related documents before grepping the codebase.
+
+Your job:
+1. Implement exactly what the task specifies
+2. Write tests (TDD: failing test first, then implementation)
+3. Run tests, verify they pass
+4. Self-review your work against these criteria:
+   - Completeness: does it satisfy the task's spec contracts?
+   - Quality: is the code clear and correct?
+   - YAGNI: did you build only what was asked for?
+   - DRY: is there real duplication to extract?
+   - Test properties: are your tests behavioral (not implementation-coupled),
+     isolated (no order dependence), deterministic, readable (motivation
+     obvious), and specific (failure cause obvious)?
+   - Tradeoffs: if you traded a test property for another (e.g. speed for
+     predictiveness in an integration test), note it.
+5. Report: what you implemented, test results, files changed, concerns
+```

--- a/examples/spec/skills/build/prompts/reviewer.md
+++ b/examples/spec/skills/build/prompts/reviewer.md
@@ -1,0 +1,42 @@
+# Reviewer Subagent Prompt
+
+Include the subagent preamble from `_common.md`, then append:
+
+```
+You are reviewing a task implementation for spec contract compliance and code quality.
+
+- Verify the implementer used `lazyspec` CLI for any document operations.
+- Check that no files were modified that aren't listed in the task specification.
+- Flag any scope creep (work done beyond what the task requested).
+
+## What Was Requested
+[Full task text from plan]
+
+## Spec Contracts This Task Addresses
+[Relevant contracts from the parent Spec]
+
+## What Implementer Claims
+[From implementer's report]
+
+## CRITICAL: Do Not Trust the Report
+The implementer's report may be incomplete or optimistic. Verify independently.
+
+## Stage 1: Contract Compliance
+- Run the test suite. Show full output.
+- For each contract this task claims to address: verify the test exists and passes.
+- Check for missing requirements the implementer skipped.
+- Check for extra work not in the spec.
+- If any contract is not satisfied: report FAIL with specifics.
+
+## Stage 2: Code Quality (only if Stage 1 passes)
+- Review code for correctness and clarity
+- Verify no unnecessary complexity (YAGNI)
+- Check for real duplication worth extracting (DRY)
+- Check for security issues
+- Evaluate tests: behavioral, structure-insensitive, isolated, deterministic,
+  readable, specific. Flag unjustified property tradeoffs.
+
+Report:
+- Stage 1: PASS or FAIL with specifics
+- Stage 2: PASS or FAIL with specifics (only if Stage 1 passed)
+```

--- a/examples/spec/skills/create-audit/SKILL.md
+++ b/examples/spec/skills/create-audit/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: create-audit
+description: Use when running a criteria-based review (health check, security audit, accessibility review, pen test, bug bash, spec compliance). Creates an Audit document with findings and presents them to the user for triage.
+---
+
+```
+AUDITS DOCUMENT FINDINGS. THEY DON'T FIX THEM.
+```
+
+Present findings to the user. Let them decide what to act on.
+
+<HARD-GATE>
+Do NOT create plans from findings. The audit produces a findings report
+that the user triages. Only after the user selects findings to act on should
+`/create-plan` be used, and that is a separate skill invocation.
+</HARD-GATE>
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<NEVER>
+- Do NOT create plans from audit findings. Present findings to the user for triage.
+- Do NOT fix issues found during the audit. Document them only.
+</NEVER>
+
+# Create Audit
+
+## Workflow Position
+
+Audits sit outside the main pipeline. They feed findings into the pipeline
+via user triage.
+
+```d2
+create-audit -> findings -> user triage -> create-plan
+
+create-audit.style.fill: "#4A9EFF"
+create-audit.style.font-color: "#FFFFFF"
+findings.style.opacity: 0.4
+user triage.style.opacity: 0.4
+create-plan.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Define scope and criteria -> Create audit doc -> Review codebase -> Document findings -> Validate -> Present to user
+
+Present to user -> User triages findings -> Use /create-plan skill: for selected findings
+
+Present to user.shape: diamond
+Use /create-plan skill.shape: double_circle
+```
+
+## Preflight
+
+1. Understand what's being audited (scope) and against what criteria
+2. Search for existing audits on the same topic: `lazyspec search "<topic>" --json`
+3. If auditing against specs, read them: `lazyspec show <spec-id> --json`
+
+## Subagent Dispatch
+
+| Operation | Agent Type | Tier | Context to provide |
+|-----------|-----------|------|-------------------|
+| Discover relevant code | Explore | Medium | Audit scope, criteria, file paths |
+| Review code against criteria | Explore | Medium | Specific criterion, file paths to check |
+
+## Steps
+
+1. **Define scope and criteria:** Work with the user to establish what is being audited and the criteria to audit against. This could be a checklist, a set of standards, or specific spec contracts.
+
+2. **Create the audit:** Run `lazyspec help create` to confirm usage, then: `lazyspec create audit "<title>" --author <name>`
+
+3. **Link to related documents:** If auditing against existing specs or RFCs, run `lazyspec help link` to confirm usage, then: `lazyspec link <audit-path> related-to <target-path>`. Link to every document the audit references.
+
+4. **Review the codebase:** Use Explore subagents to discover and review code against the criteria. Dispatch one subagent per area of the codebase or per criterion, depending on audit scope.
+
+5. **Document findings:** Edit the audit document. Each finding must include:
+   - **Severity:** critical, high, medium, low, or info
+   - **Location:** file path or component
+   - **Description:** what was found
+   - **Recommendation:** what should be done
+
+6. **Validate:** Run `lazyspec validate --json` to ensure all links resolve.
+
+7. **Present to user:** Show the complete findings to the user, grouped by severity. Do NOT create plans. The user decides which findings to act on and when.
+
+## Red Flags
+
+| Red Flag | Reality |
+|----------|---------|
+| "I'll fix this while I'm in here" | Audits document. They don't fix. |
+| "This finding is obvious, I'll skip documenting it" | If it's worth noticing, it's worth recording. |
+| "I'll create a plan for the critical findings" | The user triages findings. Not you. |
+| "I don't need to link to the specs I'm auditing" | Link to everything the audit references. Traceability matters. |
+
+## Checklist
+
+Before claiming this skill is complete:
+
+- [ ] `lazyspec validate --json` passes
+- [ ] Every finding has severity, location, description, recommendation
+- [ ] Audit links to relevant specs/RFCs (if applicable)
+- [ ] Findings presented to user, grouped by severity
+- [ ] No plans created without user direction

--- a/examples/spec/skills/create-plan/SKILL.md
+++ b/examples/spec/skills/create-plan/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: create-plan
+description: Use when planning implementation against a Spec or as a standalone plan for bug fixes, tweaks, and refactors. Creates Plan documents with task breakdown and test plan. Supports parallel subagent dispatch for Specs with multiple contract groups.
+---
+
+```
+PLAN THE WORK, THEN CONFIRM BEFORE BUILDING
+```
+
+This skill creates the plan document. It does NOT write code.
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<HARD-GATE>
+Do NOT write test code or production code in this skill. Plan tests and
+tasks only. For feature work linked to a Spec, use `/resolve-context` first
+if you haven't already. Standalone plans (bug fixes, tweaks, refactors)
+do not require a parent Spec or resolve-context.
+After identifying multiple contract groups, partition upfront and get user approval
+before dispatching subagents.
+After completion: present the plan to the user for review.
+Only use the `/build` skill after the user explicitly confirms.
+</HARD-GATE>
+
+<NEVER>
+- Do NOT write test or production code. This skill produces a plan document only.
+- Do NOT dispatch subagents without user approval of the contract grouping.
+</NEVER>
+
+# Create Plan
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+create-plan.style.fill: "#4A9EFF"
+create-plan.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+write-rfc.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Context resolved? -> Gather context: no
+Context resolved? -> Read Spec contracts: yes
+
+Gather context.shape: hexagon
+
+Read Spec contracts -> Multiple plan groups?
+
+Multiple plan groups?.shape: diamond
+Multiple plan groups? -> Define contract groups -> User approves groups?: yes
+Multiple plan groups? -> Create single plan (inline): no
+
+User approves groups?.shape: diamond
+User approves groups? -> Dispatch N subagents: yes
+User approves groups? -> Revise groups: no
+Revise groups -> Define contract groups
+
+Dispatch N subagents -> Collect results -> Validate -> Present to user
+Create single plan (inline) -> Link to spec -> Plan tests -> Write task breakdown -> Present to user
+
+Present to user -> User confirms -> Use /build skill: approved
+Present to user -> Revise: changes requested
+
+Present to user.shape: diamond
+Use /build skill.shape: double_circle
+```
+
+## Preflight
+
+1. If linked to a Spec: run `lazyspec context <spec-id> --json` to see the chain, then `lazyspec show <spec-id> --json` for the full contracts
+2. Run `lazyspec status --json` to see all documents and check no existing plan covers the same contracts
+3. Read relevant documents using `lazyspec show --json` before modifying anything
+
+## Contract Grouping
+
+Before dispatching subagents, the orchestrator must:
+
+1. Read the spec with `lazyspec show <spec-id> --json`
+2. List all contract sections
+3. Group contracts into plan-sized chunks. Each group should be a coherent unit of work (not arbitrary splits). Consider dependencies between contracts.
+4. Verify each contract belongs to exactly one group (no overlap, no gaps)
+5. Present the grouping table to the user for approval
+
+The grouping table should clearly show each plan's title, which contracts it covers, and a brief rationale for why those contracts belong together. The user must approve or request revisions before any subagents are dispatched.
+
+## Subagent Dispatch
+
+| Operation                   | Agent Type      | Tier   | Context to provide                                                   |
+| --------------------------- | --------------- | ------ | -------------------------------------------------------------------- |
+| Create plan                 | general-purpose | Heavy  | Spec context, contract group, other group boundaries, RFC intent     |
+| Discover relevant code      | Explore         | Medium | File paths and symbols from Spec contracts                           |
+| Validate file paths exist   | Explore         | Light  | List of paths referenced in task breakdown                           |
+
+Each subagent receives: full Spec body (not a file reference), RFC design intent (if exists), its contract group, and the boundaries of all other groups. Read the prompt template from `prompts/planner.md` (relative to this skill directory).
+
+Subagents are dispatched in parallel using the Agent tool.
+
+## Steps
+
+### Multi-plan specs
+
+1. **Gather context:** Run `lazyspec status --json` to see all documents at once, then `lazyspec search "<keyword>" --json` for topic-specific matches.
+   - Run `lazyspec context <spec-id> --json` to see the chain, then `lazyspec show <spec-id> --json` to read the full contracts. If you haven't already resolved context, use `/resolve-context` first.
+
+2. **Read Spec contracts:** Extract all contract sections from the spec. Identify natural groupings based on coherence and dependencies.
+
+3. **Group contracts into plan-sized chunks:** Per the Contract Grouping section. Each group should be a self-contained unit of deliverable work.
+
+4. **Present grouping to user for approval:** Show the grouping table. Wait for explicit approval. If the user requests changes, revise and re-present.
+
+5. **Dispatch N subagents in parallel:** One subagent per plan, using the Agent tool with the prompt template. Each receives the full Spec body, RFC design intent, its contract group, and the boundaries of all other groups.
+
+6. **Collect results:** Gather reports from all subagents. Run `lazyspec validate --json` to verify all plans link correctly and pass validation.
+
+7. **Present all created plans to the user:** Show a summary of each plan created, its contracts, task breakdown, and the validation result.
+
+### Single-plan specs (fallback) and standalone plans
+
+When all contracts fit in a single plan, or for standalone plans (bug fixes, tweaks, refactors), create the plan directly without subagent dispatch:
+
+1. **Gather context:** Run `lazyspec status --json` to see all documents at once, then `lazyspec search "<keyword>" --json` for topic-specific matches.
+   - **If linked to a Spec:** Run `lazyspec context <spec-id> --json` to see the chain, then `lazyspec show <spec-id> --json` to read the full contracts. If you haven't already resolved context, use `/resolve-context` first.
+   - **If standalone (bug fix, tweak, refactor):** Gather context from the codebase directly. Understand the affected code and the problem being solved. No Spec or resolve-context required.
+
+2. **Discover relevant code:** Use `lazyspec search --json` to find documents that reference the modules and types you'll be working with. Read the referenced file paths from those documents to understand the existing code before planning tasks. Task breakdowns must reference real, verified file paths.
+
+3. **Create the plan:** Run `lazyspec help create` to confirm usage, then: `lazyspec create plan "<title>" --author agent`
+
+4. **Link to spec (if applicable):** If this plan implements a Spec, run `lazyspec help link` to confirm usage, then: `lazyspec link <plan-path> implements <spec-path>`. Standalone plans for bug fixes, tweaks, or refactors do not require a parent Spec link.
+
+5. **Plan tests:** For each contract this plan covers, describe the test that will verify it. Document these in the plan's `## Test Plan` section. Do NOT write test code or production code yet -- that happens during build.
+
+   Each planned test should be evaluated against these properties:
+
+   | Property              | Meaning                                                   |
+   | --------------------- | --------------------------------------------------------- |
+   | Isolated              | Same results regardless of execution order                |
+   | Composable            | Run 1 or 1,000,000 and get the same results               |
+   | Fast                  | Cheap to run                                              |
+   | Inspiring             | Passing builds confidence in production readiness         |
+   | Writable              | Cheap to write relative to the code under test            |
+   | Readable              | Motivation for the test is obvious to the reader          |
+   | Behavioral            | Sensitive to changes in behavior, not implementation      |
+   | Structure-insensitive | Result unchanged by structural refactoring                |
+   | Deterministic         | Same result when nothing changes                          |
+   | Predictive            | All passing implies production-suitable                   |
+   | Specific              | Failure cause is obvious                                  |
+
+   These properties conflict. When planning a test that trades one for another
+   (e.g. an integration test that sacrifices Fast for Predictive), note the
+   tradeoff in the test plan and present it to the collaborator for guidance.
+
+6. **Write task breakdown:** The `## Changes` section must contain a numbered task list. Each task must be self-contained enough for a zero-context subagent to implement independently:
+
+   ```markdown
+   ### Task 1: [descriptive name]
+
+   **Contracts addressed:** [which spec contracts this implements]
+
+   **Files:**
+   - Create/Modify: `exact/path/to/file`
+   - Test: `tests/exact/path/to/test`
+
+   **What to implement:**
+   [Complete description -- not "add validation" but the actual logic]
+
+   **How to verify:**
+   [Test commands and expected output]
+   ```
+
+   Each task should reference which Spec contracts it addresses, include exact file paths, describe the implementation in enough detail that someone unfamiliar with the codebase can execute it, and specify how to verify correctness.
+
+7. **Document:** Add any discoveries or decisions to `## Notes`. If a significant decision was made, run `lazyspec help create` to confirm usage, then: `lazyspec create adr "<decision>"`.
+
+8. **Validate:** Run `lazyspec validate --json`.
+
+9. **Present to user:** Show the user the complete plan document (task breakdown, test plan, linked contracts). Ask for explicit confirmation before proceeding. Do NOT use `/build` until the user approves.
+
+## Red Flags
+
+| Red Flag | Reality |
+|----------|---------|
+| "Let me just start coding" | This skill plans. Build writes code. |
+| "I'll write the tests now" | Plan the tests here, write them during build. |
+| "I'll use /build right after" | Stop. Present to the user. Wait for confirmation. |
+| "The user will probably approve" | Probably isn't confirmed. Ask. |
+
+## Checklist
+
+Before presenting the plan to the user:
+
+- [ ] `lazyspec validate --json` passes
+- [ ] If linked to a Spec: all plans link to Spec correctly
+- [ ] Have you read the Spec contracts? (not assumed -- actually read with `lazyspec show --json`)
+- [ ] Each contract belongs to exactly one plan (no overlap)
+- [ ] Each plan has a task breakdown with file paths in `## Changes`
+- [ ] Each task references Spec contracts
+- [ ] `## Test Plan` section documents planned tests
+- [ ] Does every task reference real, verified file paths? (not guessed)
+- [ ] Is the task breakdown detailed enough for a zero-context subagent?
+- [ ] No test code or production code has been written
+- [ ] User has explicitly confirmed before `/build` is used
+
+## Rules
+
+- This skill produces a document, not code
+- Keep plans small and committable
+- Always present the plan to the user and wait for confirmation before invoking build
+- If you discover a contract needs to change, emit an ADR
+- For multi-plan specs, always get user approval of the grouping before dispatching

--- a/examples/spec/skills/create-plan/prompts/planner.md
+++ b/examples/spec/skills/create-plan/prompts/planner.md
@@ -1,0 +1,28 @@
+# Planner Subagent Prompt
+
+Include the subagent preamble from `_common.md`, then append:
+
+```
+You are creating a single Plan document within the lazyspec workflow.
+
+## Spec Context
+[Full Spec body]
+
+## RFC Design Intent
+[1-2 paragraphs from the RFC, if one exists]
+
+## Your Contract Group
+[List of contracts this plan covers]
+
+## Other Contract Groups (for boundary awareness)
+[List of other groups and their contract assignments]
+
+## Instructions
+1. Create the plan: `lazyspec create plan "<title>" --author agent`
+2. Link to spec: `lazyspec link <plan-path> implements <spec-path>`
+3. Discover relevant code using `lazyspec search` and Explore subagents
+4. Plan tests for each contract in your group
+5. Write task breakdown with real, verified file paths
+6. Validate: `lazyspec validate --json`
+7. Report: plan path, contracts covered, task count, any concerns
+```

--- a/examples/spec/skills/create-spec/SKILL.md
+++ b/examples/spec/skills/create-spec/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: create-spec
+description: Use when locking down technical contracts for a vertical slice. Creates Spec documents with data models, API surface, validation rules, error handling, edge cases, and optional acceptance criteria. Specs can be standalone or linked to an RFC. Supports parallel subagent dispatch for RFCs with multiple slices.
+---
+
+```
+NO IMPLEMENTATION WITHOUT LOCKED CONTRACTS
+```
+
+If you can't state the data models, API surface, and error handling, the contracts aren't locked down yet.
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<HARD-GATE>
+Specs can exist standalone or linked to a parent RFC. A parent RFC is NOT required.
+After identifying multiple slices, partition upfront and get user approval
+before dispatching subagents.
+After completion: use the `/create-plan` skill to plan the first implementation.
+You already have the Spec context (and RFC context if one exists) from writing
+this Spec, so resolve-context is not needed when continuing in the same session.
+</HARD-GATE>
+
+<NEVER>
+- Do NOT write contract sections without reading the parent RFC first (if one exists).
+- Do NOT dispatch subagents without user approval of the partition.
+</NEVER>
+
+# Create Spec
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+create-spec.style.fill: "#4A9EFF"
+create-spec.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+write-rfc.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+create-lazy.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Check for parent RFC -> RFC exists?
+
+RFC exists?.shape: diamond
+RFC exists? -> Read RFC and extract slices: yes
+RFC exists? -> Create standalone spec: no
+
+Read RFC and extract slices -> Multiple slices?
+
+Multiple slices?.shape: diamond
+Multiple slices? -> Define partitions -> User approves partitions?: yes
+Multiple slices? -> Create single spec (inline): no
+
+User approves partitions?.shape: diamond
+User approves partitions? -> Dispatch N subagents: yes
+User approves partitions? -> Revise partitions: no
+Revise partitions -> Define partitions
+
+Dispatch N subagents -> Collect results -> Validate -> Present to user -> Use /create-plan skill
+Create standalone spec -> Write contracts -> Validate -> Use /create-plan skill
+Create single spec (inline) -> Write contracts -> Link to RFC -> Validate -> Use /create-plan skill
+
+Use /create-plan skill.shape: double_circle
+```
+
+## Preflight
+
+1. Read relevant documents using `lazyspec show --json` before modifying anything
+2. Check for existing artifacts using `lazyspec search --json` and `lazyspec list --json`
+3. If a parent RFC exists, read it with `lazyspec show <rfc-id> --json`
+4. If a parent RFC exists, confirm you understand the design intent before writing contracts
+5. Check for existing specs: `lazyspec search "<topic>" --json`
+
+## Partitioning
+
+Before dispatching subagents, the orchestrator must:
+
+1. Read the RFC with `lazyspec show <rfc-id> --json`
+2. Extract the identified vertical slices from the Specs section
+3. For each slice, define: title, scope boundary (in/out), which RFC sections it addresses
+4. Verify slices are non-overlapping (no shared scope)
+5. Present the partition table to the user for approval
+
+The partition table should clearly show each slice's title, what is in scope, what is out of scope, and which RFC sections it maps to. The user must approve or request revisions before any subagents are dispatched.
+
+## Subagent Dispatch
+
+| Operation   | Agent Type      | Tier  | Context to provide                                       |
+| ----------- | --------------- | ----- | -------------------------------------------------------- |
+| Create spec | general-purpose | Heavy | RFC context, slice definition, adjacent slice boundaries |
+
+Each subagent receives: full RFC body (not a file reference), its slice definition, and the scope boundaries of all other slices. Read the prompt template from `prompts/spec-writer.md` (relative to this skill directory).
+
+Subagents are dispatched in parallel using the Agent tool.
+
+## Contract Sections
+
+The template suggests these sections, but adapt per-spec. Not every spec needs all sections -- include what's relevant and skip what isn't.
+
+### Data Models
+Types, schemas, and structures that this slice introduces or modifies. Use `@draft` for new types and `@ref` for existing ones.
+
+### API Surface
+Endpoints, function signatures, message formats. Include request/response shapes. An implementer should be able to build the interface from this section alone.
+
+### Validation Rules
+Input constraints, business rules, invariants that must hold. Be specific about boundaries and rejection behavior.
+
+### Error Handling
+Error types, codes, messages. How failures propagate and what callers see. Cover both expected errors (validation failures, not-found) and unexpected errors (timeouts, downstream failures).
+
+### Edge Cases
+Boundary conditions, race conditions, unusual inputs. Document expected behavior for each. If behavior is undefined, say so explicitly.
+
+### Acceptance Criteria (optional)
+For user-story-style specs, express requirements as given/when/then scenarios. This section is optional -- use it when behavior is best described from a user perspective rather than a technical contract perspective.
+
+```
+Given [precondition]
+When [action]
+Then [expected outcome]
+```
+
+## Steps
+
+### Multi-slice RFCs
+
+1. **Find the parent RFC:** Run `lazyspec list rfc --json` to find the relevant RFC. Use `lazyspec show <id> --json` to verify it's the right one. Multi-slice partitioning requires an RFC to define the slices.
+
+2. **Read RFC and extract slices:** Read the full RFC body. Identify the vertical slices described in the Specs section or equivalent.
+
+3. **Define partitions:** For each slice, define title, in-scope, out-of-scope, and which RFC sections it addresses. Verify slices are non-overlapping.
+
+4. **Present partition to user for approval:** Show the partition table. Wait for explicit approval. If the user requests changes, revise and re-present.
+
+5. **Dispatch N subagents in parallel:** One subagent per spec, using the Agent tool with the prompt template. Each receives the full RFC body, its slice definition, and the boundaries of all other slices.
+
+6. **Collect results:** Gather reports from all subagents. Run `lazyspec validate --json` to verify all specs link correctly and pass validation.
+
+7. **Present all created specs to the user:** Show a summary of each spec created, its contracts, and the validation result.
+
+### Single spec (standalone or single-slice RFC)
+
+Create the spec directly without subagent dispatch. This is the default path for most features.
+
+1. **Check for parent RFC:** Run `lazyspec search "<topic>" --json` and `lazyspec list rfc --json` to check for an existing RFC. If one exists, read it with `lazyspec show <id> --json`. If none exists, that's fine -- specs can be standalone.
+
+2. **Create the spec:** Run `lazyspec help create` to confirm usage, then: `lazyspec create spec "<title>" --author <name>`
+
+3. **Write contract sections:** Edit the created file. Include the sections relevant to this spec:
+   - **Data Models:** types, schemas, structures
+   - **API Surface:** endpoints, signatures, request/response shapes
+   - **Validation Rules:** constraints, business rules, invariants
+   - **Error Handling:** error types, codes, propagation
+   - **Edge Cases:** boundaries, race conditions, unusual inputs
+   - **Acceptance Criteria (optional):** given/when/then scenarios for user-story-style specs
+
+4. **Link to RFC (if one exists):** Run `lazyspec help link` to confirm usage, then: `lazyspec link <spec-path> implements <rfc-path>`
+
+5. **Define scope:** Fill in the In Scope and Out of Scope sections. Be explicit about what this spec does NOT cover.
+
+6. **Validate:** Run `lazyspec validate --json` to ensure all links resolve.
+
+## Red Flags
+
+| Red Flag | Reality |
+|----------|---------|
+| "The RFC covers it, I don't need a Spec" | RFCs describe intent. Specs lock down contracts. Different audiences. |
+| "I'll figure out the error handling during implementation" | That's a design judgment call. Lock it down in the spec. |
+| "This contract is obvious, I don't need to write it out" | Obvious to you. The implementer needs it explicit. |
+
+## Checklist
+
+Before claiming this skill is complete:
+
+- [ ] All created specs link to the parent RFC (if one exists)
+- [ ] No overlapping scope between specs
+- [ ] Contract sections are specific enough for an implementer to build without design judgment calls
+- [ ] Scope sections are filled (not TODO)
+- [ ] `lazyspec validate --json` passes
+- [ ] If dispatching subagents: have you read the RFC, are slices non-overlapping, has the user approved?
+
+## Rules
+
+- A Spec must be detailed enough that an implementer can build from it without making design judgment calls
+- If you can't write the Spec without mentioning implementation specifics, it's scoped wrong
+- Each contract should be independently testable
+- Keep specs focused on one vertical slice
+- Each subagent receives full RFC text, not file references

--- a/examples/spec/skills/create-spec/prompts/spec-writer.md
+++ b/examples/spec/skills/create-spec/prompts/spec-writer.md
@@ -1,0 +1,26 @@
+# Spec Writer Subagent Prompt
+
+Include the subagent preamble from `_common.md`, then append:
+
+```
+You are creating a single Spec document within the lazyspec workflow.
+
+## RFC Context
+[Full RFC body]
+
+## Your Slice
+Title: [slice title]
+In scope: [what this spec covers]
+Out of scope: [what this spec does NOT cover]
+
+## Other Slices (for boundary awareness)
+[List of other slice titles and their scope]
+
+## Instructions
+1. Create the spec: `lazyspec create spec "<title>" --author <name>`
+2. Edit the created file to write contract sections (data models, API surface, validation rules, error handling, edge cases)
+3. Link to RFC: `lazyspec link <spec-path> implements <rfc-path>`
+4. Define In Scope and Out of Scope sections in the spec body
+5. Validate: `lazyspec validate --json`
+6. Report: spec path, contracts written, any concerns
+```

--- a/examples/spec/skills/lazy/SKILL.md
+++ b/examples/spec/skills/lazy/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: lazy
+description: Use when starting new work, planning a feature, or deciding what to implement next. Detects existing RFCs, Specs, and Plans to determine the right starting point. Supports lightweight paths for bug fixes and small tweaks.
+---
+
+```
+NO WORK WITHOUT A PLAN
+```
+
+If you're about to write code without knowing where you are in the workflow, stop. Plan first.
+
+use the `lazyspec` cli tool. this is in the user's path.
+
+<HARD-GATE>
+Do NOT skip to implementation. Detect existing artifacts, classify the work,
+and use the right skill.
+</HARD-GATE>
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<NEVER>
+- Do NOT use /write-rfc, create-spec, or create-plan without user approval of the direction first.
+</NEVER>
+
+# Lazy
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+lazy.style.fill: "#4A9EFF"
+lazy.style.font-color: "#FFFFFF"
+write-rfc.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+create-plan.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+User describes work -> Detect existing artifacts -> Classify work
+
+Classify work -> New feature (full pipeline)
+Classify work -> Bug fix / small tweak (lightweight)
+
+New feature (full pipeline) -> Determine entry point
+
+Determine entry point -> Nothing exists: Brainstorm
+Determine entry point -> RFC exists, no Spec: Brainstorm slices
+Determine entry point -> Spec exists, no Plan: Resolve context
+Determine entry point -> Plan with tasks: Ready to build
+
+Nothing exists: Brainstorm -> User approves direction? -> Use /create-spec skill: yes
+User approves direction? -> Revise: no
+Revise -> Nothing exists: Brainstorm
+
+Nothing exists: Brainstorm -> Heavy/cross-cutting? -> Use /write-rfc skill: yes (optional)
+
+RFC exists, no Spec: Brainstorm slices -> Use /create-spec skill
+Spec exists, no Plan: Resolve context -> Use /resolve-context skill
+Plan with tasks: Ready to build -> Use /build skill
+
+Bug fix / small tweak (lightweight) -> Related Spec exists?
+Related Spec exists? -> Create plan against it: yes
+Related Spec exists? -> Create standalone plan: no
+
+Create plan against it -> Use /create-plan skill
+Create standalone plan -> Use /create-plan skill
+
+Use /write-rfc skill.shape: double_circle
+Use /create-spec skill.shape: double_circle
+Use /resolve-context skill.shape: double_circle
+Use /create-plan skill.shape: double_circle
+Use /build skill.shape: double_circle
+```
+
+## Preflight
+
+1. Run `lazyspec status --json` to get all documents, relationships, and validation in one call
+2. Search for topic-specific matches: `lazyspec search "<topic>" --json`
+3. Present findings to the user before choosing a direction
+4. Classify the work (new feature, bug fix, tweak, refactor) before selecting a pipeline
+
+## Subagent Dispatch
+
+| Operation                 | Agent Type | Tier   | Context to provide                        |
+| ------------------------- | ---------- | ------ | ----------------------------------------- |
+| Search existing artifacts | Explore    | Medium | Topic keywords, document types to search  |
+| Classify work complexity  | _(inline)_ | -      | No subagent needed, main agent classifies |
+
+## Steps
+
+### 1. Detect existing artifacts
+
+Get the full project state and search for related work:
+
+```
+lazyspec status --json
+lazyspec search "<topic>" --json
+lazyspec context DOC-XXX --json
+```
+
+### 2. Present findings
+
+Tell the user what you found:
+
+- Which RFCs, Specs, Plans already exist for this work
+- Their current status (draft, accepted, etc.)
+- What relationships exist between them
+
+### 3. Classify the work
+
+Not all work needs the full pipeline. Before determining entry point, classify what the user is asking for:
+
+| Classification  | Criteria                                                              | Pipeline                    |
+| --------------- | --------------------------------------------------------------------- | --------------------------- |
+| **New feature** | Adds new capability or behavior. Even small features need a Spec.     | Spec -> Plan (RFC optional) |
+| **Bug fix**     | Corrects existing behavior that doesn't match intent.                 | Plan only                   |
+| **Small tweak** | Minor adjustment to existing behavior (config change, copy, styling). | Plan only                   |
+| **Refactor**    | Restructures code without changing behavior.                          | Plan only                   |
+
+> [!NOTE]
+> When unsure, ask the user. The classification determines how much ceremony the work gets.
+
+**New features** always need a Spec. RFCs are optional, reserved for heavy or cross-cutting designs that affect multiple areas. Most features go straight to Spec.
+
+**Project RFCs** should be linked if available.
+
+**Bug fixes, small tweaks, and refactors** skip RFC and Spec creation entirely. They go straight to `create-plan`, optionally linked to an existing Spec if one is related.
+
+### 4. Determine entry point
+
+**For new features** (full pipeline):
+
+| State                                | Action                                              |
+| ------------------------------------ | --------------------------------------------------- |
+| Nothing exists                       | Brainstorm the design, then use `/create-spec`      |
+| Nothing exists (heavy/cross-cutting) | Brainstorm the design, then use `/write-rfc`        |
+| RFC exists, no Specs                 | Brainstorm contract slices, then use `/create-spec` |
+| Spec exists, no Plan                 | Use `/resolve-context` (chains to `/create-plan`)   |
+| Plan exists with task breakdown      | Use `/build`                                        |
+| Plan exists without task breakdown   | Use `/create-plan` to add tasks                     |
+
+**For bug fixes, tweaks, and refactors** (lightweight pipeline):
+
+| State                            | Action                                  |
+| -------------------------------- | --------------------------------------- |
+| Related Spec exists              | Use `/create-plan` linked to that Spec  |
+| No related Spec (standalone fix) | Use `/create-plan` as a standalone plan |
+| Plan already exists with tasks   | Use `/build`                            |
+
+### 5. Brainstorm (when needed)
+
+Brainstorming is fractal -- it applies at whatever level you're entering:
+
+**Spec level (nothing exists, or RFC exists):**
+
+- Ask clarifying questions about the problem (one at a time)
+- Propose 2-3 design approaches with trade-offs
+- Present your recommendation
+- If an RFC exists, read it to understand intent and propose contract slices
+- Get user approval before invoking create-spec
+
+**RFC level (heavy/cross-cutting work only):**
+
+- Only when the work spans multiple areas, teams, or requires significant architectural decisions
+- Ask clarifying questions about the problem (one at a time)
+- Propose 2-3 design approaches with trade-offs
+- Present your recommendation
+- Get user approval before invoking write-rfc
+
+**Plan level (Spec exists, no Plan):**
+
+- This is handled by create-plan, which generates the task breakdown
+- Propose 2-3 design approaches with trade-offs
+- Use /resolve-context skill, which chains to create-plan
+
+**Lightweight plan (bug fix / tweak):**
+
+- Confirm the problem or change with the user
+- If a related Spec exists, confirm linking to it
+- Propose 2-3 design approaches with trade-offs
+- Use /create-plan skill directly (no resolve-context needed for standalone plans)
+
+### 6. Use the appropriate skill
+
+After determining the entry point and brainstorming (if needed), use the Skill tool to invoke the next skill (e.g. `/write-rfc`, `/create-spec`, `/create-plan`, `/build`). Each skill chains to its successor -- follow the chain, don't skip ahead.
+
+## Red Flags
+
+| Red Flag                                 | Reality                                                  |
+| ---------------------------------------- | -------------------------------------------------------- |
+| "Let me just start coding"               | Code without a plan = rework. Plan first.                |
+| "I already know what to build"           | Then the plan should be quick. Still do it.              |
+| "This is too small to plan"              | Small work still gets a plan. The plan can be small too. |
+| "I'll figure out the design as I code"   | That's not design. That's hoping.                        |
+| "This bug fix needs an RFC"              | No it doesn't. Classify the work correctly.              |
+| "Let me create a Spec for this typo fix" | Overkill. Bug fixes and tweaks skip Spec creation.       |
+
+## Checklist
+
+Before invoking any downstream skill:
+
+- [ ] Have you searched for existing artifacts? (`lazyspec search --json`, `lazyspec list --json`)
+- [ ] Have you presented findings to the user?
+- [ ] Has the user approved the direction?
+- [ ] Are you invoking the correct skill for the work classification?
+
+If any answer is "no", stop. Complete the missing step.
+
+## Rules
+
+- New features need Specs. RFCs are optional (for heavy/cross-cutting work). Bug fixes, tweaks, and refactors do not.
+- One question at a time during brainstorming
+- Get user approval before invoking the next skill
+- Never skip directly to build without a Plan with tasks

--- a/examples/spec/skills/resolve-context/SKILL.md
+++ b/examples/spec/skills/resolve-context/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: resolve-context
+description: Use when an agent needs full context before beginning work on a Spec or Plan. Gathers the document chain from plan through spec to RFC.
+---
+
+```
+NO IMPLEMENTATION WITHOUT FULL CONTEXT
+```
+
+If you haven't read the Spec -> existing Plan chain (and RFC if one exists), you cannot write code.
+
+<HARD-GATE>
+Do NOT begin implementation without completing this skill. Read the full
+document chain (Spec -> Plan, and RFC if linked) before writing any code.
+After completion: use the `/create-plan` skill.
+</HARD-GATE>
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+# Resolve Context
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+resolve-context.style.fill: "#4A9EFF"
+resolve-context.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+write-rfc.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+create-lazy.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Identify target doc -> Resolve chain -> Read bodies if needed -> Check for existing work -> State context back -> Context complete
+
+Context complete.shape: double_circle
+```
+
+## Preflight
+
+1. Identify the target document path or ID
+2. Confirm the document exists with `lazyspec show <id> --json`
+
+## Subagent Dispatch
+
+| Operation | Agent Type | Tier | Context to provide |
+|-----------|-----------|------|-------------------|
+| Discover relevant codebase files | Explore | Medium | Type names, module paths from spec documents |
+| Summarize context | _(inline)_ | - | Main agent synthesizes findings |
+
+## Steps
+
+1. **Identify the document:** Use `lazyspec list --json` or `lazyspec search <query> --json` to find the target document.
+
+2. **Resolve the chain:** Run `lazyspec context <id> --json` to get the full implements chain (Spec -> Plan, and RFC if linked) in one call.
+
+3. **Read document bodies:** The context command shows frontmatter only. For documents where you need the full body (typically the Spec contracts and RFC design intent if an RFC exists), follow up with `lazyspec show <id> --json` on those specific documents.
+
+4. **Check for existing work:** Run `lazyspec status --json` to get all documents, relationships, and validation results in one call. Look for existing plans, ADRs, or related documents that cover the same ground.
+
+5. **Discover relevant code:** The spec documents often name exact files and symbols -- use those as starting points rather than guessing at file paths.
+
+6. **Assemble context:** You now have the full chain: Spec (contracts) -> existing Plans (prior work) -> relevant codebase locations. If an RFC exists: RFC (intent) -> Spec -> Plans.
+
+7. **State it back:** Before proceeding, summarise the context chain: what the RFC intends (if one exists), what contracts the Spec defines, what prior plans have already done, and which parts of the codebase are involved. This forces you to confirm you actually understood it.
+
+## Red Flags
+
+| Red Flag | Reality |
+|----------|---------|
+| "I already know this codebase" | Knowledge decays. Prior plans may have changed assumptions. |
+| "I'll read the Spec and skip the RFC" | If an RFC exists, read it -- it explains *why*. Standalone specs are fine without one. |
+| "I'll look things up as I go" | Ad-hoc context gathering misses the big picture. Resolve the full chain. |
+
+## Verification
+
+Before claiming this skill is complete:
+
+- [ ] `lazyspec context <id> --json` has been run on the target document
+- [ ] `lazyspec show --json` has been run on documents where the body is needed (Spec contracts, RFC design)
+- [ ] Existing plans and ADRs have been checked (via `lazyspec status --json` or search)
+- [ ] Context chain has been stated back (RFC intent if exists, Spec contracts, prior work)
+
+## Rules
+
+- Always resolve context before starting implementation
+- Read the full Spec contracts before writing any code
+- Check for existing plans to avoid duplicating work
+- Search for types and symbols mentioned in the Spec before creating new ones

--- a/examples/spec/skills/review-plan/SKILL.md
+++ b/examples/spec/skills/review-plan/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: review-plan
+description: Use when a Plan is complete and ready for review. Two-stage review -- spec contract compliance first, code quality second. Block on contract failure before reviewing code.
+---
+
+```
+NO APPROVAL WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If you haven't run the tests in this session, you cannot claim they pass.
+
+<HARD-GATE>
+Do NOT approve without running verification commands in this session.
+Stage 1 (contract compliance) MUST pass before entering Stage 2 (code quality).
+If contracts fail during a `/build` per-task review, dispatch a fix subagent.
+If contracts fail during a standalone review, use `/create-plan` to re-plan.
+</HARD-GATE>
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<NEVER>
+- Do NOT approve without running tests in the current session. Do NOT trust prior test reports.
+</NEVER>
+
+# Review Plan
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build -> review-plan
+
+review-plan.style.fill: "#4A9EFF"
+review-plan.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+write-rfc.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+create-lazy.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Modes
+
+This skill operates in two modes:
+
+**Per-task review** (dispatched as a reviewer subagent by `/build` after each task):
+
+- Scoped to the contracts relevant to the completed task
+- Same two-stage process (contract compliance first, code quality second)
+- On failure: report back to `/build` orchestrator, which dispatches a fix subagent
+
+**Full review** (dispatched by `/build` as final gate, or used standalone):
+
+- Checks ALL Spec contracts against the complete implementation
+- On failure during `/build`: targeted fix subagents for specific gaps
+- On failure standalone: report to user
+
+## Preflight
+
+1. Resolve the chain with `lazyspec context <plan-id> --json` to see RFC -> Spec -> Plan
+2. Read the plan body with `lazyspec show <plan-id> --json`
+3. Read the parent Spec contracts with `lazyspec show <spec-id> --json`
+4. Do NOT begin review until both documents are loaded into context
+
+## The Gate
+
+```
+BEFORE claiming review passes:
+
+1. IDENTIFY: Which Spec contracts does this plan cover?
+2. RUN: Execute the FULL test suite (fresh, in this session)
+3. READ: Full output, check exit code, count failures
+4. VERIFY: Does each claimed contract have a passing test?
+   - If NO: State which contracts are unmet. Return to create-plan.
+   - If YES: Proceed to Stage 2 (code quality)
+5. ONLY THEN: Approve
+
+Skip any step = not a review
+```
+
+## Workflow
+
+```d2
+Read plan doc -> Read parent spec contracts -> Run full test suite -> All contracts satisfied?
+
+All contracts satisfied?.shape: diamond
+All contracts satisfied? -> Fix (see failure handling below): no
+All contracts satisfied? -> Code quality review: yes
+
+Code quality review -> Critical issues?
+
+Critical issues?.shape: diamond
+Critical issues? -> Fix (see failure handling below): yes
+Critical issues? -> Approve: no
+
+Approve.shape: double_circle
+```
+
+## Stage 1: Contract Compliance
+
+1. Run `lazyspec context <plan-id> --json` to see the full chain.
+2. Run `lazyspec show <plan-id> --json` to read the plan body.
+3. Run `lazyspec show <spec-id> --json` to read the Spec's contracts.
+4. Run the full test suite. Show the output.
+5. For each contract the plan claims to cover: verify the test exists and passes.
+6. If any contract is not satisfied, state which contracts are unmet. See Failure Handling below for what to do next.
+
+## Stage 2: Code Quality
+
+Only enter this stage if all contracts are satisfied.
+
+1. Review the code changes for correctness and clarity.
+2. Verify no unnecessary complexity (YAGNI -- only what was asked for).
+3. Check for real duplication worth extracting (DRY).
+4. Check for security issues.
+5. Evaluate test quality against these properties:
+
+   | Property              | What to check                                              |
+   | --------------------- | ---------------------------------------------------------- |
+   | Behavioral            | Tests assert on behavior, not implementation details       |
+   | Structure-insensitive | A refactor preserving behavior shouldn't break tests       |
+   | Isolated              | No order dependence, no shared mutable state between tests |
+   | Deterministic         | No flaky results from timing, randomness, or global state  |
+   | Readable              | Motivation for each test is obvious to the reader          |
+   | Specific              | When a test fails, the cause is obvious                    |
+   | Writable              | Test complexity is proportional to code complexity         |
+
+   These properties conflict. If a test trades one for another (e.g. an
+   integration test that sacrifices Fast/Isolated for Predictive/Inspiring),
+   the tradeoff should be noted. Flag unjustified tradeoffs to the collaborator.
+
+## Failure Handling
+
+The response to a failed review depends on context:
+
+**During `/build` per-task review:** Report the specific failures back to the `/build` orchestrator. The build skill will dispatch a fresh implementer subagent with the failure details. Do NOT re-plan or use `/create-plan`.
+
+**During `/build` final review:** If individual contracts are unmet, the build skill dispatches targeted fix subagents. If the failures indicate a fundamental planning problem (wrong approach, missing tasks), escalate to the user.
+
+**Standalone review (not during build):** Report failures to the user. The user decides whether to use `/create-plan` to re-plan or fix directly.
+
+## Red Flags
+
+| Red Flag                     | Reality                                                              |
+| ---------------------------- | -------------------------------------------------------------------- |
+| "The agent says tests pass"  | Run them yourself. Trust is not evidence.                            |
+| "I ran them earlier"         | Earlier is stale. Run them now, in this session.                     |
+| "The code looks right to me" | Code review before contract compliance is backwards. Check contracts first. |
+| "It mostly works"            | Mostly = some contracts aren't met. Return to implementation.        |
+
+## Verification
+
+Before claiming this review is approved:
+
+- [ ] Test suite has been run in this session with full output shown
+- [ ] Every claimed contract has a corresponding passing test
+- [ ] Code quality review completed (only after Stage 1 passes)
+- [ ] `lazyspec validate --json` passes
+
+## Status Updates
+
+When a review passes (both stages), follow the status promotion steps in `_common.md`.
+
+## Rules
+
+- Never review code quality before contract compliance
+- The Spec is the source of truth -- if the code satisfies the contracts, it's correct by definition
+- If contracts are ambiguous, that's a Spec problem, not a Plan problem
+- Always update document statuses after a successful review

--- a/examples/spec/skills/write-rfc/SKILL.md
+++ b/examples/spec/skills/write-rfc/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: write-rfc
+description: Use for heavy, cross-cutting, or architecturally significant designs. Creates an RFC document with intent, interface sketches, and identifies the Specs that fall out of it. Most features skip RFCs and go straight to Spec.
+---
+
+```
+RFCS ARE FOR HEAVY DESIGN WORK
+```
+
+RFCs capture design intent for cross-cutting, project-level, or architecturally significant changes. Most features don't need an RFC -- they go straight to Spec. Use an RFC when the work spans multiple areas, involves significant trade-offs, or needs broader alignment.
+
+<HARD-GATE>
+Do NOT create Specs until this RFC is written and the user has approved it.
+After completion: use the `/create-spec` skill for each contract slice identified.
+</HARD-GATE>
+
+> [!IMPORTANT]
+> Read `_common.md` in the skills directory for CLI usage, forbidden actions, and subagent tiers.
+
+<NEVER>
+- Do NOT create Spec documents from this skill. Finish the RFC, get approval, then use the `/create-spec` skill.
+</NEVER>
+
+# Write RFC
+
+## Workflow Position
+
+```d2
+lazy -> write-rfc -> create-spec -> resolve-context -> create-plan -> build
+
+write-rfc.style.fill: "#4A9EFF"
+write-rfc.style.font-color: "#FFFFFF"
+lazy.style.opacity: 0.4
+create-spec.style.opacity: 0.4
+resolve-context.style.opacity: 0.4
+create-lazy.style.opacity: 0.4
+build.style.opacity: 0.4
+```
+
+## Workflow
+
+```d2
+Understand the problem -> Create RFC -> Write intent and context -> Sketch interfaces -> Identify specs -> Validate -> User approves?
+
+User approves?.shape: diamond
+User approves? -> Use /create-spec skill: yes
+User approves? -> Revise RFC: no
+Revise RFC -> Write intent and context
+
+Use /create-spec skill.shape: double_circle
+```
+
+## Preflight
+
+1. Read relevant documents using `lazyspec show --json` before modifying anything
+2. Check for existing artifacts using `lazyspec search --json` and `lazyspec list --json`
+3. Search for existing RFCs on the topic: `lazyspec search "<topic>" --json`, `lazyspec list rfc --json`
+4. Read any related RFCs with `lazyspec show <id> --json`
+5. Confirm no existing RFC already covers this design
+
+## Steps
+
+1. **Understand the problem:** Search existing docs with `lazyspec search <topic> --json` to avoid duplicating prior work. Check for superseded RFCs.
+
+2. **Create the RFC:** Run `lazyspec help create` to confirm usage, then: `lazyspec create rfc "<title>" --author <name>`
+
+3. **Write intent:** Describe the problem being solved and why. This is design intent, not implementation detail.
+
+4. **Sketch interfaces:** Use `@draft` syntax for types that don't exist yet:
+   ```
+   @draft UserProfile { id: string; email: string }
+   ```
+   Use `@ref` for types that already exist in the codebase:
+   ```
+   @ref src/types/user.ts#UserProfile
+   ```
+
+5. **Identify Specs:** List the contract slices that fall out of this RFC. Each spec should lock down the contracts for one vertical slice -- data models, API surface, validation, error handling, edge cases. An implementer should be able to build from a spec without making design judgment calls.
+
+6. **Emit ADRs:** For significant decisions made during RFC writing, run `lazyspec help create` to confirm usage, then: `lazyspec create adr "<decision>"`. Run `lazyspec help link` to confirm usage, then: `lazyspec link <adr-path> related-to <rfc-path>`.
+
+7. **Validate:** Run `lazyspec validate --json`.
+
+## Red Flags
+
+| Red Flag | Reality |
+|----------|---------|
+| "I'll just start coding and document later" | Documentation after = rationalisation. Write the RFC. |
+| "This is too small for an RFC" | Maybe it is. RFCs are for heavy/cross-cutting work. Most features just need a Spec. |
+| "I already know the design" | If it's not written down, it doesn't exist. |
+
+## Verification
+
+Before claiming this skill is complete:
+
+- [ ] `lazyspec validate --json` passes
+- [ ] User has explicitly approved the RFC
+- [ ] At least one Spec has been identified
+- [ ] Any significant decisions have ADRs
+
+## Rules
+
+- RFCs describe intent, not implementation
+- An RFC is a design record -- it captures thinking at the time of writing
+- Sketch interfaces in prose or TypeScript, not as live code
+- Every RFC should identify at least one Spec


### PR DESCRIPTION
## Summary

- Adds a complete set of example skill definitions and templates for a spec-driven development workflow
- Includes skills for RFC writing, spec/plan/audit creation, building, reviewing, and context resolution
- Provides `.lazyspec.toml` config and markdown templates (ADR, plan, RFC, spec) as a reference implementation

## Details

This sets up the `examples/spec/` directory with a full skill suite that demonstrates how lazyspec can drive a structured development workflow: from RFC through stories, plans, iterations, and builds. Each skill includes prompts, triggers, and subagent dispatch patterns.