### PR TITLE
Forward and backward context with related records 🔗

### DIFF
--- a/docs/iterations/ITERATION-049-forward-and-backward-context-with-related-records.md
+++ b/docs/iterations/ITERATION-049-forward-and-backward-context-with-related-records.md
@@ -1,0 +1,175 @@
+---
+title: Forward and Backward Context with Related Records
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-10
+tags: []
+related:
+- implements: docs/stories/STORY-054-forward-and-backward-context-with-related-records.md
+---
+
+
+
+## Changes
+
+### Task 1: Extend `resolve_chain` to return the target index and build forward context
+
+**ACs addressed:** Forward context, "You are here" marker
+
+**Files:**
+- Modify: `src/cli/context.rs`
+
+**What to implement:**
+
+`resolve_chain` currently returns `Vec<&DocMeta>` -- just the backward chain. It needs to also return:
+1. The index of the target document within the chain (so callers know which card to mark)
+2. The forward children of the target document (documents whose `implements` points at the target)
+
+Change `resolve_chain` to return a struct:
+
+```rust
+pub struct ResolvedContext<'a> {
+    pub chain: Vec<&'a DocMeta>,
+    pub target_index: usize,
+    pub forward: Vec<&'a DocMeta>,
+    pub related: Vec<&'a DocMeta>,
+}
+```
+
+After building the backward chain (existing logic), walk forward from the target: use `store.reverse_links` or iterate all docs to find documents that `implements` the target. These are `forward` entries.
+
+For `related`: iterate all documents in the chain, collect their `RelatedTo` links, resolve them via `store.get()`, deduplicate by path.
+
+**How to verify:**
+`cargo test` -- new tests in Task 4 will cover this.
+
+---
+
+### Task 2: Update `run_human` for forward context, "you are here" marker, and related section
+
+**ACs addressed:** Forward context (CLI), "You are here" marker, Related records (CLI)
+
+**Files:**
+- Modify: `src/cli/context.rs` (`run_human`, `mini_card`)
+
+**What to implement:**
+
+1. Add a `marker: bool` parameter to `mini_card`. When true, append `  ← you are here` after the closing `╯` on the top-right line (the `╮` line). In no-color mode, append after `+`.
+
+2. In `run_human`, use the new `ResolvedContext` from Task 1. For each card in the chain, pass `marker: i == ctx.target_index`.
+
+3. After the last card in the chain, if `ctx.forward` is non-empty, render the forward children with `├─`/`└─` tree connectors (same style as the existing children rendering on lines 92-104, but for the target's forward children specifically). The existing children_of rendering for ancestor nodes in the chain stays as-is.
+
+4. After the chain + forward section, if `ctx.related` is non-empty, render a `─── related ───` header (use `dim()` for styling), then list each related doc as `  SHORTHAND  Title [status]` where SHORTHAND is extracted from the path (e.g. `RFC-002`), Title is `doc.title`, and status uses `styled_status()`.
+
+5. If `ctx.related` is empty, omit the related section entirely.
+
+**How to verify:**
+`cargo test` -- existing `context_human_output` test should still pass. New tests in Task 4 cover the extended output.
+
+---
+
+### Task 3: Update `run_json` to include `related` array
+
+**ACs addressed:** JSON output
+
+**Files:**
+- Modify: `src/cli/context.rs` (`run_json`)
+
+**What to implement:**
+
+Use `ResolvedContext` from Task 1. The JSON output gains a `related` key alongside `chain`:
+
+```json
+{
+  "chain": [...],
+  "related": [
+    { "path": "...", "title": "...", "type": "...", "status": "...", ... }
+  ]
+}
+```
+
+Each related document uses `doc_to_json_with_family` (same as chain entries). The `chain` field continues to include forward children via the existing `children` key on each chain entry. The `related` array is the deduplicated set of `RelatedTo` targets from all chain documents. If empty, emit `"related": []`.
+
+**How to verify:**
+`cargo test` -- new tests in Task 4.
+
+---
+
+### Task 4: Tests for CLI context changes
+
+**ACs addressed:** All CLI ACs
+
+**Files:**
+- Modify: `tests/cli_context_test.rs`
+
+**What to implement:**
+
+Add test fixtures and cases:
+
+1. **Forward context from RFC:** Create an RFC with two Stories implementing it. Run `resolve_chain` from the RFC. Assert `forward` contains both Stories.
+
+2. **Forward context from Story:** Create RFC -> Story -> 2 Iterations. Run from the Story. Assert chain has [RFC, Story], forward has both Iterations.
+
+3. **"You are here" marker:** Run `run_human` from a Story in a 3-level chain. Assert output contains `← you are here` on the Story card line, not on RFC or Iteration cards.
+
+4. **Related records in human output:** Add `related to` links to the RFC. Run `run_human`. Assert output contains `─── related ───` and the related document titles.
+
+5. **Related records omitted when none:** Run `run_human` on a chain with no `related to` links. Assert output does not contain `related`.
+
+6. **JSON related field:** Run `run_json` on a chain where the RFC has `related to` links. Parse JSON, assert `related` array is non-empty and contains the expected documents.
+
+7. **JSON related empty:** Run `run_json` on a chain with no related links. Assert `related` is an empty array.
+
+8. **No forward children:** Run from an Iteration (leaf). Assert `forward` is empty, output matches existing behavior.
+
+**How to verify:**
+`cargo test --test cli_context_test`
+
+---
+
+### Task 5: TUI relations tab shows chain, children, and related records
+
+**ACs addressed:** TUI context view
+
+**Files:**
+- Modify: `src/tui/ui.rs` (`draw_relations_content`)
+- Modify: `src/tui/app.rs` (`relation_count`, `navigate_to_relation`)
+
+**What to implement:**
+
+Restructure `draw_relations_content` to show three sections instead of grouping by relationship type:
+
+1. **Chain** section (dim italic header `  chain`): show the backward chain from the selected doc. For each ancestor, render as `    Title  type [status]` (same format as existing relation items). The chain walks `implements` upward, same as `resolve_chain`.
+
+2. **Children** section (dim italic header `  children`): show documents that implement the selected doc (reverse `implements` lookup). Same item format.
+
+3. **Related** section (dim italic header `  related`): show `RelatedTo` links from the selected doc. Same item format as today.
+
+The flat indexing for selection (`selected_relation`, `flat_index`) stays the same pattern but now indexes across all three sections. Update `relation_count` to return the total across all sections. Update `navigate_to_relation` to resolve the correct target path from the new section layout -- it needs to map `selected_relation` to the right document across chain, children, and related items.
+
+Navigation (Enter key) already calls `navigate_to_relation` which jumps to the target doc. This works as long as the path mapping is correct.
+
+**How to verify:**
+`cargo run` then launch the TUI, select a document with relations, switch to Relations tab. Verify chain, children, and related sections appear. Press Enter on a relation to navigate.
+
+## Test Plan
+
+| # | AC | Test | Properties |
+|---|---|---|---|
+| 1 | Forward context (RFC) | Fixture: RFC + 2 Stories. `resolve_chain(RFC)` -> forward contains both Stories | Isolated, Deterministic, Specific |
+| 2 | Forward context (Story) | Fixture: RFC -> Story -> 2 Iters. `resolve_chain(Story)` -> chain=[RFC,Story], forward=[Iter1,Iter2] | Isolated, Deterministic |
+| 3 | Forward context (leaf) | `resolve_chain(Iteration)` -> forward is empty | Isolated, Behavioral |
+| 4 | You are here marker | `run_human(Story)` in 3-level chain -> output contains `← you are here` on Story line only | Behavioral, Specific |
+| 5 | Related records (human) | RFC with `related to` links. `run_human` -> `─── related ───` + titles | Behavioral, Readable |
+| 6 | Related records omitted | No related links -> no `related` in output | Behavioral |
+| 7 | JSON related (present) | `run_json` -> `related` array with expected docs | Isolated, Specific |
+| 8 | JSON related (empty) | `run_json` -> `"related": []` | Isolated |
+
+> [!NOTE]
+> TUI changes (Task 5) are verified manually. The existing `navigate_to_relation` tests in the codebase (if any) may need updating to account for the new section layout.
+
+## Notes
+
+The existing `children_of` rendering in `run_human` (lines 92-104) shows child documents (subfolder children) for each node in the chain. This is distinct from "forward context" which shows documents that `implements` the target. Both should appear: subfolder children inline with their parent card, forward implementers after the target card.

--- a/docs/stories/STORY-054-forward-and-backward-context-with-related-records.md
+++ b/docs/stories/STORY-054-forward-and-backward-context-with-related-records.md
@@ -1,0 +1,117 @@
+---
+title: Forward and Backward Context with Related Records
+type: story
+status: accepted
+author: jkaloger
+date: 2026-03-10
+tags:
+- cli
+- tui
+- context
+related:
+- implements: docs/rfcs/RFC-007-agent-native-cli.md
+---
+
+
+
+## Context
+
+The `lazyspec context` command walks the `implements` chain upward from a document (Iteration -> Story -> RFC). This is useful for understanding design intent, but it only tells half the story. When looking at an RFC, you can't see what Stories implement it. When looking at a Story, you can't see its Iterations. And `related to` links are present in frontmatter but invisible in context output.
+
+Agents and humans both need the full picture: what came before, what came after, and what's related.
+
+## Acceptance Criteria
+
+### Forward context (CLI)
+
+- **Given** an RFC that has Stories implementing it
+  **When** I run `lazyspec context <rfc-id>`
+  **Then** the output includes the RFC mini-card followed by its child Stories listed with tree connectors (`├─`, `└─`)
+
+- **Given** a Story that has Iterations implementing it
+  **When** I run `lazyspec context <story-id>`
+  **Then** the output shows the backward chain (RFC → Story as mini-cards with `│` connectors), then the Story's child Iterations listed with tree connectors
+
+- **Given** a document with no forward relationships
+  **When** I run `lazyspec context <id>`
+  **Then** the output shows only the backward chain (existing behavior, no empty children section)
+
+> [!NOTE]
+> The existing code already renders `children_of` with tree connectors for every node in the chain. The change here is that the target document must also show its own children (forward context), not just nodes above it in the chain.
+
+### "You are here" marker (CLI)
+
+- **Given** I run `lazyspec context <id>` where `<id>` resolves to a document in the middle of a chain
+  **When** the styled output renders
+  **Then** the target document's mini-card has a `← you are here` marker appended to its top line, distinguishing it from ancestors and descendants
+
+### Related records (CLI)
+
+- **Given** a document in the chain has `related to` links in its frontmatter
+  **When** the styled output renders
+  **Then** a `─── related ───` section appears after the chain, listing each related document as `SHORTHAND  Title [status]`
+
+- **Given** no documents in the chain have `related to` links
+  **When** the styled output renders
+  **Then** the related section is omitted entirely (no empty header)
+
+> [!NOTE]
+> Related records are collected from all documents in the chain, not just the target. The related section aggregates them, deduplicated.
+
+### JSON output (CLI)
+
+- **Given** `--json` is passed
+  **When** I run `lazyspec context <id> --json`
+  **Then** the output includes `chain` (the full backward+forward chain as today), plus a new `related` array containing frontmatter objects for all `related to` targets across the chain
+
+### TUI context view
+
+- **Given** a document is selected in the TUI
+  **When** I view its Relations tab
+  **Then** the tab shows the backward chain, forward children, and related records grouped by section
+
+- **Given** a related or child document is shown in the TUI relations view
+  **When** I select it
+  **Then** I navigate to that document's detail view
+
+### Example: styled CLI output
+
+```
+$ lazyspec context STORY-019
+
+╭──────────────────╮
+│ Agent-Native CLI  │
+│ rfc [accepted]    │
+╰──────────────────╯
+  │
+╭───────────────────╮
+│ Context Command    │  ← you are here
+│ story [accepted]   │
+╰───────────────────╯
+  │
+╭─────────────────────────╮
+│ Context Command          │
+│ iteration [accepted]     │
+╰─────────────────────────╯
+
+─── related ───
+  RFC-002  AI-Driven Development Workflow [accepted]
+  STORY-002  CLI Commands [accepted]
+```
+
+## Scope
+
+### In Scope
+
+- Forward traversal of `implements` relationships (reverse direction)
+- Surfacing `related to` links in context output
+- JSON schema extension for forward and related fields
+- TUI detail view showing forward, backward, and related records
+- Navigation from related/child records in TUI
+
+### Out of Scope
+
+- Transitive forward traversal (RFC -> Story -> Iteration in one forward walk)
+- New relationship types
+- Graph visualization
+- Modifying the `status` command output

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -4,9 +4,17 @@ use crate::engine::document::{DocMeta, RelationType};
 use crate::engine::store::Store;
 use anyhow::Result;
 use console::colors_enabled;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
-pub fn resolve_chain<'a>(store: &'a Store, id: &str) -> Result<Vec<&'a DocMeta>> {
+pub struct ResolvedContext<'a> {
+    pub chain: Vec<&'a DocMeta>,
+    pub target_index: usize,
+    pub forward: Vec<&'a DocMeta>,
+    pub related: Vec<&'a DocMeta>,
+}
+
+pub fn resolve_chain<'a>(store: &'a Store, id: &str) -> Result<ResolvedContext<'a>> {
     let doc = store
         .resolve_shorthand(id)
         .ok_or_else(|| anyhow::anyhow!("document not found: {}", id))?;
@@ -29,41 +37,105 @@ pub fn resolve_chain<'a>(store: &'a Store, id: &str) -> Result<Vec<&'a DocMeta>>
         }
     }
 
-    Ok(chain)
+    let target_index = chain.iter().position(|d| d.path == doc.path).unwrap_or(0);
+
+    // Forward context: find docs whose `implements` points at the target
+    let target_path = &doc.path;
+    let forward: Vec<&DocMeta> = store
+        .reverse_links
+        .get(target_path)
+        .map(|links| {
+            links
+                .iter()
+                .filter(|(rel_type, _)| *rel_type == RelationType::Implements)
+                .filter_map(|(_, source_path)| store.get(source_path))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Related: collect RelatedTo links from all chain documents, deduplicated
+    let chain_paths: HashSet<&PathBuf> = chain.iter().map(|d| &d.path).collect();
+    let mut seen = HashSet::new();
+    let mut related = Vec::new();
+
+    for chain_doc in &chain {
+        // Forward RelatedTo links from this doc
+        if let Some(fwd) = store.forward_links.get(&chain_doc.path) {
+            for (rel_type, target) in fwd {
+                if *rel_type == RelationType::RelatedTo
+                    && !chain_paths.contains(target)
+                    && seen.insert(target.clone())
+                {
+                    if let Some(resolved) = store.get(target) {
+                        related.push(resolved);
+                    }
+                }
+            }
+        }
+        // Reverse RelatedTo links pointing at this doc
+        if let Some(rev) = store.reverse_links.get(&chain_doc.path) {
+            for (rel_type, source) in rev {
+                if *rel_type == RelationType::RelatedTo
+                    && !chain_paths.contains(source)
+                    && seen.insert(source.clone())
+                {
+                    if let Some(resolved) = store.get(source) {
+                        related.push(resolved);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ResolvedContext {
+        chain,
+        target_index,
+        forward,
+        related,
+    })
 }
 
 pub fn run_json(store: &Store, id: &str) -> Result<String> {
-    let chain = resolve_chain(store, id)?;
-    let items: Vec<_> = chain.iter().map(|d| doc_to_json_with_family(d, store)).collect();
-    let output = serde_json::json!({ "chain": items });
+    let resolved = resolve_chain(store, id)?;
+    let chain: Vec<_> = resolved.chain.iter().map(|d| doc_to_json_with_family(d, store)).collect();
+    let related: Vec<_> = resolved.related.iter().map(|d| doc_to_json_with_family(d, store)).collect();
+    let output = serde_json::json!({ "chain": chain, "related": related });
     Ok(serde_json::to_string_pretty(&output)?)
 }
 
-fn mini_card(doc: &DocMeta) -> String {
+fn mini_card(doc: &DocMeta, marker: bool) -> String {
     let title = &doc.title;
     let doc_type = format!("{}", doc.doc_type).to_lowercase();
+    let shorthand = doc.id.to_uppercase();
     let status = &doc.status;
     let status_str = format!("{}", status);
-    let line2_plain = format!("{} [{}]", doc_type, status_str);
+    let line2_plain = format!("{} {} [{}]", shorthand, doc_type, status_str);
     let content_width = title.len().max(line2_plain.len()) + 2;
+    let marker_suffix = if marker { "  \u{2190} you are here" } else { "" };
 
     if !colors_enabled() {
         let border = "-".repeat(content_width);
         return format!(
-            "+{}+\n| {:<width$}|\n| {:<width$}|\n+{}+",
+            "+{}+\n| {:<width$}|{}\n| {:<width$}|\n+{}+",
             border,
             format!("{} ", title),
+            marker_suffix,
             format!("{} ", line2_plain),
             border,
             width = content_width - 1,
         );
     }
 
+    let styled_marker = if marker {
+        format!("  {}", dim("\u{2190} you are here"))
+    } else {
+        String::new()
+    };
     let top = format!("\u{256d}{}\u{256e}", "\u{2500}".repeat(content_width));
     let pad1 = " ".repeat(content_width - 1 - title.len());
-    let mid1 = format!("\u{2502} {}{}\u{2502}", bold(title), pad1);
+    let mid1 = format!("\u{2502} {}{}\u{2502}{}", bold(title), pad1, styled_marker);
     let pad2 = " ".repeat(content_width - 1 - line2_plain.len());
-    let line2_styled = format!("{} [{}]", doc_type, styled_status(status));
+    let line2_styled = format!("{} {} [{}]", shorthand, doc_type, styled_status(status));
     let mid2 = format!("\u{2502} {}{}\u{2502}", line2_styled, pad2);
     let bot = format!("\u{2570}{}\u{256f}", "\u{2500}".repeat(content_width));
     format!("{}\n{}\n{}\n{}", top, mid1, mid2, bot)
@@ -78,15 +150,15 @@ fn chain_connector() -> String {
 }
 
 pub fn run_human(store: &Store, id: &str) -> Result<String> {
-    let chain = resolve_chain(store, id)?;
+    let resolved = resolve_chain(store, id)?;
     let mut output = String::new();
 
-    for (i, doc) in chain.iter().enumerate() {
+    for (i, doc) in resolved.chain.iter().enumerate() {
         if i > 0 {
             output.push_str(&chain_connector());
             output.push('\n');
         }
-        output.push_str(&mini_card(doc));
+        output.push_str(&mini_card(doc, i == resolved.target_index));
         output.push('\n');
 
         let child_paths = store.children_of(&doc.path);
@@ -97,10 +169,56 @@ pub fn run_human(store: &Store, id: &str) -> Result<String> {
                 .collect();
             for (j, child) in children.iter().enumerate() {
                 let connector = if j == children.len() - 1 { "\u{2514}\u{2500}" } else { "\u{251c}\u{2500}" };
+                let shorthand = child.id.to_uppercase();
                 let title = &child.title;
-                let path = child.path.to_string_lossy();
-                output.push_str(&format!("  {} {}  ({})\n", connector, title, path));
+                let status_display = if colors_enabled() {
+                    styled_status(&child.status)
+                } else {
+                    format!("{}", child.status)
+                };
+                output.push_str(&format!("  {} {} {} [{}]\n", connector, shorthand, title, status_display));
             }
+        }
+    }
+
+    if !resolved.forward.is_empty() {
+        output.push_str(&chain_connector());
+        output.push('\n');
+        for (j, child) in resolved.forward.iter().enumerate() {
+            let connector = if j == resolved.forward.len() - 1 {
+                "\u{2514}\u{2500}"
+            } else {
+                "\u{251c}\u{2500}"
+            };
+            let shorthand = child.id.to_uppercase();
+            let title = &child.title;
+            let status_display = if colors_enabled() {
+                styled_status(&child.status)
+            } else {
+                format!("{}", child.status)
+            };
+            output.push_str(&format!("  {} {} {} [{}]\n", connector, shorthand, title, status_display));
+        }
+    }
+
+    if !resolved.related.is_empty() {
+        output.push('\n');
+        if colors_enabled() {
+            output.push_str(&format!("{}\n", dim("\u{2500}\u{2500}\u{2500} related \u{2500}\u{2500}\u{2500}")));
+        } else {
+            output.push_str("--- related ---\n");
+        }
+        for rel_doc in &resolved.related {
+            let shorthand = rel_doc.id.to_uppercase();
+            let status_display = if colors_enabled() {
+                styled_status(&rel_doc.status)
+            } else {
+                format!("{}", rel_doc.status)
+            };
+            output.push_str(&format!(
+                "  {}  {} [{}]\n",
+                shorthand, rel_doc.title, status_display
+            ));
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -810,9 +810,74 @@ impl App {
         self.selected_relation = 0;
     }
 
+    pub fn relation_items(&self, doc: &DocMeta) -> Vec<PathBuf> {
+        let mut items = Vec::new();
+
+        // Chain: walk Implements links upward from doc
+        let mut chain = Vec::new();
+        let mut current_path = doc.path.clone();
+        loop {
+            let current_doc = match self.store.get(&current_path) {
+                Some(d) => d,
+                None => break,
+            };
+            let implements_target = current_doc.related.iter().find_map(|r| {
+                if r.rel_type == RelationType::Implements {
+                    // resolve target path via forward_links
+                    if let Some(fwd) = self.store.forward_links.get(&current_doc.path) {
+                        for (rel, target) in fwd {
+                            if *rel == RelationType::Implements {
+                                return Some(target.clone());
+                            }
+                        }
+                    }
+                    None
+                } else {
+                    None
+                }
+            });
+            match implements_target {
+                Some(parent) => {
+                    chain.push(parent.clone());
+                    current_path = parent;
+                }
+                None => break,
+            }
+        }
+        chain.reverse();
+        items.extend(chain);
+
+        // Children: docs that implement this doc (reverse Implements)
+        if let Some(rev) = self.store.reverse_links.get(&doc.path) {
+            for (rel, source) in rev {
+                if *rel == RelationType::Implements {
+                    items.push(source.clone());
+                }
+            }
+        }
+
+        // Related: forward and reverse RelatedTo links
+        if let Some(fwd) = self.store.forward_links.get(&doc.path) {
+            for (rel, target) in fwd {
+                if *rel == RelationType::RelatedTo {
+                    items.push(target.clone());
+                }
+            }
+        }
+        if let Some(rev) = self.store.reverse_links.get(&doc.path) {
+            for (rel, source) in rev {
+                if *rel == RelationType::RelatedTo {
+                    items.push(source.clone());
+                }
+            }
+        }
+
+        items
+    }
+
     pub fn relation_count(&self) -> usize {
         match self.selected_doc_meta() {
-            Some(doc) => self.store.related_to(&doc.path).len(),
+            Some(doc) => self.relation_items(doc).len(),
             None => 0,
         }
     }
@@ -835,9 +900,9 @@ impl App {
             Some(d) => d,
             None => return,
         };
-        let relations = self.store.related_to(&doc.path);
-        let target = match relations.get(self.selected_relation) {
-            Some((_, path)) => (*path).clone(),
+        let items = self.relation_items(doc);
+        let target = match items.get(self.selected_relation) {
+            Some(path) => path.clone(),
             None => return,
         };
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -451,9 +451,9 @@ fn draw_relations_content(f: &mut Frame, app: &App, area: Rect, block: Block, do
         return;
     };
 
-    let relations = app.store.related_to(&doc.path);
+    let all_items = app.relation_items(doc);
 
-    if relations.is_empty() {
+    if all_items.is_empty() {
         let paragraph = Paragraph::new(" No relations.")
             .block(block)
             .wrap(Wrap { trim: false });
@@ -461,59 +461,123 @@ fn draw_relations_content(f: &mut Frame, app: &App, area: Rect, block: Block, do
         return;
     }
 
+    // Build the three sections using the same logic as relation_items
+    // Chain: walk Implements upward
+    let mut chain_paths = Vec::new();
+    {
+        let mut current_path = doc.path.clone();
+        loop {
+            let current_doc = match app.store.get(&current_path) {
+                Some(d) => d,
+                None => break,
+            };
+            let implements_target = current_doc.related.iter().find_map(|r| {
+                if r.rel_type == RelationType::Implements {
+                    if let Some(fwd) = app.store.forward_links.get(&current_doc.path) {
+                        for (rel, target) in fwd {
+                            if *rel == RelationType::Implements {
+                                return Some(target.clone());
+                            }
+                        }
+                    }
+                    None
+                } else {
+                    None
+                }
+            });
+            match implements_target {
+                Some(parent) => {
+                    chain_paths.push(parent.clone());
+                    current_path = parent;
+                }
+                None => break,
+            }
+        }
+        chain_paths.reverse();
+    }
+
+    // Children: reverse Implements
+    let mut children_paths = Vec::new();
+    if let Some(rev) = app.store.reverse_links.get(&doc.path) {
+        for (rel, source) in rev {
+            if *rel == RelationType::Implements {
+                children_paths.push(source.clone());
+            }
+        }
+    }
+
+    // Related: forward + reverse RelatedTo
+    let mut related_paths = Vec::new();
+    if let Some(fwd) = app.store.forward_links.get(&doc.path) {
+        for (rel, target) in fwd {
+            if *rel == RelationType::RelatedTo {
+                related_paths.push(target.clone());
+            }
+        }
+    }
+    if let Some(rev) = app.store.reverse_links.get(&doc.path) {
+        for (rel, source) in rev {
+            if *rel == RelationType::RelatedTo {
+                related_paths.push(source.clone());
+            }
+        }
+    }
+
     let mut items: Vec<ListItem> = Vec::new();
     let mut flat_index = 0usize;
     let mut list_index = 0usize;
     let mut selected_flat_index = 0usize;
 
-    let type_order = [
-        RelationType::Implements,
-        RelationType::Supersedes,
-        RelationType::Blocks,
-        RelationType::RelatedTo,
-    ];
-
-    for rel_type in &type_order {
-        let matching: Vec<_> = relations
-            .iter()
-            .filter(|(rt, _)| *rt == rel_type)
-            .collect();
-
-        if matching.is_empty() {
-            continue;
-        }
-
-        items.push(ListItem::new(Line::from(Span::styled(
-            format!("  {}", rel_type),
+    let section_header = |label: &str| -> ListItem {
+        ListItem::new(Line::from(Span::styled(
+            format!("  {}", label),
             Style::default()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::ITALIC),
-        ))));
+        )))
+    };
+
+    let render_item = |path: &std::path::Path| -> ListItem {
+        let (title, doc_type_str, status_str, status_clr) =
+            if let Some(target_doc) = app.store.get(path) {
+                (
+                    target_doc.title.clone(),
+                    format!("{}", target_doc.doc_type),
+                    format!("{}", target_doc.status),
+                    status_color(&target_doc.status),
+                )
+            } else {
+                let name = display_name(path);
+                (name.to_string(), "?".to_string(), "missing".to_string(), Color::Red)
+            };
+
+        ListItem::new(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(format!("{:<35} ", title), Style::default()),
+            Span::styled(format!("{} ", doc_type_str), Style::default().fg(Color::DarkGray)),
+            Span::styled(format!("[{}]", status_str), Style::default().fg(status_clr)),
+        ]))
+    };
+
+    let sections: Vec<(&str, &Vec<std::path::PathBuf>)> = vec![
+        ("chain", &chain_paths),
+        ("children", &children_paths),
+        ("related", &related_paths),
+    ];
+
+    for (label, paths) in &sections {
+        if paths.is_empty() {
+            continue;
+        }
+
+        items.push(section_header(label));
         list_index += 1;
 
-        for (_, target_path) in &matching {
+        for path in *paths {
             if flat_index == app.selected_relation {
                 selected_flat_index = list_index;
             }
-
-            let (title, status_str, status_clr) =
-                if let Some(target_doc) = app.store.get(target_path) {
-                    (
-                        target_doc.title.as_str(),
-                        format!("{}", target_doc.status),
-                        status_color(&target_doc.status),
-                    )
-                } else {
-                    let name = display_name(target_path);
-                    (name, "missing".to_string(), Color::Red)
-                };
-
-            items.push(ListItem::new(Line::from(vec![
-                Span::raw("    "),
-                Span::styled(format!("{:<35} ", title), Style::default()),
-                Span::styled(status_str, Style::default().fg(status_clr)),
-            ])));
-
+            items.push(render_item(path));
             flat_index += 1;
             list_index += 1;
         }

--- a/tests/cli_context_test.rs
+++ b/tests/cli_context_test.rs
@@ -23,22 +23,24 @@ fn setup() -> TestFixture {
 fn context_walks_full_chain() {
     let fixture = setup();
     let store = fixture.store();
-    let chain = lazyspec::cli::context::resolve_chain(&store, "ITERATION-001").unwrap();
+    let resolved = lazyspec::cli::context::resolve_chain(&store, "ITERATION-001").unwrap();
 
-    assert_eq!(chain.len(), 3);
-    assert_eq!(chain[0].title, "Auth Redesign");
-    assert_eq!(chain[1].title, "Auth Implementation");
-    assert_eq!(chain[2].title, "Auth Sprint 1");
+    assert_eq!(resolved.chain.len(), 3);
+    assert_eq!(resolved.chain[0].title, "Auth Redesign");
+    assert_eq!(resolved.chain[1].title, "Auth Implementation");
+    assert_eq!(resolved.chain[2].title, "Auth Sprint 1");
+    assert_eq!(resolved.target_index, 2);
 }
 
 #[test]
 fn context_standalone_document() {
     let fixture = setup();
     let store = fixture.store();
-    let chain = lazyspec::cli::context::resolve_chain(&store, "RFC-001").unwrap();
+    let resolved = lazyspec::cli::context::resolve_chain(&store, "RFC-001").unwrap();
 
-    assert_eq!(chain.len(), 1);
-    assert_eq!(chain[0].title, "Auth Redesign");
+    assert_eq!(resolved.chain.len(), 1);
+    assert_eq!(resolved.chain[0].title, "Auth Redesign");
+    assert_eq!(resolved.target_index, 0);
 }
 
 #[test]
@@ -75,6 +77,134 @@ fn context_not_found() {
     let fixture = setup();
     let store = fixture.store();
     let result = lazyspec::cli::context::resolve_chain(&store, "NONEXISTENT-999");
-
     assert!(result.is_err());
+}
+
+fn setup_with_related() -> TestFixture {
+    let fixture = TestFixture::new();
+    fixture.write_doc(
+        "docs/rfcs/RFC-001-auth.md",
+        "---\ntitle: \"Auth Redesign\"\ntype: rfc\nstatus: accepted\nauthor: jkaloger\ndate: 2026-03-01\ntags: [security]\nrelated:\n- related to: docs/adrs/ADR-001-tokens.md\n---\n\nRFC body.\n",
+    );
+    fixture.write_doc(
+        "docs/adrs/ADR-001-tokens.md",
+        "---\ntitle: \"Token Strategy\"\ntype: adr\nstatus: accepted\nauthor: jkaloger\ndate: 2026-03-01\ntags: []\nrelated: []\n---\n\nADR body.\n",
+    );
+    fixture.write_doc(
+        "docs/stories/STORY-001-auth-impl.md",
+        "---\ntitle: \"Auth Implementation\"\ntype: story\nstatus: draft\nauthor: jkaloger\ndate: 2026-03-02\ntags: [security]\nrelated:\n- implements: docs/rfcs/RFC-001-auth.md\n---\n\nStory body.\n",
+    );
+    fixture.write_doc(
+        "docs/iterations/ITERATION-001-auth-sprint.md",
+        "---\ntitle: \"Auth Sprint 1\"\ntype: iteration\nstatus: draft\nauthor: agent\ndate: 2026-03-03\ntags: []\nrelated:\n- implements: docs/stories/STORY-001-auth-impl.md\n---\n\nIteration body.\n",
+    );
+    fixture
+}
+
+#[test]
+fn forward_context_from_rfc() {
+    let fixture = TestFixture::new();
+    fixture.write_doc(
+        "docs/rfcs/RFC-001-auth.md",
+        "---\ntitle: \"Auth Redesign\"\ntype: rfc\nstatus: accepted\nauthor: jkaloger\ndate: 2026-03-01\ntags: []\nrelated: []\n---\n\nRFC body.\n",
+    );
+    fixture.write_story("STORY-001-impl-a.md", "Impl A", "draft", Some("docs/rfcs/RFC-001-auth.md"));
+    fixture.write_story("STORY-002-impl-b.md", "Impl B", "draft", Some("docs/rfcs/RFC-001-auth.md"));
+
+    let store = fixture.store();
+    let resolved = lazyspec::cli::context::resolve_chain(&store, "RFC-001").unwrap();
+
+    assert_eq!(resolved.chain.len(), 1);
+    assert_eq!(resolved.forward.len(), 2);
+    let forward_titles: Vec<&str> = resolved.forward.iter().map(|d| d.title.as_str()).collect();
+    assert!(forward_titles.contains(&"Impl A"));
+    assert!(forward_titles.contains(&"Impl B"));
+}
+
+#[test]
+fn forward_context_from_story() {
+    let fixture = TestFixture::new();
+    fixture.write_rfc("RFC-001-auth.md", "Auth Redesign", "accepted");
+    fixture.write_story("STORY-001-auth.md", "Auth Implementation", "draft", Some("docs/rfcs/RFC-001-auth.md"));
+    fixture.write_iteration("ITERATION-001-sprint1.md", "Sprint 1", "draft", Some("docs/stories/STORY-001-auth.md"));
+    fixture.write_iteration("ITERATION-002-sprint2.md", "Sprint 2", "draft", Some("docs/stories/STORY-001-auth.md"));
+
+    let store = fixture.store();
+    let resolved = lazyspec::cli::context::resolve_chain(&store, "STORY-001").unwrap();
+
+    assert_eq!(resolved.chain.len(), 2);
+    assert_eq!(resolved.chain[0].title, "Auth Redesign");
+    assert_eq!(resolved.chain[1].title, "Auth Implementation");
+    assert_eq!(resolved.forward.len(), 2);
+    let forward_titles: Vec<&str> = resolved.forward.iter().map(|d| d.title.as_str()).collect();
+    assert!(forward_titles.contains(&"Sprint 1"));
+    assert!(forward_titles.contains(&"Sprint 2"));
+}
+
+#[test]
+fn you_are_here_marker() {
+    let fixture = setup();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_human(&store, "STORY-001").unwrap();
+
+    let marker = "\u{2190} you are here";
+    let marker_count = output.matches(marker).count();
+    assert_eq!(marker_count, 1, "expected exactly one 'you are here' marker, found {}", marker_count);
+
+    let marker_line = output.lines().find(|l| l.contains(marker)).unwrap();
+    assert!(marker_line.contains("Auth Implementation"), "marker should be on the Story line, got: {}", marker_line);
+    assert!(!marker_line.contains("Auth Redesign"));
+    assert!(!marker_line.contains("Auth Sprint 1"));
+}
+
+#[test]
+fn related_records_in_human_output() {
+    let fixture = setup_with_related();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_human(&store, "STORY-001").unwrap();
+
+    assert!(output.contains("related"), "output should contain 'related' section header");
+    assert!(output.contains("Token Strategy"), "output should contain the related document title");
+}
+
+#[test]
+fn related_records_omitted_when_none() {
+    let fixture = setup();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_human(&store, "STORY-001").unwrap();
+
+    assert!(!output.contains("related"), "output should not contain 'related' when there are no related-to links");
+}
+
+#[test]
+fn json_related_field_present() {
+    let fixture = setup_with_related();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_json(&store, "STORY-001").unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    let related = parsed["related"].as_array().unwrap();
+    assert!(!related.is_empty(), "related array should be non-empty");
+    let titles: Vec<&str> = related.iter().filter_map(|r| r["title"].as_str()).collect();
+    assert!(titles.contains(&"Token Strategy"), "related should contain 'Token Strategy'");
+}
+
+#[test]
+fn json_related_empty() {
+    let fixture = setup();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_json(&store, "STORY-001").unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    let related = parsed["related"].as_array().unwrap();
+    assert!(related.is_empty(), "related array should be empty when no related-to links exist");
+}
+
+#[test]
+fn no_forward_children_for_leaf() {
+    let fixture = setup();
+    let store = fixture.store();
+    let resolved = lazyspec::cli::context::resolve_chain(&store, "ITERATION-001").unwrap();
+
+    assert!(resolved.forward.is_empty(), "leaf node should have no forward children");
 }


### PR DESCRIPTION
## Summary

- `lazyspec context` now shows forward children (documents that implement the target), backward chain (existing), related records aggregated from the whole chain, and a "you are here" marker on the target document
- JSON output gains a `related` array alongside `chain`
- TUI Relations tab restructured into chain/children/related sections with navigation
- IDs shown on all elements (cards, children, related)

## Test plan

- [x] 8 new tests covering forward context, marker, related records (human + JSON), and leaf nodes
- [x] All 300+ existing tests pass
- [x] Manual verification of CLI output from RFC, Story, and Iteration levels
- [x] TUI relations tab renders and navigates correctly