### PR TITLE
fix: @ref symbol extraction falling back to whole file 🔍🩹

### DIFF
--- a/docs/iterations/ITERATION-065-fix-ref-symbol-extraction-falling-back-to-whole-file.md
+++ b/docs/iterations/ITERATION-065-fix-ref-symbol-extraction-falling-back-to-whole-file.md
@@ -1,0 +1,130 @@
+---
+title: Fix @ref symbol extraction falling back to whole file
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-13
+tags: []
+related:
+- implements: docs/stories/STORY-058-ref-expansion-hardening-and-performance.md
+---
+
+
+
+## Context
+
+When `@ref path#symbol` references a function, trait, impl, type alias, const, or static in Rust (or a class, function, const, or enum in TypeScript), the symbol extractor returns `None` because it only matches `struct_item`/`enum_item` (Rust) or `type_alias`/`interface_declaration` (TypeScript). The fallback in `resolve_ref` then dumps the entire file content into the preview.
+
+A secondary issue: line-number refs (`@ref path#42`) return everything from line 42 to EOF instead of a bounded range.
+
+**ACs addressed from STORY-058:**
+- "Given a TypeScript or Rust source file with multiple type definitions, When the symbol extractor is called, Then it finds the correct symbol without skipping any"
+- "Given an unresolvable @ref directive, When expansion runs, Then the output is `> [unresolved: path#symbol]`"
+
+## Changes
+
+### Task 1: Expand Rust tree-sitter node types
+
+**ACs addressed:** symbol extractor finds correct symbol
+
+**Files:**
+- Modify: `src/engine/symbols.rs`
+- Test: `src/engine/symbols.rs` (inline tests)
+
+**What to implement:**
+
+In `RustSymbolExtractor::extract`, expand the `match_node_types` slice from `["struct_item", "enum_item"]` to include:
+- `function_item` (free functions)
+- `trait_item` (trait definitions)
+- `impl_item` (impl blocks -- note: `find_symbol_node` matches by `name` field, and `impl_item` uses `type` field for the type name, so this needs the name extraction to also check `child_by_field_name("type")`)
+- `type_item` (type aliases)
+- `const_item` (constants)
+- `static_item` (statics)
+- `macro_definition` (macro_rules!)
+
+For `impl_item`, `find_symbol_node` currently only checks `child_by_field_name("name")`. `impl_item` nodes use `type` as the field name for the implementing type. Add a fallback in `find_symbol_node`: if `child_by_field_name("name")` returns `None`, also try `child_by_field_name("type")` and check the text of that node.
+
+**How to verify:**
+```
+cargo test --lib engine::symbols
+```
+Verify new tests pass for function, trait, type alias, const, and impl extraction.
+
+### Task 2: Expand TypeScript tree-sitter node types
+
+**ACs addressed:** symbol extractor finds correct symbol
+
+**Files:**
+- Modify: `src/engine/symbols.rs`
+- Test: `src/engine/symbols.rs` (inline tests)
+
+**What to implement:**
+
+In `TypeScriptSymbolExtractor::extract`, expand the `match_node_types` slice from `["type_alias", "type_alias_declaration", "interface_declaration"]` to include:
+- `class_declaration`
+- `function_declaration`
+- `enum_declaration`
+
+For `const`/`let` exports (`lexical_declaration`), the symbol name lives in a nested `variable_declarator` node, not directly on the `name` field. This is more complex and can be deferred to a follow-up. Document this limitation in Notes.
+
+**How to verify:**
+```
+cargo test --lib engine::symbols
+```
+Verify new tests pass for class, function, and enum extraction.
+
+### Task 3: Replace whole-file fallback with unresolved marker
+
+**ACs addressed:** unresolvable @ref outputs `> [unresolved: path#symbol]`
+
+**Files:**
+- Modify: `src/engine/refs.rs`
+- Test: `src/engine/refs.rs` (inline tests)
+
+**What to implement:**
+
+In `resolve_ref` at line 174-176, replace:
+```rust
+self.extract_symbol(path, sym, &file_content)
+    .unwrap_or_else(|| file_content.to_string())
+```
+with:
+```rust
+match self.extract_symbol(path, sym, &file_content) {
+    Some(content) => content,
+    None => return Ok(format!("> [unresolved: {}#{}]", path, sym)),
+}
+```
+
+This matches the existing error pattern used when `git show` fails (line 161).
+
+Also fix the line-number branch (line 173): `lines[line_num - 1..]` returns everything from that line to EOF. Change to take a single line: `lines[line_num - 1].to_string()`.
+
+**How to verify:**
+```
+cargo test --lib engine::refs
+```
+Verify that a ref to an unknown symbol produces `> [unresolved: ...]` instead of a code block with the full file.
+
+## Test Plan
+
+| Test name | AC | What it verifies |
+|---|---|---|
+| `test_extract_rust_function` | symbol extraction | `fn foo() {}` is extracted by name |
+| `test_extract_rust_trait` | symbol extraction | `trait MyTrait {}` is extracted by name |
+| `test_extract_rust_type_alias` | symbol extraction | `type Alias = ...` is extracted by name |
+| `test_extract_rust_const` | symbol extraction | `const FOO: ...` is extracted by name |
+| `test_extract_rust_impl` | symbol extraction | `impl MyStruct {}` is extracted by type name |
+| `test_extract_ts_class` | symbol extraction | `class Foo {}` is extracted by name |
+| `test_extract_ts_function` | symbol extraction | `function foo() {}` is extracted by name |
+| `test_extract_ts_enum` | symbol extraction | `enum Color {}` is extracted by name |
+| `test_unknown_symbol_returns_unresolved` | unresolved marker | Ref to non-existent symbol produces `> [unresolved: ...]` not file content |
+| `test_line_number_ref_single_line` | line-number fix | `#42` returns only line 42, not 42-EOF |
+
+All tests are unit-level, deterministic, fast, and isolated. No tradeoffs to flag.
+
+## Notes
+
+- `lexical_declaration` extraction for TypeScript (const/let exports) is out of scope. The name is nested in a `variable_declarator` child, requiring different traversal logic. Worth a follow-up if users reference TS constants frequently.
+- STORY-058 marks "Additional language grammars (Python, Go, etc.)" as out of scope, so we only expand within existing Rust and TypeScript extractors.
+- The `macro_definition` node type uses `name` field in tree-sitter-rust, so `find_symbol_node` handles it without changes.

--- a/src/engine/cache.rs
+++ b/src/engine/cache.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
-const CACHE_VERSION: u32 = 2;
+const CACHE_VERSION: u32 = 3;
 
 pub struct DiskCache {
     dir: PathBuf,

--- a/src/engine/refs.rs
+++ b/src/engine/refs.rs
@@ -170,10 +170,12 @@ impl RefExpander {
                 if line_num == 0 || line_num > lines.len() {
                     return Ok(format!("> [unresolved: {}#{}]", path, sym));
                 }
-                lines[line_num - 1..].join("\n")
+                lines[line_num - 1].to_string()
             } else {
-                self.extract_symbol(path, sym, &file_content)
-                    .unwrap_or_else(|| file_content.to_string())
+                match self.extract_symbol(path, sym, &file_content) {
+                    Some(content) => content,
+                    None => return Ok(format!("> [unresolved: {}#{}]", path, sym)),
+                }
             }
         } else {
             file_content.to_string()
@@ -377,5 +379,47 @@ mod tests {
         assert!(result.is_ok());
         let expanded = result.unwrap();
         assert!(expanded.contains("> [unresolved:"));
+    }
+
+    #[test]
+    fn test_unknown_symbol_produces_unresolved_marker() {
+        let expander = RefExpander::with_max_lines(std::env::current_dir().unwrap(), 9999);
+
+        let content = "See: @ref Cargo.toml#NonExistentSymbol";
+        let result = expander.expand(content).unwrap();
+        assert!(
+            result.contains("> [unresolved: Cargo.toml#NonExistentSymbol]"),
+            "Expected unresolved marker, got: {}",
+            result
+        );
+        // Should NOT contain the full file content
+        assert!(
+            !result.contains("[package]"),
+            "Should not dump full file content for unknown symbol"
+        );
+    }
+
+    #[test]
+    fn test_line_number_ref_returns_single_line() {
+        let expander = RefExpander::with_max_lines(std::env::current_dir().unwrap(), 9999);
+
+        // Line 1 of Cargo.toml is [package]
+        let content = "See: @ref Cargo.toml#1";
+        let result = expander.expand(content).unwrap();
+        assert!(result.contains("[package]"), "Should contain the first line");
+        // The code block should only have one line of actual content
+        // (i.e., it should NOT contain line 2+)
+        let lines_in_block: Vec<&str> = result
+            .lines()
+            .skip_while(|l| !l.starts_with("```"))
+            .skip(1) // skip opening ```
+            .take_while(|l| !l.starts_with("```"))
+            .collect();
+        assert_eq!(
+            lines_in_block.len(),
+            1,
+            "Line-number ref should return exactly one line, got: {:?}",
+            lines_in_block
+        );
     }
 }

--- a/src/engine/symbols.rs
+++ b/src/engine/symbols.rs
@@ -16,7 +16,10 @@ fn find_symbol_node(
     let node_type = node.kind();
 
     if match_node_types.contains(&node_type) {
-        if let Some(name_node) = node.child_by_field_name("name") {
+        let name_node = node
+            .child_by_field_name("name")
+            .or_else(|| node.child_by_field_name("type"));
+        if let Some(name_node) = name_node {
             let name = source.get(name_node.start_byte()..name_node.end_byte());
             if name == Some(symbol) {
                 let start = node.start_byte();
@@ -61,7 +64,14 @@ impl SymbolExtractor for TypeScriptSymbolExtractor {
             &mut cursor,
             source,
             symbol,
-            &["type_alias", "type_alias_declaration", "interface_declaration"],
+            &[
+                "type_alias",
+                "type_alias_declaration",
+                "interface_declaration",
+                "class_declaration",
+                "function_declaration",
+                "enum_declaration",
+            ],
         )
     }
 }
@@ -92,7 +102,17 @@ impl SymbolExtractor for RustSymbolExtractor {
             &mut cursor,
             source,
             symbol,
-            &["struct_item", "enum_item"],
+            &[
+                "struct_item",
+                "enum_item",
+                "function_item",
+                "trait_item",
+                "impl_item",
+                "type_item",
+                "const_item",
+                "static_item",
+                "macro_definition",
+            ],
         )
     }
 }
@@ -358,6 +378,192 @@ interface Outer { y: string; }"#;
         let extracted = result.unwrap();
         assert!(extracted.contains("Outer"));
         assert!(extracted.contains("y"));
+    }
+
+    // Rust function extraction
+    #[test]
+    fn test_extract_rust_function() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"pub fn process(input: &str) -> String {
+    input.to_uppercase()
+}"#;
+        let result = extractor.extract(source, "process");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("process"));
+        assert!(extracted.contains("input: &str"));
+        assert!(extracted.contains("to_uppercase"));
+    }
+
+    // Rust trait extraction
+    #[test]
+    fn test_extract_rust_trait() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"pub trait Drawable {
+    fn draw(&self);
+    fn bounds(&self) -> Rect;
+}"#;
+        let result = extractor.extract(source, "Drawable");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Drawable"));
+        assert!(extracted.contains("draw"));
+        assert!(extracted.contains("bounds"));
+    }
+
+    // Rust impl block extraction (uses "type" field, not "name")
+    #[test]
+    fn test_extract_rust_impl() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"pub struct Widget { size: u32 }
+
+impl Widget {
+    pub fn new() -> Self {
+        Widget { size: 0 }
+    }
+}"#;
+        let result = extractor.extract(source, "Widget");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Widget"));
+    }
+
+    // Rust type alias extraction
+    #[test]
+    fn test_extract_rust_type_alias() {
+        let extractor = RustSymbolExtractor::new();
+        let source = "pub type NodeId = u64;";
+        let result = extractor.extract(source, "NodeId");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("NodeId"));
+        assert!(extracted.contains("u64"));
+    }
+
+    // Rust const extraction
+    #[test]
+    fn test_extract_rust_const() {
+        let extractor = RustSymbolExtractor::new();
+        let source = "pub const MAX_SIZE: usize = 1024;";
+        let result = extractor.extract(source, "MAX_SIZE");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("MAX_SIZE"));
+        assert!(extracted.contains("1024"));
+    }
+
+    // Rust static extraction
+    #[test]
+    fn test_extract_rust_static() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"static GLOBAL_COUNT: AtomicU64 = AtomicU64::new(0);"#;
+        let result = extractor.extract(source, "GLOBAL_COUNT");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("GLOBAL_COUNT"));
+        assert!(extracted.contains("AtomicU64"));
+    }
+
+    // Rust macro_rules! extraction
+    #[test]
+    fn test_extract_rust_macro() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"macro_rules! my_macro {
+    ($x:expr) => { println!("{}", $x) };
+}"#;
+        let result = extractor.extract(source, "my_macro");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("my_macro"));
+        assert!(extracted.contains("println"));
+    }
+
+    // impl block found by "type" field when struct not present
+    #[test]
+    fn test_extract_rust_impl_without_struct() {
+        let extractor = RustSymbolExtractor::new();
+        let source = r#"impl Display for Foo {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Foo")
+    }
+}"#;
+        let result = extractor.extract(source, "Foo");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("impl Display for Foo"));
+        assert!(extracted.contains("fmt"));
+    }
+
+    // TS class extraction
+    #[test]
+    fn test_extract_ts_class_basic() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = "class Animal { name: string; constructor(name: string) { this.name = name; } }";
+        let result = extractor.extract(source, "Animal");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Animal"));
+        assert!(extracted.contains("constructor"));
+    }
+
+    #[test]
+    fn test_extract_ts_class_with_extends() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = "class Dog extends Animal { bark() { return 'woof'; } }";
+        let result = extractor.extract(source, "Dog");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Dog"));
+        assert!(extracted.contains("extends"));
+        assert!(extracted.contains("bark"));
+    }
+
+    // TS function extraction
+    #[test]
+    fn test_extract_ts_function_basic() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = "function greet(name: string): string { return `Hello ${name}`; }";
+        let result = extractor.extract(source, "greet");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("greet"));
+        assert!(extracted.contains("name: string"));
+    }
+
+    #[test]
+    fn test_extract_ts_function_async() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = "async function fetchData(url: string): Promise<Response> { return fetch(url); }";
+        let result = extractor.extract(source, "fetchData");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("fetchData"));
+        assert!(extracted.contains("Promise"));
+    }
+
+    // TS enum extraction
+    #[test]
+    fn test_extract_ts_enum_basic() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = "enum Direction { Up, Down, Left, Right }";
+        let result = extractor.extract(source, "Direction");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Direction"));
+        assert!(extracted.contains("Up"));
+        assert!(extracted.contains("Right"));
+    }
+
+    #[test]
+    fn test_extract_ts_enum_with_values() {
+        let extractor = TypeScriptSymbolExtractor::new();
+        let source = r#"enum Color { Red = "RED", Green = "GREEN", Blue = "BLUE" }"#;
+        let result = extractor.extract(source, "Color");
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("Color"));
+        assert!(extracted.contains("Red"));
+        assert!(extracted.contains("GREEN"));
     }
 
     #[test]

--- a/tests/expand_refs_test.rs
+++ b/tests/expand_refs_test.rs
@@ -213,8 +213,9 @@ See the code:
     assert!(result.is_ok());
     let output = result.unwrap();
     assert!(
-        output.contains("```"),
-        "Output should contain code block even for nonexistent symbol"
+        output.contains("> [unresolved: src/user.ts#NonExistentSymbol]"),
+        "Output should contain unresolved marker for nonexistent symbol, got: {}",
+        output
     );
 }
 


### PR DESCRIPTION
## Summary

- Expand tree-sitter node types for Rust (`function_item`, `trait_item`, `impl_item`, `type_item`, `const_item`, `static_item`, `macro_definition`) and TypeScript (`class_declaration`, `function_declaration`, `enum_declaration`) so `@ref path#symbol` no longer silently falls back to dumping the entire file
- Replace whole-file fallback with `> [unresolved: path#symbol]` marker matching existing error pattern
- Fix line-number refs (`@ref path#42`) to return a single line instead of everything from that line to EOF
- Bump disk cache version to invalidate stale TUI expansion cache

## Test plan

- [x] `cargo test --lib engine::symbols` -- 15 new tests for expanded node types
- [x] `cargo test --lib engine::refs` -- 2 new tests for unresolved marker and single-line ref
- [x] `cargo test` -- full suite passes (76 unit + integration)
- [ ] Manual: open TUI, select a doc with `@ref path#some_function`, confirm it shows the function not the whole file