### PR TITLE
feat: sqids document numbering 🦑🔢

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,12 +614,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -637,11 +661,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -659,6 +694,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1203,7 +1269,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1332,6 +1398,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sqids",
  "tempfile",
  "toml",
  "tree-sitter",
@@ -2676,6 +2743,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqids"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ec921820cea6db964ad35463cd8e5fa33cd04760e4dcd8329ecbfbcf98d60b"
+dependencies = [
+ "derive_builder",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ crossbeam-channel = "0.5"
 ratatui-image = { version = "10", default-features = false, features = ["crossterm", "image-defaults"] }
 image = "0.25"
 unicode-width = "0.2"
+sqids = "0.4"
 
 [features]
 default = []

--- a/docs/audits/AUDIT-003-rfc-027-sqids-implementation-quality-review.md
+++ b/docs/audits/AUDIT-003-rfc-027-sqids-implementation-quality-review.md
@@ -1,0 +1,48 @@
+---
+title: "RFC-027 sqids implementation quality review"
+type: audit
+status: draft
+author: "agent"
+date: 2026-03-17
+tags: []
+related:
+- related-to: docs/rfcs/RFC-027-sqids-document-numbering.md
+- related-to: docs/iterations/ITERATION-074-fix-numbering-format-conversion.md
+---
+
+## Scope
+
+Code quality review of the sqids numbering implementation introduced by RFC-027. Audit type: code quality. Focused on `src/cli/fix.rs` which contains the renumber and external reference scanning logic.
+
+## Criteria
+
+- No unnecessary code duplication (DRY)
+- Safe filesystem traversal (skip noise directories)
+- Correct handling of mixed-format document directories (no ID collisions)
+
+## Findings
+
+### Finding 1: scan_external_references doesn't skip .git/target/node_modules dirs
+
+**Severity:** medium
+**Location:** `src/cli/fix.rs:359` (`scan_dir_for_references`)
+**Description:** The directory walker only skips directories listed in `config.types[].dir` (the managed doc directories). It does not skip conventional noise directories like `.git`, `target/`, `node_modules/`, `.venv/`, etc. On real projects this causes unnecessary I/O and risks false-positive reference matches inside vendored or build-artifact files.
+**Recommendation:** Add a hardcoded skip-list for common noise directories (`.git`, `target`, `node_modules`, `.venv`, `dist`, `build`) or, better, make the skip-list configurable.
+
+### Finding 2: run_renumber_json duplicates logic from run_renumber
+
+**Severity:** low
+**Location:** `src/cli/fix.rs:508` (`run_renumber_json`) and `src/cli/fix.rs:98` (`run_renumber`)
+**Description:** `run_renumber_json` is a near-copy of `run_renumber`. Both call `collect_renumber_fixes` + `scan_external_references`, construct an identical `RenumberOutput`, and serialize it. The only difference is the output sink: one prints to stdout, the other returns a `String`. Any future change to the output structure must be applied in both places.
+**Recommendation:** Extract the shared logic into a single function that returns the `RenumberOutput`, then have `run_renumber` and `run_renumber_json` call it and handle presentation separately.
+
+### Finding 3: Potential ID collision in sqids-to-incremental conversion
+
+**Severity:** high
+**Location:** `src/cli/fix.rs:262-267` (inside `collect_renumber_fixes`, `RenumberFormat::Incremental` branch)
+**Description:** When converting sqids-format docs to incremental, the code filters to only sqids docs and then assigns numbers starting at 1 (`let new_num = (i + 1) as u32`). It does not account for existing incremental docs in the same type. If `RFC-001-foo.md` already exists alongside `RFC-abc-bar.md`, the sqids doc gets assigned `RFC-001`, colliding with the existing file.
+**Recommendation:** Before assigning incremental numbers, collect the set of already-used incremental IDs for the type and start numbering above the maximum, or interleave the new docs into gaps.
+
+## Summary
+
+Three findings across one file. The ID collision (finding 3) is the highest priority since it can cause data loss through file overwrites. The missing directory skip-list (finding 1) is a practical concern for any project with `node_modules` or a `target/` build directory. The DRY violation (finding 2) is low severity but straightforward to fix and reduces future maintenance risk.

--- a/docs/iterations/ITERATION-072-sqids-numbering-and-config.md
+++ b/docs/iterations/ITERATION-072-sqids-numbering-and-config.md
@@ -1,0 +1,127 @@
+---
+title: Sqids numbering and config
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/stories/STORY-064-sqids-numbering-and-config.md
+---
+
+
+
+## Changes
+
+### Task 1: Add sqids dependency and numbering config types
+
+**ACs addressed:** AC-4, AC-5, AC-6, AC-7
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/engine/config.rs`
+
+**What to implement:**
+
+Add `sqids = "0.4"` to `[dependencies]` in `Cargo.toml`.
+
+In `config.rs`, add a `NumberingStrategy` enum (`Incremental`, `Sqids`) and a `SqidsConfig` struct with fields `salt: String` and `min_length: u8`. Add an optional `numbering` field to `TypeDef` (defaults to `Incremental`). Add an optional `[numbering.sqids]` section to `RawConfig`/`Config`.
+
+In `Config::parse`, add validation:
+- If any type has `numbering = "sqids"`, a `[numbering.sqids]` section with a non-empty `salt` is required (AC-7).
+- `min_length` must be in range 1..=10 (AC-6). Default to 3 if omitted.
+
+Return `anyhow::bail!` with a clear message on validation failure.
+
+**How to verify:**
+`cargo test -- config` should pass. Write unit tests in `tests/config_test.rs` that assert: valid sqids config parses, missing salt fails, min_length=0 and min_length=11 fail, absent numbering field defaults to incremental.
+
+---
+
+### Task 2: Implement sqids ID generation in template.rs
+
+**ACs addressed:** AC-1, AC-8, AC-9
+
+**Files:**
+- Modify: `src/engine/template.rs`
+
+**What to implement:**
+
+Add a `pub fn next_sqids_id(dir: &Path, prefix: &str, sqids_config: &SqidsConfig) -> String` function. It should:
+1. Count existing files in `dir` that start with `prefix` (same scan as `next_number`).
+2. Build a `sqids::Sqids` instance using the configured `salt` and `min_length`.
+3. Encode `count + 1` to produce a candidate ID.
+4. Check for filename collision in `dir`. If collision, increment input and retry (AC-8).
+5. Return the ID as lowercase (AC-9).
+
+Update `resolve_filename` to accept an optional `NumberingStrategy` + `SqidsConfig`. When sqids, replace `{n:03}` / `{n}` with the sqids ID instead of the zero-padded number. When incremental (or None), preserve current behavior (AC-2, AC-3).
+
+**How to verify:**
+`cargo test -- template` with new unit tests: sqids ID is lowercase, min_length respected, salt changes output, collision retry works.
+
+---
+
+### Task 3: Thread numbering config through the create command
+
+**ACs addressed:** AC-1, AC-2, AC-3
+
+**Files:**
+- Modify: `src/cli/create.rs`
+- Modify: `src/cli/fix.rs`
+
+**What to implement:**
+
+In `create.rs::run`, after resolving `type_def`, look up its `numbering` strategy. If sqids, retrieve `sqids_config` from `config` and pass both to `resolve_filename`. The call site change is small since `resolve_filename` is the integration point.
+
+In `fix.rs`, update the call to `next_number` to be numbering-strategy-aware (use sqids ID generation when the type is configured for sqids).
+
+**How to verify:**
+Integration test: set up a temp project with `.lazyspec.toml` containing `numbering = "sqids"` on a type with a valid `[numbering.sqids]` section. Run `cargo run -- create rfc "Test" --json`. Assert the filename matches `RFC-<sqids-id>-test.md` pattern. Run again with default config and assert `RFC-001-test.md` pattern.
+
+---
+
+### Task 4: Integration tests for all ACs
+
+**ACs addressed:** AC-1 through AC-9
+
+**Files:**
+- Create: `tests/sqids_numbering_test.rs`
+- Modify: `tests/config_test.rs`
+
+**What to implement:**
+
+Tests covering each AC:
+- AC-1: create with sqids config produces sqids filename
+- AC-2: create with no numbering field produces incremental filename
+- AC-3: create with `numbering = "incremental"` produces incremental filename
+- AC-4: two different salts produce different IDs for same input
+- AC-5: `min_length = 5` produces IDs >= 5 chars
+- AC-6: `min_length = 0` and `min_length = 11` fail config validation
+- AC-7: sqids numbering without salt fails config validation
+- AC-8: pre-populate dir with colliding filename, verify retry
+- AC-9: generated ID is all lowercase
+
+Use `TestFixture` from `tests/common/mod.rs` and write custom `.lazyspec.toml` files into the temp dir.
+
+**How to verify:**
+`cargo test -- sqids` passes all tests.
+
+## Test Plan
+
+| AC | Test | Method |
+|----|------|--------|
+| AC-1 | Create doc with sqids config, assert filename pattern `RFC-<sqid>-title.md` | Integration |
+| AC-2 | Create doc with no numbering field, assert `RFC-001-title.md` | Integration |
+| AC-3 | Create doc with `numbering = "incremental"`, assert `RFC-001-title.md` | Integration |
+| AC-4 | Generate IDs with two different salts, assert different outputs | Unit |
+| AC-5 | Set `min_length = 5`, assert ID length >= 5 | Unit |
+| AC-6 | Set `min_length = 0` or `11`, assert config parse error | Unit |
+| AC-7 | Set sqids numbering with no salt, assert config parse error | Unit |
+| AC-8 | Pre-create file with expected sqids name, assert next create increments | Unit |
+| AC-9 | Generate sqids ID, assert `id == id.to_lowercase()` | Unit |
+
+## Notes
+
+The `sqids` crate (v0.4) handles alphabet customization and encoding. Salt is used to shuffle the default alphabet, not as a direct crate parameter -- implement by deterministically shuffling the alphabet using the salt before passing to `Sqids::builder().alphabet()`.
+
+The `resolve_filename` signature change is the main integration point. All callers (`create.rs`, `fix.rs`) need updating but the change is mechanical.

--- a/docs/iterations/ITERATION-073-id-resolution-for-mixed-formats.md
+++ b/docs/iterations/ITERATION-073-id-resolution-for-mixed-formats.md
@@ -1,0 +1,72 @@
+---
+title: ID resolution for mixed formats
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/stories/STORY-065-id-resolution-for-mixed-formats.md
+---
+
+
+
+## Test Plan
+
+- `extract_id_from_name("RFC-022-some-title")` returns `"RFC-022"` (AC-1)
+- `extract_id_from_name("RFC-k3f-some-title")` returns `"RFC-k3f"` (AC-2)
+- `extract_id_from_name("STORY-a2b-some-title")` returns `"STORY-a2b"` (AC-5)
+- `resolve_shorthand("RFC-022")` resolves to `RFC-022-foo.md` in a mixed directory (AC-3)
+- `resolve_shorthand("RFC-k3f")` resolves to `RFC-k3f-bar.md` in a mixed directory (AC-4)
+- `resolve_shorthand` with a non-existent sqids ID returns `NotFound` (AC-6)
+- `extract_id` on `RFC-k3f-some-title/index.md` returns `"RFC-k3f"` (AC-7)
+- Existing numeric-only tests still pass (regression)
+
+## Changes
+
+### Task 1: Update `extract_id_from_name` to accept alphanumeric ID segments
+
+**ACs addressed:** AC-1, AC-2, AC-5
+
+**Files:**
+- Modify: `src/engine/store.rs`
+
+**What to implement:**
+The current `extract_id_from_name` scans for the first all-digit segment after the prefix. Change the logic: after the uppercase prefix (e.g. `RFC-`, `STORY-`), treat the next segment as the ID regardless of whether it is numeric or alphanumeric. The pattern is `{PREFIX}-{ID}-{slug}`, where PREFIX is one or more uppercase letters and ID is the segment immediately following. Return `parts[..=prefix_end+1].join("-")` where `prefix_end` is the index of the last uppercase-only segment.
+
+Concretely: find the first segment that is NOT all-uppercase. That segment is the ID. Return everything up to and including it. This preserves `RFC-022` (022 is not all-uppercase) and adds `RFC-k3f` (k3f is not all-uppercase). Multi-word prefixes are not used, so the prefix is always index 0.
+
+**How to verify:**
+`cargo test` -- all existing store tests pass, plus new tests from Task 3.
+
+### Task 2: Update `strip_type_prefix` to handle alphanumeric IDs
+
+**ACs addressed:** AC-3, AC-4 (indirect, supports title extraction)
+
+**Files:**
+- Modify: `src/engine/store.rs`
+
+**What to implement:**
+`strip_type_prefix` currently expects digits after the prefix dash. Update the digit-scanning loop to also accept lowercase alphanumeric characters (`is_ascii_alphanumeric`). This ensures folder/file names with sqids IDs get their titles extracted correctly.
+
+**How to verify:**
+`cargo test` -- title extraction for sqids-named documents works.
+
+### Task 3: Add unit and integration tests for mixed-format ID resolution
+
+**ACs addressed:** AC-1 through AC-7
+
+**Files:**
+- Modify: `tests/store_test.rs`
+
+**What to implement:**
+Add a `setup_mixed_fixture()` that creates both `RFC-022-foo.md` and `RFC-k3f-bar.md` in the same directory, plus a folder-based `RFC-a1b-folder-doc/index.md`. Add tests:
+1. `extract_id_from_name` returns correct IDs for numeric, sqids, and multi-segment cases
+2. `resolve_shorthand` finds the right document for both `RFC-022` and `RFC-k3f`
+3. `resolve_shorthand` returns `NotFound` for `RFC-zzz`
+4. `extract_id` on folder-based sqids path returns `RFC-a1b`
+
+Note: `extract_id_from_name` is already `pub`. `extract_id` is private, so test it indirectly through store loading (check `doc.id` after loading the fixture).
+
+**How to verify:**
+`cargo test store` -- all new tests pass.

--- a/docs/iterations/ITERATION-074-fix-numbering-format-conversion.md
+++ b/docs/iterations/ITERATION-074-fix-numbering-format-conversion.md
@@ -1,0 +1,89 @@
+---
+title: Fix numbering format conversion
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/stories/STORY-066-fix-numbering-format-conversion.md
+---
+
+
+
+## Changes
+
+### Task 1: Add `--renumber` and `--type` CLI flags to fix command
+
+**ACs addressed:** AC-1, AC-2, AC-3, AC-5
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Modify: `src/main.rs`
+
+**What to implement:**
+Add two new options to the `Fix` variant in `Commands`: `--renumber <FORMAT>` (accepts `sqids` or `incremental`) and `--type <TYPE>` (optional, filters to a single document type like `rfc`). Pass both values through to `fix::run()`. When `--renumber` is provided, skip the existing field-fix and conflict-fix logic and instead run the new renumber logic (Task 2).
+
+**How to verify:**
+`cargo run -- help fix` shows the new flags. `cargo run -- fix --renumber sqids --dry-run --json` runs without error.
+
+### Task 2: Implement renumber collection logic in fix.rs
+
+**ACs addressed:** AC-1, AC-2, AC-3, AC-5, AC-7
+
+**Files:**
+- Modify: `src/cli/fix.rs`
+
+**What to implement:**
+Add a `collect_renumber_fixes` function. It iterates all docs from the store (filtered by `--type` if given). For each document, extract its current ID using `extract_id_from_name`. Determine the current format: if the ID segment after the prefix dash is all digits, it's incremental; otherwise it's sqids. Skip documents already in the target format (AC-7).
+
+For incremental-to-sqids: decode the numeric ID, encode through `sqids::Sqids` using the project's `SqidsConfig` from config. For sqids-to-incremental: sort target documents alphabetically by filename, assign sequential zero-padded numbers starting from 1 (AC-2). Build a `ConflictFixResult`-like struct for each rename. When `dry_run` is false, call `std::fs::rename` and `update_title_in_file`. Add a new `RenumberFixResult` struct and extend `FixOutput` with a `renumber_fixes` field.
+
+Wire the existing `cascade_references` function (already in fix.rs) to update all `related` frontmatter and `@ref` body directives after each rename (AC-4). Process all renames first to build the old-to-new path map, then cascade in a second pass to avoid partial updates.
+
+**How to verify:**
+`cargo test -- fix_renumber` passes. Manual: create a temp project with `RFC-001-foo.md` and `RFC-002-bar.md`, run `cargo run -- fix --renumber sqids --dry-run --json`, verify output lists expected renames.
+
+### Task 3: External reference detection and summary
+
+**ACs addressed:** AC-6
+
+**Files:**
+- Modify: `src/cli/fix.rs`
+
+**What to implement:**
+After renaming, scan non-lazyspec markdown files (any `.md` file not managed by the store) and any file matching common patterns (`*.wiki`, `README*`) for occurrences of the old filenames. Collect these as `ExternalReference { file: String, old_name: String, line: usize }`. Include them in the JSON output under `external_references`. In human output, print a summary like: `Warning: 3 external references found that could not be auto-updated` followed by the file/line list.
+
+**How to verify:**
+Create a `README.md` referencing `RFC-001-foo.md`, run renumber with `--dry-run`, verify the external reference appears in output.
+
+### Task 4: Human-readable and JSON output for renumber
+
+**ACs addressed:** AC-5
+
+**Files:**
+- Modify: `src/cli/fix.rs`
+
+**What to implement:**
+Extend `format_human` and the JSON serialization to include renumber results. For dry-run, prefix each line with "Would rename". For actual runs, prefix with "Renamed". Include reference updates in the output. The `FixOutput` struct gains `renumber_fixes: Vec<RenumberFixResult>` and `external_references: Vec<ExternalReference>`.
+
+**How to verify:**
+`cargo run -- fix --renumber sqids --dry-run` prints human-readable rename plan. `--json` flag produces parseable JSON with all fields.
+
+## Test Plan
+
+| AC | Test | Type |
+|----|------|------|
+| AC-1 | Create project with `RFC-001-foo.md`, run `fix --renumber sqids`, assert file renamed to `RFC-<sqid>-foo.md` | Integration |
+| AC-2 | Create project with sqids-named docs, run `fix --renumber incremental`, assert files renamed to `RFC-001-...`, `RFC-002-...` in alphabetical order | Integration |
+| AC-3 | Create project with RFCs and stories, run `fix --renumber sqids --type rfc`, assert only RFCs renamed | Integration |
+| AC-4 | Create two docs where one has `related: [{implements: <old-path>}]`, run renumber, assert related path updated | Integration |
+| AC-5 | Run any renumber with `--dry-run`, assert no files changed on disk, output lists planned renames | Integration |
+| AC-6 | Create a README referencing a doc path, run renumber, assert external reference warning in output | Integration |
+| AC-7 | Create mixed incremental + sqids docs, run `fix --renumber sqids`, assert only incremental docs converted | Integration |
+
+## Notes
+
+This iteration depends on the sqids numbering infrastructure from ITERATION-072 (the `SqidsConfig` struct and sqids crate dependency). The `cascade_references` function already exists in `fix.rs` and handles both `related` frontmatter and `@ref` body directives, so AC-4 is largely covered by reusing it.
+
+For sqids-to-incremental conversion, alphabetical filename ordering produces a deterministic sequence per the RFC design. The numbering starts at 1, not at `next_number`, since the goal is a clean cutover.

--- a/docs/iterations/ITERATION-075-audit-003-fix-id-collision-noise-dir-skip-dry-renumber.md
+++ b/docs/iterations/ITERATION-075-audit-003-fix-id-collision-noise-dir-skip-dry-renumber.md
@@ -1,0 +1,103 @@
+---
+title: 'AUDIT-003 fix: ID collision, noise dir skip, DRY renumber'
+type: iteration
+status: accepted
+author: agent
+date: 2026-03-17
+tags: []
+related:
+- implements: docs/stories/STORY-066-fix-numbering-format-conversion.md
+- related-to: docs/audits/AUDIT-003-rfc-027-sqids-implementation-quality-review.md
+---
+
+
+
+
+## Changes
+
+### Task 1: Fix ID collision in sqids-to-incremental conversion
+
+**Findings addressed:** AUDIT-003 Finding 3 (high)
+
+**Files:**
+- Modify: `src/cli/fix.rs` (lines 250-277, `collect_renumber_fixes` `Incremental` branch)
+- Test: `tests/cli_fix_renumber_test.rs`
+
+**What to implement:**
+
+The `RenumberFormat::Incremental` branch currently assigns numbers starting at 1 regardless of existing incremental docs. When a directory contains both `RFC-001-foo.md` (incremental) and `RFC-abc-bar.md` (sqids), converting to incremental assigns `RFC-001` to the sqids doc, colliding with the existing file.
+
+Fix: before assigning new numbers, collect the set of existing incremental IDs for this type. Start numbering above the maximum existing ID. Specifically:
+
+1. Collect all docs for the type that already have incremental IDs (filter where `is_incremental_id` is true)
+2. Parse their numeric segments and find the max
+3. Assign new numbers starting from `max + 1` instead of `1`
+
+**How to verify:**
+```
+cargo test --test cli_fix_renumber_test renumber_sqids_to_incremental_avoids_collision
+```
+
+### Task 2: Skip noise directories in scan_dir_for_references
+
+**Findings addressed:** AUDIT-003 Finding 1 (medium)
+
+**Files:**
+- Modify: `src/cli/fix.rs` (lines 359-416, `scan_dir_for_references`)
+- Test: `tests/cli_fix_renumber_test.rs`
+
+**What to implement:**
+
+Add a hardcoded skip-list for common noise directories at the top of `scan_dir_for_references`. When iterating directory entries, check if the directory name matches any entry in the skip-list and `continue` if so. This check should happen before the existing `managed_dirs` check.
+
+Skip-list: `.git`, `target`, `node_modules`, `.venv`, `dist`, `build`, `.hg`.
+
+The check should compare the directory's file name (not the full path), since these directories can appear at any depth.
+
+**How to verify:**
+```
+cargo test --test cli_fix_renumber_test renumber_external_refs_skips_noise_dirs
+```
+
+### Task 3: Extract shared renumber logic (DRY)
+
+**Findings addressed:** AUDIT-003 Finding 2 (low)
+
+**Files:**
+- Modify: `src/cli/fix.rs` (lines 98-157 `run_renumber`, lines 508-534 `run_renumber_json`)
+
+**What to implement:**
+
+Extract the shared logic from `run_renumber` and `run_renumber_json` into a helper function:
+
+```rust
+fn collect_renumber_output(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    format: &RenumberFormat,
+    doc_type: Option<&str>,
+    dry_run: bool,
+) -> RenumberOutput
+```
+
+This function builds the `RenumberOutput` (format string, collect changes, scan external refs). Then:
+- `run_renumber` calls it and handles human/json printing
+- `run_renumber_json` calls it and serializes to string
+
+No new tests needed -- existing `renumber_json_output_structure` already exercises both paths. Run the full test suite to confirm no regressions.
+
+**How to verify:**
+```
+cargo test --test cli_fix_renumber_test
+```
+
+## Test Plan
+
+- `renumber_sqids_to_incremental_avoids_collision`: Set up a directory with `RFC-001-foo.md` (incremental) and `RFC-abc-bar.md` (sqids). Run renumber to incremental. Assert `RFC-001-foo.md` still exists unchanged, and the sqids doc is renamed to `RFC-002-bar.md` (not `RFC-001`). Isolated, deterministic, specific.
+- `renumber_external_refs_skips_noise_dirs`: Set up a fixture with a `.git/config` file and a `node_modules/pkg/README.md` that both contain a reference to an old filename. Run `scan_external_references`. Assert neither file appears in the results. Fast, isolated, behavioral.
+- Existing tests run green with no changes: `cargo test --test cli_fix_renumber_test`
+
+## Notes
+
+Task ordering matters: Task 1 (collision fix) is the highest-priority data-loss bug. Task 3 (DRY) should come last since it restructures the functions that Tasks 1 and 2 may touch.

--- a/docs/rfcs/RFC-027-sqids-document-numbering.md
+++ b/docs/rfcs/RFC-027-sqids-document-numbering.md
@@ -1,7 +1,7 @@
 ---
 title: "Sqids Document Numbering"
 type: rfc
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-03-15
 tags:
@@ -12,6 +12,7 @@ related:
   - related to: docs/rfcs/RFC-020-fix-command-numbering-conflict-resolution.md
   - related to: docs/rfcs/RFC-013-custom-document-types.md
 ---
+
 
 ## Problem
 

--- a/docs/stories/STORY-064-sqids-numbering-and-config.md
+++ b/docs/stories/STORY-064-sqids-numbering-and-config.md
@@ -1,0 +1,76 @@
+---
+title: Sqids numbering and config
+type: story
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/rfcs/RFC-027-sqids-document-numbering.md
+---
+
+
+
+## Context
+
+Document numbering currently uses sequential integers (`RFC-001`, `RFC-002`). This breaks in distributed workflows where two branches can independently claim the same number. Sqids provides short, unique, non-sequential IDs as an alternative strategy, configured per-type.
+
+This story covers the core numbering infrastructure: the `sqids` dependency, config parsing, ID generation dispatch, and integration with the `create` command. ID resolution and migration are handled in separate stories.
+
+## Acceptance Criteria
+
+- **Given** a `.lazyspec.toml` with `numbering = "sqids"` on a type and a valid `[numbering.sqids]` section
+  **When** `lazyspec create` is run for that type
+  **Then** the generated document filename uses a sqids-encoded ID (e.g. `RFC-k3f-my-title.md`)
+
+- **Given** a `.lazyspec.toml` with no `numbering` field on a type
+  **When** `lazyspec create` is run for that type
+  **Then** the document uses incremental numbering as before
+
+- **Given** a `.lazyspec.toml` with `numbering = "incremental"` on a type
+  **When** `lazyspec create` is run for that type
+  **Then** the document uses incremental numbering as before
+
+- **Given** a `[numbering.sqids]` section with a `salt` value
+  **When** sqids IDs are generated
+  **Then** the salt influences the output alphabet so IDs differ from the unsalted default
+
+- **Given** a `[numbering.sqids]` section with `min_length = 5`
+  **When** a sqids ID is generated
+  **Then** the ID is at least 5 characters long
+
+- **Given** a `[numbering.sqids]` section with `min_length` outside the range 1-10
+  **When** the config is loaded
+  **Then** validation fails with a clear error message
+
+- **Given** `numbering = "sqids"` on a type but no `[numbering.sqids]` section with a `salt`
+  **When** the config is loaded
+  **Then** validation fails indicating that `salt` is required for sqids numbering
+
+- **Given** a directory with existing sqids-numbered documents
+  **When** `lazyspec create` generates the next ID
+  **Then** the input integer is `count + 1` of existing documents, and if the resulting filename collides, the input increments until no collision occurs
+
+- **Given** sqids numbering is configured
+  **When** a document is created
+  **Then** the ID portion of the filename is lowercase
+
+## Scope
+
+### In Scope
+
+- Add `sqids` crate dependency
+- `NumberingStrategy` enum (`Incremental`, `Sqids`)
+- `SqidsConfig` struct (`min_length`, `alphabet`, `salt`)
+- Parse `numbering` field on `[[types]]` entries
+- Parse `[numbering.sqids]` global config section
+- `next_id` function that dispatches to incremental or sqids generation
+- Update `create` command to use `next_id`
+- Validate: `salt` required when sqids is used, `min_length` in range 1-10
+
+### Out of Scope
+
+- ID resolution changes (`extract_id_from_name`, `resolve_shorthand`) -- Story B
+- `fix --renumber` migration between strategies -- Story C
+- Changes to `lazyspec validate` document-level validation
+- Custom per-type sqids config (all sqids types share one global config)

--- a/docs/stories/STORY-065-id-resolution-for-mixed-formats.md
+++ b/docs/stories/STORY-065-id-resolution-for-mixed-formats.md
@@ -1,0 +1,62 @@
+---
+title: ID resolution for mixed formats
+type: story
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/rfcs/RFC-027-sqids-document-numbering.md
+---
+
+
+
+## Context
+
+Document IDs are currently assumed to be numeric (`RFC-022`, `STORY-064`). With the introduction of sqids-based numbering (RFC-027), IDs can also be short alphanumeric strings like `RFC-k3f`. The ID extraction and resolution logic needs to handle both formats so that sqids and incremental documents can coexist in the same directory.
+
+## Acceptance Criteria
+
+- **Given** a document with a numeric ID (e.g. `RFC-022-some-title.md`)
+  **When** `extract_id_from_name` is called
+  **Then** it returns `RFC-022`
+
+- **Given** a document with an alphanumeric sqids ID (e.g. `RFC-k3f-some-title.md`)
+  **When** `extract_id_from_name` is called
+  **Then** it returns `RFC-k3f`
+
+- **Given** a directory containing both `RFC-022-foo.md` and `RFC-k3f-bar.md`
+  **When** resolving shorthand `RFC-022`
+  **Then** it resolves to `RFC-022-foo.md`
+
+- **Given** a directory containing both `RFC-022-foo.md` and `RFC-k3f-bar.md`
+  **When** resolving shorthand `RFC-k3f`
+  **Then** it resolves to `RFC-k3f-bar.md`
+
+- **Given** a document with a multi-segment alphanumeric ID (e.g. `STORY-a2b-some-title.md`)
+  **When** `extract_id_from_name` is called
+  **Then** it returns `STORY-a2b` (the prefix plus the first alphanumeric segment after it)
+
+- **Given** shorthand input with no matching document
+  **When** resolving the shorthand
+  **Then** the existing error behavior is preserved
+
+- **Given** an `index.md` inside a folder named `RFC-k3f-some-title`
+  **When** `extract_id` is called on its path
+  **Then** it correctly extracts `RFC-k3f` from the folder name
+
+## Scope
+
+### In Scope
+
+- Update `extract_id_from_name` to recognize alphanumeric ID segments (not just numeric)
+- Update `resolve_shorthand` to match against alphanumeric IDs
+- Coexistence of sqids and incremental documents in the same directory
+- Folder-based documents with sqids IDs (index.md inside `RFC-k3f-slug/`)
+
+### Out of Scope
+
+- Numbering strategy implementation, `NumberingStrategy` enum, config parsing (Story A)
+- `fix --renumber` migration between formats (Story C)
+- Sqids crate integration or ID generation
+- Validation of sqids config (`min_length`, `salt`, `alphabet`)

--- a/docs/stories/STORY-066-fix-numbering-format-conversion.md
+++ b/docs/stories/STORY-066-fix-numbering-format-conversion.md
@@ -1,0 +1,65 @@
+---
+title: Fix numbering format conversion
+type: story
+status: accepted
+author: agent
+date: 2026-03-16
+tags: []
+related:
+- implements: docs/rfcs/RFC-027-sqids-document-numbering.md
+---
+
+
+
+## Context
+
+When a team switches their numbering strategy from incremental to sqids (or vice versa), existing documents retain their original IDs. This works fine for coexistence, but teams that want a clean cutover need a way to bulk-convert document IDs. The `lazyspec fix` command already handles frontmatter repair and numbering conflicts, making it the natural home for format conversion.
+
+Renaming files is only half the problem. Every `related` frontmatter reference pointing at a renamed document must be updated in the same pass, or relationships silently break.
+
+## Acceptance Criteria
+
+- **Given** a project with incremental-numbered documents
+  **When** `lazyspec fix --renumber sqids` is run
+  **Then** each document is renamed with its sqids-encoded ID (e.g. `RFC-022-slug.md` becomes `RFC-k3f-slug.md`)
+
+- **Given** a project with sqids-numbered documents
+  **When** `lazyspec fix --renumber incremental` is run
+  **Then** each document is renamed with its zero-padded numeric ID decoded from the sqids value
+
+- **Given** a project with multiple document types
+  **When** `lazyspec fix --renumber sqids --type rfc` is run
+  **Then** only RFC documents are renamed; other types are left unchanged
+
+- **Given** documents with `related` frontmatter referencing a document that will be renamed
+  **When** the renumber operation completes
+  **Then** all `related` paths across the project are updated to reflect the new filenames
+
+- **Given** any renumber operation
+  **When** `--dry-run` is passed
+  **Then** no files are modified on disk, and the output lists every rename and reference update that would occur
+
+- **Given** non-lazyspec files (READMEs, wikis) that reference renamed documents
+  **When** the renumber operation completes
+  **Then** a summary of external references that could not be auto-updated is printed
+
+- **Given** a project with mixed incremental and sqids documents for the same type
+  **When** `lazyspec fix --renumber sqids` is run
+  **Then** only incremental-numbered documents are converted; already-sqids documents are skipped
+
+## Scope
+
+### In Scope
+
+- `lazyspec fix --renumber sqids|incremental` command
+- `--type` flag to scope conversion to specific document types
+- `--dry-run` flag to preview changes without filesystem modifications
+- File renames translating between incremental and sqids ID formats
+- Cascading updates to all `related` frontmatter paths across the project
+- Summary output listing external references that couldn't be auto-updated
+
+### Out of Scope
+
+- Core sqids numbering strategy, `NumberingStrategy` enum, config, and `next_id` logic (Story A)
+- ID resolution changes to `extract_id_from_name` and `resolve_shorthand` (Story B)
+- Updating `@ref` directives or external links outside the docs directory

--- a/src/cli/create.rs
+++ b/src/cli/create.rs
@@ -1,5 +1,5 @@
 use crate::cli::json::doc_to_json;
-use crate::engine::config::Config;
+use crate::engine::config::{Config, NumberingStrategy};
 use crate::engine::document::DocMeta;
 use crate::engine::template;
 use anyhow::{anyhow, Result};
@@ -22,8 +22,16 @@ pub fn run(
     let target_dir = root.join(dir);
     fs::create_dir_all(&target_dir)?;
 
+    let numbering = match type_def.numbering {
+        NumberingStrategy::Sqids => {
+            let sqids_config = config.sqids.as_ref()
+                .ok_or_else(|| anyhow!("type '{}' uses sqids numbering but no [numbering.sqids] config found", doc_type))?;
+            Some((&type_def.numbering, sqids_config))
+        }
+        NumberingStrategy::Incremental => None,
+    };
     let filename =
-        template::resolve_filename(&config.naming.pattern, doc_type, title, &target_dir);
+        template::resolve_filename(&config.naming.pattern, doc_type, title, &target_dir, numbering);
     let target_path = target_dir.join(&filename);
 
     let template_path = root

--- a/src/cli/fix.rs
+++ b/src/cli/fix.rs
@@ -1,19 +1,46 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use regex::Regex;
 use serde::Serialize;
 
-use crate::engine::config::Config;
+use crate::cli::RenumberFormat;
+use crate::engine::config::{Config, NumberingStrategy, SqidsConfig};
 use crate::engine::document::split_frontmatter;
 use crate::engine::refs::REF_PATTERN;
 use crate::engine::store::{extract_id_from_name, Store};
-use crate::engine::template::next_number;
+use crate::engine::template::{next_number, next_sqids_id, shuffle_alphabet};
 
 #[derive(Debug, Serialize)]
 struct FixOutput {
     field_fixes: Vec<FieldFixResult>,
     conflict_fixes: Vec<ConflictFixResult>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct RenumberFixResult {
+    pub old_path: String,
+    pub new_path: String,
+    pub old_id: String,
+    pub new_id: String,
+    pub references_updated: Vec<ReferenceUpdate>,
+    pub written: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ExternalReference {
+    pub file: String,
+    pub old_name: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct RenumberOutput {
+    format: String,
+    doc_type: Option<String>,
+    dry_run: bool,
+    changes: Vec<RenumberFixResult>,
+    external_references: Vec<ExternalReference>,
 }
 
 #[derive(Debug, Serialize)]
@@ -68,6 +95,439 @@ pub fn run(
     if has_fixes { 0 } else { 1 }
 }
 
+fn collect_renumber_output(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    format: &RenumberFormat,
+    doc_type: Option<&str>,
+    dry_run: bool,
+) -> RenumberOutput {
+    let format_str = match format {
+        RenumberFormat::Sqids => "sqids",
+        RenumberFormat::Incremental => "incremental",
+    };
+
+    let changes = collect_renumber_fixes(root, store, config, format, doc_type, dry_run);
+    let external_references = scan_external_references(root, store, config, &changes);
+
+    RenumberOutput {
+        format: format_str.to_string(),
+        doc_type: doc_type.map(|s| s.to_string()),
+        dry_run,
+        changes,
+        external_references,
+    }
+}
+
+pub fn run_renumber(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    format: &RenumberFormat,
+    doc_type: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> i32 {
+    let output = collect_renumber_output(root, store, config, format, doc_type, dry_run);
+
+    if json {
+        let wrapper = serde_json::json!({ "renumber": output });
+        println!("{}", serde_json::to_string_pretty(&wrapper).unwrap());
+    } else {
+        for c in &output.changes {
+            if dry_run {
+                println!("Would rename {} -> {}", c.old_path, c.new_path);
+            } else {
+                println!("Renamed {} -> {}", c.old_path, c.new_path);
+            }
+            for r in &c.references_updated {
+                if dry_run {
+                    println!("  Would update ref in {}: {} -> {}", r.file, r.old_value, r.new_value);
+                } else {
+                    println!("  Updated ref in {}: {} -> {}", r.file, r.old_value, r.new_value);
+                }
+            }
+        }
+        if output.changes.is_empty() {
+            let type_filter = doc_type.map(|t| format!(" (type: {})", t)).unwrap_or_default();
+            println!("No documents to renumber{}", type_filter);
+        }
+        if !output.external_references.is_empty() {
+            println!(
+                "Warning: {} external references found that could not be auto-updated",
+                output.external_references.len()
+            );
+            for ext in &output.external_references {
+                println!("  {}:{} references {}", ext.file, ext.line, ext.old_name);
+            }
+        }
+    }
+
+    0
+}
+
+fn is_incremental_id(id_segment: &str) -> bool {
+    !id_segment.is_empty() && id_segment.chars().all(|c| c.is_ascii_digit())
+}
+
+fn build_sqids_encoder(sqids_config: &SqidsConfig) -> sqids::Sqids {
+    let alphabet = shuffle_alphabet(&sqids_config.salt);
+    sqids::Sqids::builder()
+        .alphabet(alphabet)
+        .min_length(sqids_config.min_length)
+        .blocklist(HashSet::new())
+        .build()
+        .expect("valid sqids config")
+}
+
+fn collect_renumber_fixes(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    format: &RenumberFormat,
+    doc_type_filter: Option<&str>,
+    dry_run: bool,
+) -> Vec<RenumberFixResult> {
+    let target_types: Vec<&crate::engine::config::TypeDef> = config
+        .types
+        .iter()
+        .filter(|t| {
+            if let Some(filter) = doc_type_filter {
+                t.name.eq_ignore_ascii_case(filter) || t.prefix.eq_ignore_ascii_case(filter)
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    let mut all_renames: Vec<RenumberFixResult> = Vec::new();
+
+    for type_def in &target_types {
+        let prefix = &type_def.prefix;
+
+        // Collect docs belonging to this type
+        let mut type_docs: Vec<&crate::engine::document::DocMeta> = store
+            .all_docs()
+            .into_iter()
+            .filter(|d| {
+                if d.virtual_doc {
+                    return false;
+                }
+                let filename = d.path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+                let name = if filename == "index.md" {
+                    d.path
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|f| f.to_str())
+                        .unwrap_or("")
+                } else {
+                    d.path.file_stem().and_then(|f| f.to_str()).unwrap_or("")
+                };
+                name.starts_with(&format!("{}-", prefix))
+            })
+            .collect();
+
+        // Sort alphabetically by filename for stable ordering
+        type_docs.sort_by(|a, b| a.path.cmp(&b.path));
+
+        match format {
+            RenumberFormat::Sqids => {
+                let sqids_config = match config.sqids.as_ref() {
+                    Some(c) => c,
+                    None => continue,
+                };
+                let encoder = build_sqids_encoder(sqids_config);
+
+                for doc in &type_docs {
+                    let name = doc_display_name(doc);
+                    let id = extract_id_from_name(&name);
+                    let id_segment = id.strip_prefix(&format!("{}-", prefix)).unwrap_or("");
+
+                    // Already sqids format -- skip (AC-7)
+                    if !is_incremental_id(id_segment) {
+                        continue;
+                    }
+
+                    let numeric: u64 = id_segment.parse().unwrap_or(0);
+                    let sqid = encoder.encode(&[numeric]).expect("sqids encode").to_lowercase();
+                    let new_id = format!("{}-{}", prefix, sqid);
+
+                    if let Some(rename) = build_rename(root, doc, &id, &new_id, dry_run) {
+                        all_renames.push(rename);
+                    }
+                }
+            }
+            RenumberFormat::Incremental => {
+                // Find the max existing incremental ID to avoid collisions
+                let max_existing: u32 = type_docs
+                    .iter()
+                    .filter_map(|d| {
+                        let name = doc_display_name(d);
+                        let id = extract_id_from_name(&name);
+                        let id_segment = id.strip_prefix(&format!("{}-", prefix)).unwrap_or("");
+                        if is_incremental_id(id_segment) {
+                            id_segment.parse::<u32>().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .max()
+                    .unwrap_or(0);
+
+                // Filter to only docs currently in sqids format
+                let sqids_docs: Vec<&&crate::engine::document::DocMeta> = type_docs
+                    .iter()
+                    .filter(|d| {
+                        let name = doc_display_name(d);
+                        let id = extract_id_from_name(&name);
+                        let id_segment = id.strip_prefix(&format!("{}-", prefix)).unwrap_or("");
+                        !is_incremental_id(id_segment)
+                    })
+                    .collect();
+
+                for (i, doc) in sqids_docs.iter().enumerate() {
+                    let name = doc_display_name(doc);
+                    let id = extract_id_from_name(&name);
+
+                    let new_num = max_existing + (i as u32) + 1;
+                    let new_id = format!("{}-{:03}", prefix, new_num);
+
+                    // Already incremental -- skip (AC-7, though we filtered above)
+                    if id == new_id {
+                        continue;
+                    }
+
+                    if let Some(rename) = build_rename(root, doc, &id, &new_id, dry_run) {
+                        all_renames.push(rename);
+                    }
+                }
+            }
+        }
+    }
+
+    // Second pass: cascade references using the old->new path map
+    if !all_renames.is_empty() {
+        let path_map: HashMap<String, String> = all_renames
+            .iter()
+            .map(|r| (r.old_path.clone(), r.new_path.clone()))
+            .collect();
+
+        for rename in &mut all_renames {
+            let refs = cascade_references(root, store, &rename.old_path, &rename.new_path, dry_run);
+            rename.references_updated = refs;
+        }
+
+        // Also update references that point between renamed docs
+        // (cascade_references handles individual old->new, but if doc A references doc B
+        // and both are renamed, we need to update A's new location too)
+        if !dry_run {
+            for rename in &all_renames {
+                let new_abs = root.join(&rename.new_path);
+                let content = match std::fs::read_to_string(&new_abs) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+
+                let mut updated = content.clone();
+                for (old_p, new_p) in &path_map {
+                    if old_p == &rename.old_path {
+                        continue;
+                    }
+                    updated = updated.replace(old_p.as_str(), new_p.as_str());
+                }
+                if updated != content {
+                    let _ = std::fs::write(&new_abs, &updated);
+                }
+            }
+        }
+    }
+
+    all_renames
+}
+
+pub fn scan_external_references(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    changes: &[RenumberFixResult],
+) -> Vec<ExternalReference> {
+    if changes.is_empty() {
+        return vec![];
+    }
+
+    // Collect old filenames from changes (just the filename, not the full path)
+    let old_names: Vec<String> = changes
+        .iter()
+        .map(|c| {
+            Path::new(&c.old_path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(&c.old_path)
+                .to_string()
+        })
+        .collect();
+
+    // Build set of managed directories so we can skip them
+    let managed_dirs: HashSet<String> = config.types.iter().map(|t| t.dir.clone()).collect();
+
+    // Build set of store-managed file paths (relative)
+    let managed_paths: HashSet<String> = store
+        .all_docs()
+        .iter()
+        .map(|d| d.path.display().to_string())
+        .collect();
+
+    let mut refs = Vec::new();
+    scan_dir_for_references(root, root, &managed_dirs, &managed_paths, &old_names, &mut refs);
+    refs
+}
+
+fn scan_dir_for_references(
+    root: &Path,
+    dir: &Path,
+    managed_dirs: &HashSet<String>,
+    managed_paths: &HashSet<String>,
+    old_names: &[String],
+    refs: &mut Vec<ExternalReference>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    const NOISE_DIRS: &[&str] = &[".git", "target", "node_modules", ".venv", "dist", "build", ".hg"];
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if NOISE_DIRS.contains(&name) {
+                    continue;
+                }
+            }
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            let rel_str = rel.display().to_string();
+            if managed_dirs.contains(&rel_str) {
+                continue;
+            }
+            scan_dir_for_references(root, &path, managed_dirs, managed_paths, old_names, refs);
+            continue;
+        }
+
+        let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        let is_scannable = filename.ends_with(".md")
+            || filename.ends_with(".wiki")
+            || filename.starts_with("README");
+
+        if !is_scannable {
+            continue;
+        }
+
+        // Skip store-managed files
+        let rel = path.strip_prefix(root).unwrap_or(&path);
+        let rel_str = rel.display().to_string();
+        if managed_paths.contains(&rel_str) {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            for old_name in old_names {
+                if line.contains(old_name.as_str()) {
+                    refs.push(ExternalReference {
+                        file: rel_str.clone(),
+                        old_name: old_name.clone(),
+                        line: line_num + 1,
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn doc_display_name(doc: &crate::engine::document::DocMeta) -> String {
+    let filename = doc.path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+    if filename == "index.md" {
+        doc.path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|f| f.to_str())
+            .unwrap_or("")
+            .to_string()
+    } else {
+        doc.path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap_or("")
+            .to_string()
+    }
+}
+
+fn build_rename(
+    root: &Path,
+    doc: &crate::engine::document::DocMeta,
+    old_id: &str,
+    new_id: &str,
+    dry_run: bool,
+) -> Option<RenumberFixResult> {
+    let filename = doc.path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+    let is_subfolder = filename == "index.md";
+    let old_path_str = doc.path.display().to_string();
+
+    if is_subfolder {
+        let parent_rel = doc.path.parent()?;
+        let parent_name = parent_rel.file_name().and_then(|f| f.to_str())?;
+        let new_dir_name = parent_name.replacen(old_id, new_id, 1);
+        let new_parent_rel = parent_rel.with_file_name(&new_dir_name);
+        let new_path_str = new_parent_rel.join("index.md").display().to_string();
+
+        let old_abs = root.join(parent_rel);
+        let new_abs = root.join(&new_parent_rel);
+
+        if !dry_run {
+            std::fs::rename(&old_abs, &new_abs).ok()?;
+            update_title_in_file(&new_abs.join("index.md"), old_id, new_id);
+        }
+
+        Some(RenumberFixResult {
+            old_path: old_path_str,
+            new_path: new_path_str,
+            old_id: old_id.to_string(),
+            new_id: new_id.to_string(),
+            references_updated: vec![],
+            written: !dry_run,
+        })
+    } else {
+        let stem = doc.path.file_stem().and_then(|f| f.to_str())?;
+        let new_stem = stem.replacen(old_id, new_id, 1);
+        let new_filename = format!("{}.md", new_stem);
+        let new_rel = doc.path.with_file_name(&new_filename);
+        let new_path_str = new_rel.display().to_string();
+
+        let old_abs = root.join(&doc.path);
+        let new_abs = root.join(&new_rel);
+
+        if !dry_run {
+            std::fs::rename(&old_abs, &new_abs).ok()?;
+            update_title_in_file(&new_abs, old_id, new_id);
+        }
+
+        Some(RenumberFixResult {
+            old_path: old_path_str,
+            new_path: new_path_str,
+            old_id: old_id.to_string(),
+            new_id: new_id.to_string(),
+            references_updated: vec![],
+            written: !dry_run,
+        })
+    }
+}
+
 pub fn run_json(
     root: &Path,
     store: &Store,
@@ -77,6 +537,19 @@ pub fn run_json(
 ) -> String {
     let output = collect_all(root, store, config, paths, dry_run);
     serde_json::to_string_pretty(&output).unwrap()
+}
+
+pub fn run_renumber_json(
+    root: &Path,
+    store: &Store,
+    config: &Config,
+    format: &RenumberFormat,
+    doc_type: Option<&str>,
+    dry_run: bool,
+) -> String {
+    let output = collect_renumber_output(root, store, config, format, doc_type, dry_run);
+    let wrapper = serde_json::json!({ "renumber": output });
+    serde_json::to_string_pretty(&wrapper).unwrap()
 }
 
 pub fn run_human(
@@ -281,8 +754,17 @@ fn renumber_doc(
     let type_def = config.types.iter().find(|t| t.prefix.eq_ignore_ascii_case(doc_type_prefix))?;
     let type_dir = root.join(&type_def.dir);
 
-    let new_num = next_number(&type_dir, &type_def.prefix);
-    let new_id = format!("{}-{:03}", type_def.prefix, new_num);
+    let new_id = match type_def.numbering {
+        NumberingStrategy::Sqids => {
+            let sqids_config = config.sqids.as_ref()?;
+            let sqid = next_sqids_id(&type_dir, &type_def.prefix, sqids_config);
+            format!("{}-{}", type_def.prefix, sqid)
+        }
+        NumberingStrategy::Incremental => {
+            let new_num = next_number(&type_dir, &type_def.prefix);
+            format!("{}-{:03}", type_def.prefix, new_num)
+        }
+    };
 
     let filename = doc.path.file_name().and_then(|f| f.to_str()).unwrap_or("");
     let is_subfolder = filename == "index.md";

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,7 +14,13 @@ pub mod search;
 pub mod validate;
 pub mod fix;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum RenumberFormat {
+    Sqids,
+    Incremental,
+}
 
 #[derive(Parser)]
 #[command(name = "lazyspec", about = "Manage project stories, RFCs, ADRs, and iterations")]
@@ -161,6 +167,12 @@ pub enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Renumber all documents to the given format
+        #[arg(long)]
+        renumber: Option<RenumberFormat>,
+        /// Filter to a single document type (e.g. rfc, story)
+        #[arg(long = "type")]
+        doc_type: Option<String>,
     },
     /// Validate all documents
     Validate {

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -29,6 +29,25 @@ pub enum ValidationRule {
     },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NumberingStrategy {
+    #[default]
+    Incremental,
+    Sqids,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SqidsConfig {
+    pub salt: String,
+    #[serde(default = "default_sqids_min_length")]
+    pub min_length: u8,
+}
+
+fn default_sqids_min_length() -> u8 {
+    3
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TypeDef {
     pub name: String,
@@ -36,6 +55,8 @@ pub struct TypeDef {
     pub dir: String,
     pub prefix: String,
     pub icon: Option<String>,
+    #[serde(default)]
+    pub numbering: NumberingStrategy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,6 +69,8 @@ pub struct Config {
     pub templates: Templates,
     pub naming: Naming,
     pub tui: Tui,
+    #[serde(skip)]
+    pub sqids: Option<SqidsConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,6 +103,11 @@ impl Default for Tui {
 }
 
 #[derive(Deserialize)]
+struct RawNumbering {
+    sqids: Option<SqidsConfig>,
+}
+
+#[derive(Deserialize)]
 struct RawConfig {
     types: Option<Vec<TypeDef>>,
     rules: Option<Vec<ValidationRule>>,
@@ -87,6 +115,7 @@ struct RawConfig {
     templates: Option<Templates>,
     naming: Option<Naming>,
     tui: Option<Tui>,
+    numbering: Option<RawNumbering>,
 }
 
 fn default_types() -> Vec<TypeDef> {
@@ -97,6 +126,7 @@ fn default_types() -> Vec<TypeDef> {
             dir: "docs/rfcs".to_string(),
             prefix: "RFC".to_string(),
             icon: Some("●".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "story".to_string(),
@@ -104,6 +134,7 @@ fn default_types() -> Vec<TypeDef> {
             dir: "docs/stories".to_string(),
             prefix: "STORY".to_string(),
             icon: Some("▲".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "iteration".to_string(),
@@ -111,6 +142,7 @@ fn default_types() -> Vec<TypeDef> {
             dir: "docs/iterations".to_string(),
             prefix: "ITERATION".to_string(),
             icon: Some("◆".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "adr".to_string(),
@@ -118,6 +150,7 @@ fn default_types() -> Vec<TypeDef> {
             dir: "docs/adrs".to_string(),
             prefix: "ADR".to_string(),
             icon: Some("■".to_string()),
+            numbering: NumberingStrategy::default(),
         },
     ]
 }
@@ -171,6 +204,7 @@ fn types_from_directories(dirs: &Directories) -> Vec<TypeDef> {
             dir: dirs.rfcs.clone(),
             prefix: "RFC".to_string(),
             icon: Some("●".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "story".to_string(),
@@ -178,6 +212,7 @@ fn types_from_directories(dirs: &Directories) -> Vec<TypeDef> {
             dir: dirs.stories.clone(),
             prefix: "STORY".to_string(),
             icon: Some("▲".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "iteration".to_string(),
@@ -185,6 +220,7 @@ fn types_from_directories(dirs: &Directories) -> Vec<TypeDef> {
             dir: dirs.iterations.clone(),
             prefix: "ITERATION".to_string(),
             icon: Some("◆".to_string()),
+            numbering: NumberingStrategy::default(),
         },
         TypeDef {
             name: "adr".to_string(),
@@ -192,6 +228,7 @@ fn types_from_directories(dirs: &Directories) -> Vec<TypeDef> {
             dir: dirs.adrs.clone(),
             prefix: "ADR".to_string(),
             icon: Some("■".to_string()),
+            numbering: NumberingStrategy::default(),
         },
     ]
 }
@@ -211,6 +248,7 @@ impl Default for Config {
                 pattern: "{type}-{n:03}-{title}.md".to_string(),
             },
             tui: Tui::default(),
+            sqids: None,
         }
     }
 }
@@ -235,6 +273,21 @@ impl Config {
 
         let rules = raw.rules.unwrap_or_else(default_rules);
 
+        let any_sqids = types.iter().any(|t| t.numbering == NumberingStrategy::Sqids);
+        let sqids = raw.numbering.and_then(|n| n.sqids);
+
+        if any_sqids {
+            let Some(ref sqids_cfg) = sqids else {
+                bail!("numbering = \"sqids\" requires a [numbering.sqids] section with a non-empty salt");
+            };
+            if sqids_cfg.salt.is_empty() {
+                bail!("numbering.sqids.salt must not be empty");
+            }
+            if sqids_cfg.min_length < 1 || sqids_cfg.min_length > 10 {
+                bail!("numbering.sqids.min_length must be between 1 and 10, got {}", sqids_cfg.min_length);
+            }
+        }
+
         Ok(Config {
             types,
             rules,
@@ -246,6 +299,7 @@ impl Config {
                 pattern: "{type}-{n:03}-{title}.md".to_string(),
             }),
             tui: raw.tui.unwrap_or_default(),
+            sqids,
         })
     }
 

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -487,7 +487,7 @@ impl Store {
 pub fn extract_id_from_name(name: &str) -> String {
     let parts: Vec<&str> = name.split('-').collect();
     for (i, part) in parts.iter().enumerate() {
-        if part.chars().all(|c| c.is_ascii_digit()) && !part.is_empty() {
+        if !part.is_empty() && !part.chars().all(|c| c.is_ascii_uppercase()) {
             return parts[..=i].join("-");
         }
     }
@@ -533,11 +533,11 @@ fn strip_type_prefix(name: &str) -> &str {
     }
     i += 1;
 
-    let digit_start = i;
-    while i < bytes.len() && bytes[i].is_ascii_digit() {
+    let id_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_alphanumeric() && !bytes[i].is_ascii_uppercase() {
         i += 1;
     }
-    if i == digit_start || i >= bytes.len() || bytes[i] != b'-' {
+    if i == id_start || i >= bytes.len() || bytes[i] != b'-' {
         return name;
     }
     i += 1;

--- a/src/engine/template.rs
+++ b/src/engine/template.rs
@@ -1,5 +1,8 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
+
+use crate::engine::config::{NumberingStrategy, SqidsConfig};
 
 pub fn render_template(template_content: &str, vars: &[(&str, &str)]) -> String {
     let mut result = template_content.to_string();
@@ -19,6 +22,19 @@ pub fn slugify(title: &str) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-")
+}
+
+fn count_prefixed_files(dir: &Path, prefix: &str) -> u32 {
+    let mut count = 0u32;
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with(prefix) {
+                count += 1;
+            }
+        }
+    }
+    count
 }
 
 pub fn next_number(dir: &Path, prefix: &str) -> u32 {
@@ -41,22 +57,259 @@ pub fn next_number(dir: &Path, prefix: &str) -> u32 {
     max + 1
 }
 
-pub fn resolve_filename(pattern: &str, doc_type: &str, title: &str, dir: &Path) -> String {
+pub fn shuffle_alphabet(salt: &str) -> Vec<char> {
+    let mut alphabet: Vec<char> = sqids::DEFAULT_ALPHABET.chars().collect();
+    if salt.is_empty() {
+        return alphabet;
+    }
+    let salt_bytes = salt.as_bytes();
+    let len = alphabet.len();
+    for i in (1..len).rev() {
+        let salt_idx = (len - 1 - i) % salt_bytes.len();
+        let j = (salt_bytes[salt_idx] as usize + salt_idx + i) % (i + 1);
+        alphabet.swap(i, j);
+    }
+    alphabet
+}
+
+fn file_exists_with_prefix(dir: &Path, prefix: &str) -> bool {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if entry.file_name().to_string_lossy().starts_with(prefix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn next_sqids_id(dir: &Path, prefix: &str, sqids_config: &SqidsConfig) -> String {
+    let alphabet = shuffle_alphabet(&sqids_config.salt);
+    let sqids = sqids::Sqids::builder()
+        .alphabet(alphabet)
+        .min_length(sqids_config.min_length)
+        .blocklist(HashSet::new())
+        .build()
+        .expect("valid sqids config");
+
+    let count = count_prefixed_files(dir, prefix);
+    let mut input = (count + 1) as u64;
+
+    loop {
+        let id = sqids.encode(&[input]).expect("sqids encode");
+        let id = id.to_lowercase();
+        let candidate_prefix = format!("{}-{}", prefix, id);
+        if !file_exists_with_prefix(dir, &candidate_prefix) {
+            return id;
+        }
+        input += 1;
+    }
+}
+
+pub fn resolve_filename(
+    pattern: &str,
+    doc_type: &str,
+    title: &str,
+    dir: &Path,
+    numbering: Option<(&NumberingStrategy, &SqidsConfig)>,
+) -> String {
     let slug = slugify(title);
     let date = chrono::Local::now().format("%Y-%m-%d").to_string();
     let type_upper = doc_type.to_uppercase();
-    let n = next_number(dir, &type_upper);
 
     let mut filename = pattern.to_string();
     filename = filename.replace("{type}", &type_upper);
     filename = filename.replace("{title}", &slug);
     filename = filename.replace("{date}", &date);
 
-    if filename.contains("{n:03}") {
-        filename = filename.replace("{n:03}", &format!("{:03}", n));
-    } else if filename.contains("{n}") {
-        filename = filename.replace("{n}", &n.to_string());
+    let has_number_placeholder = filename.contains("{n:03}") || filename.contains("{n}");
+    if !has_number_placeholder {
+        return filename;
+    }
+
+    match numbering {
+        Some((NumberingStrategy::Sqids, sqids_config)) => {
+            let id = next_sqids_id(dir, &type_upper, sqids_config);
+            filename = filename.replace("{n:03}", &id);
+            filename = filename.replace("{n}", &id);
+        }
+        _ => {
+            let n = next_number(dir, &type_upper);
+            if filename.contains("{n:03}") {
+                filename = filename.replace("{n:03}", &format!("{:03}", n));
+            } else if filename.contains("{n}") {
+                filename = filename.replace("{n}", &n.to_string());
+            }
+        }
     }
 
     filename
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sqids_id_is_lowercase() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "test-salt".to_string(),
+            min_length: 3,
+        };
+        let id = next_sqids_id(dir.path(), "RFC", &config);
+        assert_eq!(id, id.to_lowercase(), "sqids ID should be lowercase");
+    }
+
+    #[test]
+    fn sqids_min_length_respected() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "test-salt".to_string(),
+            min_length: 6,
+        };
+        let id = next_sqids_id(dir.path(), "RFC", &config);
+        assert!(
+            id.len() >= 6,
+            "expected min_length 6, got {} (id: {})",
+            id.len(),
+            id
+        );
+    }
+
+    #[test]
+    fn sqids_salt_changes_output() {
+        let dir = TempDir::new().unwrap();
+        let config_a = SqidsConfig {
+            salt: "salt-alpha".to_string(),
+            min_length: 3,
+        };
+        let config_b = SqidsConfig {
+            salt: "salt-beta".to_string(),
+            min_length: 3,
+        };
+        let id_a = next_sqids_id(dir.path(), "RFC", &config_a);
+        let id_b = next_sqids_id(dir.path(), "RFC", &config_b);
+        assert_ne!(id_a, id_b, "different salts should produce different IDs");
+    }
+
+    #[test]
+    fn sqids_collision_retry() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "collision-test".to_string(),
+            min_length: 3,
+        };
+
+        // Generate the first ID (for input=1 since dir is empty)
+        let first_id = next_sqids_id(dir.path(), "RFC", &config);
+
+        // Create a file that would collide with the first candidate
+        // (next call will see count=0 again if no prefix files, so we create one
+        // that matches the first_id to force a collision)
+        let colliding_filename = format!("RFC-{}-something.md", first_id);
+        fs::write(dir.path().join(&colliding_filename), "").unwrap();
+
+        // Now there's 1 file with prefix RFC, so count=1, input=2
+        // The second ID should differ from the first
+        let second_id = next_sqids_id(dir.path(), "RFC", &config);
+        assert_ne!(first_id, second_id, "should retry on collision");
+    }
+
+    #[test]
+    fn sqids_collision_retry_forced() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "forced-collision".to_string(),
+            min_length: 3,
+        };
+
+        // Pre-create a file so count=1
+        fs::write(dir.path().join("RFC-placeholder.md"), "").unwrap();
+
+        // The function will try input=2; get an ID for that
+        let alphabet = shuffle_alphabet(&config.salt);
+        let sqids = sqids::Sqids::builder()
+            .alphabet(alphabet)
+            .min_length(config.min_length)
+            .blocklist(HashSet::new())
+            .build()
+            .unwrap();
+        let candidate_for_2 = sqids.encode(&[2]).unwrap().to_lowercase();
+
+        // Create a file that collides with that candidate
+        let colliding = format!("RFC-{}-blocker.md", candidate_for_2);
+        fs::write(dir.path().join(&colliding), "").unwrap();
+
+        // Now count=2, input=3. The candidate for 3 should be returned
+        // (assuming no further collision)
+        let id = next_sqids_id(dir.path(), "RFC", &config);
+        let expected = sqids.encode(&[3]).unwrap().to_lowercase();
+        assert_eq!(id, expected, "should skip colliding ID and use next");
+    }
+
+    #[test]
+    fn resolve_filename_with_sqids() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "resolve-test".to_string(),
+            min_length: 3,
+        };
+        let filename = resolve_filename(
+            "{type}-{n:03}-{title}.md",
+            "rfc",
+            "My Feature",
+            dir.path(),
+            Some((&NumberingStrategy::Sqids, &config)),
+        );
+        assert!(filename.starts_with("RFC-"), "got: {}", filename);
+        assert!(filename.ends_with("-my-feature.md"), "got: {}", filename);
+        // The middle part should be the sqids ID, not zero-padded
+        let parts: Vec<&str> = filename.split('-').collect();
+        assert!(
+            !parts[1].chars().all(|c| c.is_ascii_digit()),
+            "sqids ID should not be purely numeric, got: {}",
+            parts[1]
+        );
+    }
+
+    #[test]
+    fn resolve_filename_incremental_unchanged() {
+        let dir = TempDir::new().unwrap();
+        let filename = resolve_filename(
+            "{type}-{n:03}-{title}.md",
+            "rfc",
+            "Test",
+            dir.path(),
+            None,
+        );
+        assert!(
+            filename.starts_with("RFC-001-"),
+            "incremental should still work, got: {}",
+            filename
+        );
+    }
+
+    #[test]
+    fn resolve_filename_explicit_incremental() {
+        let dir = TempDir::new().unwrap();
+        let config = SqidsConfig {
+            salt: "unused".to_string(),
+            min_length: 3,
+        };
+        let filename = resolve_filename(
+            "{type}-{n:03}-{title}.md",
+            "rfc",
+            "Test",
+            dir.path(),
+            Some((&NumberingStrategy::Incremental, &config)),
+        );
+        assert!(
+            filename.starts_with("RFC-001-"),
+            "explicit incremental should use numbers, got: {}",
+            filename
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,11 +96,18 @@ fn main() -> anyhow::Result<()> {
                 print!("{}", output);
             }
         }
-        Some(Commands::Fix { paths, dry_run, json }) => {
+        Some(Commands::Fix { paths, dry_run, json, renumber, doc_type }) => {
             let store = Store::load(&cwd, &config)?;
-            let exit_code = lazyspec::cli::fix::run(&cwd, &store, &config, &paths, dry_run, json);
-            if exit_code != 0 {
-                std::process::exit(exit_code);
+            if let Some(format) = renumber {
+                let exit_code = lazyspec::cli::fix::run_renumber(&cwd, &store, &config, &format, doc_type.as_deref(), dry_run, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+            } else {
+                let exit_code = lazyspec::cli::fix::run(&cwd, &store, &config, &paths, dry_run, json);
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
             }
         }
         Some(Commands::Validate { json, warnings }) => {

--- a/tests/cli_fix_renumber_test.rs
+++ b/tests/cli_fix_renumber_test.rs
@@ -1,0 +1,532 @@
+mod common;
+
+use lazyspec::cli::RenumberFormat;
+
+fn sqids_config() -> lazyspec::engine::config::Config {
+    let toml = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+
+[[types]]
+name = "story"
+plural = "stories"
+dir = "docs/stories"
+prefix = "STORY"
+
+[[types]]
+name = "iteration"
+plural = "iterations"
+dir = "docs/iterations"
+prefix = "ITERATION"
+
+[[types]]
+name = "adr"
+plural = "adrs"
+dir = "docs/adrs"
+prefix = "ADR"
+
+[numbering.sqids]
+salt = "test-renumber-salt"
+min_length = 3
+"#;
+    lazyspec::engine::config::Config::parse(toml).unwrap()
+}
+
+fn valid_doc(title: &str, doc_type: &str) -> String {
+    format!(
+        "---\ntitle: \"{}\"\ntype: {}\nstatus: draft\nauthor: test\ndate: 2026-01-01\ntags: []\n---\n",
+        title, doc_type
+    )
+}
+
+fn valid_doc_with_related(title: &str, doc_type: &str, related_path: &str) -> String {
+    format!(
+        "---\ntitle: \"{}\"\ntype: {}\nstatus: draft\nauthor: test\ndate: 2026-01-01\ntags: []\nrelated:\n- implements: {}\n---\n",
+        title, doc_type, related_path
+    )
+}
+
+// AC-1: incremental -> sqids renames files correctly
+#[test]
+fn renumber_incremental_to_sqids() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc("docs/rfcs/RFC-002-bar.md", &valid_doc("RFC-002 Bar", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    let exit_code = lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        None,
+        false,
+        false,
+    );
+    assert_eq!(exit_code, 0);
+
+    // Original files should be gone
+    assert!(!fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+    assert!(!fixture.root().join("docs/rfcs/RFC-002-bar.md").exists());
+
+    // New files should exist with sqids IDs (non-numeric)
+    let entries: Vec<String> = std::fs::read_dir(fixture.root().join("docs/rfcs"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(entries.len(), 2);
+    for name in &entries {
+        assert!(name.starts_with("RFC-"));
+        let parts: Vec<&str> = name.split('-').collect();
+        assert!(
+            !parts[1].chars().all(|c| c.is_ascii_digit()),
+            "expected sqids ID, got numeric: {}",
+            name
+        );
+    }
+}
+
+// AC-2: sqids -> incremental renames files with zero-padded sequential numbers
+#[test]
+fn renumber_sqids_to_incremental() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-abc-foo.md", &valid_doc("RFC-abc Foo", "rfc"));
+    fixture.write_doc("docs/rfcs/RFC-def-bar.md", &valid_doc("RFC-def Bar", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    let exit_code = lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Incremental,
+        None,
+        false,
+        false,
+    );
+    assert_eq!(exit_code, 0);
+
+    // Original sqids files should be gone
+    assert!(!fixture.root().join("docs/rfcs/RFC-abc-foo.md").exists());
+    assert!(!fixture.root().join("docs/rfcs/RFC-def-bar.md").exists());
+
+    // New files should be sequential zero-padded
+    assert!(fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+    assert!(fixture.root().join("docs/rfcs/RFC-002-bar.md").exists());
+}
+
+// AC-3: --type filter limits conversion to specified type
+#[test]
+fn renumber_type_filter() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc(
+        "docs/stories/STORY-001-baz.md",
+        &valid_doc("STORY-001 Baz", "story"),
+    );
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        Some("rfc"),
+        false,
+        false,
+    );
+
+    // RFC should have been renamed
+    assert!(!fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+
+    // Story should NOT have been renamed
+    assert!(fixture.root().join("docs/stories/STORY-001-baz.md").exists());
+}
+
+// AC-5: dry_run previews without modifying disk
+#[test]
+fn renumber_dry_run_no_side_effects() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc("docs/rfcs/RFC-002-bar.md", &valid_doc("RFC-002 Bar", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        None,
+        true,
+        false,
+    );
+
+    // Files should still exist at original paths
+    assert!(fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+    assert!(fixture.root().join("docs/rfcs/RFC-002-bar.md").exists());
+}
+
+// AC-7: already-converted docs are skipped
+#[test]
+fn renumber_skips_already_converted_sqids() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    // Already sqids format
+    fixture.write_doc("docs/rfcs/RFC-abc-foo.md", &valid_doc("RFC-abc Foo", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        None,
+        false,
+        false,
+    );
+
+    // File should still exist unchanged
+    assert!(fixture.root().join("docs/rfcs/RFC-abc-foo.md").exists());
+}
+
+#[test]
+fn renumber_skips_already_converted_incremental() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    // Already incremental format
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Incremental,
+        None,
+        false,
+        false,
+    );
+
+    // File should still exist unchanged (nothing to convert)
+    assert!(fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+}
+
+// JSON output includes expected structure
+#[test]
+fn renumber_json_output() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    // Capture stdout by using dry_run + json through the function directly
+    // We can't easily capture stdout, so let's verify the logic works via dry_run
+    let exit_code = lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        None,
+        true,
+        true,
+    );
+    assert_eq!(exit_code, 0);
+}
+
+// AC-4: related frontmatter paths updated after renames
+#[test]
+fn renumber_updates_related_references() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc(
+        "docs/stories/STORY-001-impl.md",
+        &valid_doc_with_related("STORY-001 Impl", "story", "docs/rfcs/RFC-001-foo.md"),
+    );
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        Some("rfc"),
+        false,
+        false,
+    );
+
+    // The story file should have its related path updated
+    let story_content =
+        std::fs::read_to_string(fixture.root().join("docs/stories/STORY-001-impl.md")).unwrap();
+    assert!(
+        !story_content.contains("RFC-001-foo.md"),
+        "related reference should have been updated, still contains old path"
+    );
+}
+
+// AC-6: external references detected and reported
+#[test]
+fn renumber_detects_external_references() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+
+    // Create a README outside managed dirs that references the old filename
+    fixture.write_doc("README.md", "# Project\n\nSee [RFC-001-foo.md](docs/rfcs/RFC-001-foo.md) for details.\n");
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    // Collect what changes would be made (dry run)
+    let changes = vec![lazyspec::cli::fix::RenumberFixResult {
+        old_path: "docs/rfcs/RFC-001-foo.md".to_string(),
+        new_path: "docs/rfcs/RFC-xyz-foo.md".to_string(),
+        old_id: "RFC-001".to_string(),
+        new_id: "RFC-xyz".to_string(),
+        references_updated: vec![],
+        written: false,
+    }];
+
+    let ext_refs =
+        lazyspec::cli::fix::scan_external_references(fixture.root(), &store, &config, &changes);
+
+    assert_eq!(ext_refs.len(), 1);
+    assert_eq!(ext_refs[0].file, "README.md");
+    assert_eq!(ext_refs[0].old_name, "RFC-001-foo.md");
+    assert_eq!(ext_refs[0].line, 3);
+}
+
+#[test]
+fn renumber_external_refs_skips_managed_files() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    // A story that references the RFC (managed file, should be skipped)
+    fixture.write_doc(
+        "docs/stories/STORY-001-impl.md",
+        &valid_doc_with_related("STORY-001 Impl", "story", "docs/rfcs/RFC-001-foo.md"),
+    );
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    let changes = vec![lazyspec::cli::fix::RenumberFixResult {
+        old_path: "docs/rfcs/RFC-001-foo.md".to_string(),
+        new_path: "docs/rfcs/RFC-xyz-foo.md".to_string(),
+        old_id: "RFC-001".to_string(),
+        new_id: "RFC-xyz".to_string(),
+        references_updated: vec![],
+        written: false,
+    }];
+
+    let ext_refs =
+        lazyspec::cli::fix::scan_external_references(fixture.root(), &store, &config, &changes);
+
+    // Managed store files should not appear in external references
+    assert!(
+        ext_refs.is_empty(),
+        "expected no external refs for managed files, got: {:?}",
+        ext_refs.iter().map(|r| &r.file).collect::<Vec<_>>()
+    );
+}
+
+// AC-5: JSON output includes all expected fields
+#[test]
+fn renumber_json_output_structure() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc(
+        "docs/stories/STORY-001-impl.md",
+        &valid_doc_with_related("STORY-001 Impl", "story", "docs/rfcs/RFC-001-foo.md"),
+    );
+    fixture.write_doc("README.md", "See RFC-001-foo.md for details.\n");
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    let json_str = lazyspec::cli::fix::run_renumber_json(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        Some("rfc"),
+        true,
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    let renumber = &parsed["renumber"];
+
+    assert_eq!(renumber["format"], "sqids");
+    assert_eq!(renumber["doc_type"], "rfc");
+    assert_eq!(renumber["dry_run"], true);
+
+    let changes = renumber["changes"].as_array().unwrap();
+    assert_eq!(changes.len(), 1);
+
+    let change = &changes[0];
+    assert!(change["old_path"].as_str().unwrap().contains("RFC-001"));
+    assert!(change["new_path"].as_str().unwrap().starts_with("docs/rfcs/RFC-"));
+    assert_eq!(change["old_id"], "RFC-001");
+    assert!(change["new_id"].as_str().unwrap().starts_with("RFC-"));
+    assert_eq!(change["written"], false);
+    assert!(change["references_updated"].is_array());
+
+    let ext_refs = renumber["external_references"].as_array().unwrap();
+    assert_eq!(ext_refs.len(), 1);
+    assert_eq!(ext_refs[0]["file"], "README.md");
+    assert!(ext_refs[0]["old_name"].as_str().unwrap().contains("RFC-001"));
+    assert!(ext_refs[0]["line"].is_number());
+}
+
+// AUDIT-003 Finding 3: sqids->incremental conversion must not collide with existing incremental IDs
+#[test]
+fn renumber_sqids_to_incremental_avoids_collision() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    // RFC-001 already exists as incremental; RFC-abc is sqids and needs conversion
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc("docs/rfcs/RFC-abc-bar.md", &valid_doc("RFC-abc Bar", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Incremental,
+        None,
+        false,
+        false,
+    );
+
+    // RFC-001 should still exist untouched (it's already incremental)
+    assert!(
+        fixture.root().join("docs/rfcs/RFC-001-foo.md").exists(),
+        "existing incremental doc RFC-001 should not be touched"
+    );
+
+    // The sqids doc should be renamed to RFC-002, not RFC-001
+    assert!(
+        fixture.root().join("docs/rfcs/RFC-002-bar.md").exists(),
+        "sqids doc should be renumbered to RFC-002 to avoid collision with existing RFC-001"
+    );
+    assert!(
+        !fixture.root().join("docs/rfcs/RFC-001-bar.md").exists(),
+        "sqids doc must NOT be renumbered to RFC-001 (collision)"
+    );
+}
+
+// Mixed docs: only those needing conversion are touched
+#[test]
+fn renumber_mixed_formats_only_converts_needed() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    // One incremental, one already sqids
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+    fixture.write_doc("docs/rfcs/RFC-abc-bar.md", &valid_doc("RFC-abc Bar", "rfc"));
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    lazyspec::cli::fix::run_renumber(
+        fixture.root(),
+        &store,
+        &config,
+        &RenumberFormat::Sqids,
+        None,
+        false,
+        false,
+    );
+
+    // The sqids one should still exist unchanged
+    assert!(fixture.root().join("docs/rfcs/RFC-abc-bar.md").exists());
+    // The incremental one should be gone (renamed)
+    assert!(!fixture.root().join("docs/rfcs/RFC-001-foo.md").exists());
+}
+
+// AUDIT-003 Finding 1: noise directories should be skipped during external reference scan
+#[test]
+fn renumber_external_refs_skips_noise_dirs() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config();
+
+    fixture.write_doc("docs/rfcs/RFC-001-foo.md", &valid_doc("RFC-001 Foo", "rfc"));
+
+    // Create files in noise directories that reference the old filename
+    let git_dir = fixture.root().join(".git");
+    std::fs::create_dir_all(&git_dir).unwrap();
+    std::fs::write(
+        git_dir.join("config"),
+        "# references RFC-001-foo.md in a git config\n",
+    )
+    .unwrap();
+
+    let nm_dir = fixture.root().join("node_modules").join("pkg");
+    std::fs::create_dir_all(&nm_dir).unwrap();
+    std::fs::write(
+        nm_dir.join("README.md"),
+        "See RFC-001-foo.md for details.\n",
+    )
+    .unwrap();
+
+    let target_dir = fixture.root().join("target").join("debug");
+    std::fs::create_dir_all(&target_dir).unwrap();
+    std::fs::write(
+        target_dir.join("README.md"),
+        "Built from RFC-001-foo.md\n",
+    )
+    .unwrap();
+
+    let venv_dir = fixture.root().join(".venv").join("lib");
+    std::fs::create_dir_all(&venv_dir).unwrap();
+    std::fs::write(
+        venv_dir.join("README.md"),
+        "RFC-001-foo.md referenced here\n",
+    )
+    .unwrap();
+
+    let store = lazyspec::engine::store::Store::load(fixture.root(), &config).unwrap();
+
+    let changes = vec![lazyspec::cli::fix::RenumberFixResult {
+        old_path: "docs/rfcs/RFC-001-foo.md".to_string(),
+        new_path: "docs/rfcs/RFC-xyz-foo.md".to_string(),
+        old_id: "RFC-001".to_string(),
+        new_id: "RFC-xyz".to_string(),
+        references_updated: vec![],
+        written: false,
+    }];
+
+    let ext_refs =
+        lazyspec::cli::fix::scan_external_references(fixture.root(), &store, &config, &changes);
+
+    assert!(
+        ext_refs.is_empty(),
+        "expected no external refs from noise directories, got: {:?}",
+        ext_refs.iter().map(|r| &r.file).collect::<Vec<_>>()
+    );
+}

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,4 +1,4 @@
-use lazyspec::engine::config::{Config, Severity, ValidationRule};
+use lazyspec::engine::config::{Config, NumberingStrategy, Severity, ValidationRule};
 
 #[test]
 fn parse_config_from_toml() {
@@ -321,4 +321,133 @@ dir = ".lazyspec/templates"
 fn default_config_has_ascii_diagrams_false() {
     let config = Config::default();
     assert!(!config.tui.ascii_diagrams);
+}
+
+// --- Numbering / Sqids config tests ---
+
+#[test]
+fn absent_numbering_defaults_to_incremental() {
+    let toml_str = r#"
+[templates]
+dir = ".lazyspec/templates"
+"#;
+    let config = Config::parse(toml_str).unwrap();
+    for t in &config.types {
+        assert_eq!(t.numbering, NumberingStrategy::Incremental);
+    }
+}
+
+#[test]
+fn valid_sqids_config_parses() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "my-secret-salt"
+min_length = 5
+"#;
+    let config = Config::parse(toml_str).unwrap();
+    let rfc = config.type_by_name("rfc").unwrap();
+    assert_eq!(rfc.numbering, NumberingStrategy::Sqids);
+    let sqids_cfg = config.sqids.unwrap();
+    assert_eq!(sqids_cfg.salt, "my-secret-salt");
+    assert_eq!(sqids_cfg.min_length, 5);
+}
+
+#[test]
+fn sqids_config_defaults_min_length_to_3() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "my-salt"
+"#;
+    let config = Config::parse(toml_str).unwrap();
+    let sqids_cfg = config.sqids.unwrap();
+    assert_eq!(sqids_cfg.min_length, 3);
+}
+
+#[test]
+fn sqids_missing_salt_fails() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+"#;
+    let result = Config::parse(toml_str);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("salt"), "Error should mention salt, got: {msg}");
+}
+
+#[test]
+fn sqids_empty_salt_fails() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = ""
+"#;
+    let result = Config::parse(toml_str);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("salt"), "Error should mention salt, got: {msg}");
+}
+
+#[test]
+fn sqids_min_length_zero_fails() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "my-salt"
+min_length = 0
+"#;
+    let result = Config::parse(toml_str);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("min_length"), "Error should mention min_length, got: {msg}");
+}
+
+#[test]
+fn sqids_min_length_eleven_fails() {
+    let toml_str = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "my-salt"
+min_length = 11
+"#;
+    let result = Config::parse(toml_str);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("min_length"), "Error should mention min_length, got: {msg}");
 }

--- a/tests/sqids_numbering_test.rs
+++ b/tests/sqids_numbering_test.rs
@@ -1,0 +1,308 @@
+mod common;
+
+use std::fs;
+
+fn sqids_config(salt: &str, min_length: u8) -> lazyspec::engine::config::Config {
+    let toml = format!(
+        r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[[types]]
+name = "story"
+plural = "stories"
+dir = "docs/stories"
+prefix = "STORY"
+
+[numbering.sqids]
+salt = "{salt}"
+min_length = {min_length}
+"#
+    );
+    lazyspec::engine::config::Config::parse(&toml).unwrap()
+}
+
+// AC-1: sqids numbering produces sqids-based filename
+#[test]
+fn create_with_sqids_produces_sqids_filename() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+    let config = sqids_config("integration-salt", 3);
+
+    let path =
+        lazyspec::cli::create::run(root, &config, "rfc", "Test Feature", "author").unwrap();
+    let filename = path.file_name().unwrap().to_str().unwrap();
+
+    assert!(filename.starts_with("RFC-"), "expected RFC- prefix, got: {filename}");
+    // Should NOT be incremental (RFC-001)
+    assert!(
+        !filename.starts_with("RFC-001"),
+        "sqids filename should not be incremental, got: {filename}"
+    );
+    // The ID portion (between first and second dash) should be alphabetic (sqids output)
+    let parts: Vec<&str> = filename.split('-').collect();
+    assert!(parts.len() >= 3, "filename should have at least 3 dash-separated parts: {filename}");
+    let id_part = parts[1];
+    assert!(
+        id_part.chars().all(|c| c.is_ascii_alphanumeric()),
+        "sqids ID should be alphanumeric, got: {id_part}"
+    );
+}
+
+// AC-2: no numbering field defaults to incremental
+#[test]
+fn create_without_numbering_field_uses_incremental() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+    let config = fixture.config(); // default config has no sqids
+
+    let path =
+        lazyspec::cli::create::run(root, &config, "rfc", "Incremental Test", "author").unwrap();
+    let filename = path.file_name().unwrap().to_str().unwrap();
+
+    assert!(
+        filename.starts_with("RFC-001"),
+        "default numbering should be incremental (RFC-001), got: {filename}"
+    );
+}
+
+// AC-3: explicit incremental numbering
+#[test]
+fn create_with_explicit_incremental_uses_incremental() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+
+    let toml = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "incremental"
+"#;
+    let config = lazyspec::engine::config::Config::parse(toml).unwrap();
+
+    let path =
+        lazyspec::cli::create::run(root, &config, "rfc", "Explicit Incremental", "author")
+            .unwrap();
+    let filename = path.file_name().unwrap().to_str().unwrap();
+
+    assert!(
+        filename.starts_with("RFC-001"),
+        "explicit incremental should produce RFC-001, got: {filename}"
+    );
+}
+
+// AC-4: different salts produce different IDs
+#[test]
+fn different_salts_produce_different_ids() {
+    let fixture_a = common::TestFixture::new();
+    let fixture_b = common::TestFixture::new();
+
+    let config_a = sqids_config("salt-alpha", 3);
+    let config_b = sqids_config("salt-beta", 3);
+
+    let path_a =
+        lazyspec::cli::create::run(fixture_a.root(), &config_a, "rfc", "Same Title", "author")
+            .unwrap();
+    let path_b =
+        lazyspec::cli::create::run(fixture_b.root(), &config_b, "rfc", "Same Title", "author")
+            .unwrap();
+
+    let name_a = path_a.file_name().unwrap().to_str().unwrap();
+    let name_b = path_b.file_name().unwrap().to_str().unwrap();
+
+    // Extract the sqids ID portion (second segment)
+    let id_a = name_a.split('-').nth(1).unwrap();
+    let id_b = name_b.split('-').nth(1).unwrap();
+
+    assert_ne!(
+        id_a, id_b,
+        "different salts should produce different IDs: {id_a} vs {id_b}"
+    );
+}
+
+// AC-5: min_length = 5 produces IDs >= 5 chars
+#[test]
+fn min_length_five_produces_ids_at_least_five_chars() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config("min-length-test", 5);
+
+    let path =
+        lazyspec::cli::create::run(fixture.root(), &config, "rfc", "Length Test", "author")
+            .unwrap();
+    let filename = path.file_name().unwrap().to_str().unwrap();
+
+    let id_part = filename.split('-').nth(1).unwrap();
+    assert!(
+        id_part.len() >= 5,
+        "min_length=5 should produce ID >= 5 chars, got '{}' (len={})",
+        id_part,
+        id_part.len()
+    );
+}
+
+// AC-6: min_length outside 1-10 fails validation
+#[test]
+fn min_length_zero_fails_validation() {
+    let toml = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "test"
+min_length = 0
+"#;
+    let result = lazyspec::engine::config::Config::parse(toml);
+    assert!(result.is_err(), "min_length=0 should fail");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("min_length"), "error should mention min_length, got: {msg}");
+}
+
+#[test]
+fn min_length_eleven_fails_validation() {
+    let toml = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+
+[numbering.sqids]
+salt = "test"
+min_length = 11
+"#;
+    let result = lazyspec::engine::config::Config::parse(toml);
+    assert!(result.is_err(), "min_length=11 should fail");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("min_length"), "error should mention min_length, got: {msg}");
+}
+
+// AC-7: sqids without salt fails validation
+#[test]
+fn sqids_without_salt_section_fails_validation() {
+    let toml = r#"
+[[types]]
+name = "rfc"
+plural = "rfcs"
+dir = "docs/rfcs"
+prefix = "RFC"
+numbering = "sqids"
+"#;
+    let result = lazyspec::engine::config::Config::parse(toml);
+    assert!(result.is_err(), "sqids without salt should fail");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("salt"), "error should mention salt, got: {msg}");
+}
+
+// AC-8: collision retry with pre-existing files
+#[test]
+fn create_retries_on_collision() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+    let config = sqids_config("collision-integration", 3);
+
+    // Create the first doc to get its ID
+    let path1 =
+        lazyspec::cli::create::run(root, &config, "rfc", "First Doc", "author").unwrap();
+    let name1 = path1.file_name().unwrap().to_str().unwrap();
+    let id1 = name1.split('-').nth(1).unwrap();
+
+    // Create a second doc; it should get a different ID
+    let path2 =
+        lazyspec::cli::create::run(root, &config, "rfc", "Second Doc", "author").unwrap();
+    let name2 = path2.file_name().unwrap().to_str().unwrap();
+    let id2 = name2.split('-').nth(1).unwrap();
+
+    assert_ne!(id1, id2, "sequential creates should produce different IDs");
+
+    // Verify both files exist
+    assert!(path1.exists());
+    assert!(path2.exists());
+}
+
+#[test]
+fn create_handles_preexisting_colliding_file() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+    let config = sqids_config("collision-pre-existing", 3);
+
+    // First, generate what the first ID would be by creating and removing
+    let path1 =
+        lazyspec::cli::create::run(root, &config, "rfc", "Probe", "author").unwrap();
+    let name1 = path1.file_name().unwrap().to_str().unwrap().to_string();
+    let id1: String = name1.split('-').nth(1).unwrap().to_string();
+
+    // Remove it and recreate a file with the same ID prefix but different slug
+    // to simulate a collision scenario
+    fs::remove_file(&path1).unwrap();
+    let colliding = format!("RFC-{}-pre-existing.md", id1);
+    fs::write(root.join("docs/rfcs").join(&colliding), "---\ntitle: \"X\"\ntype: rfc\nstatus: draft\nauthor: \"a\"\ndate: 2026-01-01\ntags: []\n---\n").unwrap();
+
+    // Now create should detect the collision and use the next ID
+    let path2 =
+        lazyspec::cli::create::run(root, &config, "rfc", "After Collision", "author").unwrap();
+    let name2 = path2.file_name().unwrap().to_str().unwrap();
+    let id2 = name2.split('-').nth(1).unwrap();
+
+    assert_ne!(
+        id1, id2,
+        "should have retried past the colliding ID: {id1} vs {id2}"
+    );
+}
+
+// AC-9: generated ID is all lowercase
+#[test]
+fn sqids_id_is_lowercase() {
+    let fixture = common::TestFixture::new();
+    let config = sqids_config("lowercase-test", 3);
+
+    let path =
+        lazyspec::cli::create::run(fixture.root(), &config, "rfc", "Case Test", "author")
+            .unwrap();
+    let filename = path.file_name().unwrap().to_str().unwrap();
+    let id_part = filename.split('-').nth(1).unwrap();
+
+    assert_eq!(
+        id_part,
+        id_part.to_lowercase(),
+        "sqids ID should be all lowercase, got: {id_part}"
+    );
+}
+
+// AC-2 + AC-1: mixed types - sqids on one, incremental on another
+#[test]
+fn mixed_numbering_types_work_together() {
+    let fixture = common::TestFixture::new();
+    let root = fixture.root();
+    let config = sqids_config("mixed-test", 3);
+
+    // rfc uses sqids
+    let rfc_path =
+        lazyspec::cli::create::run(root, &config, "rfc", "Sqids RFC", "author").unwrap();
+    let rfc_name = rfc_path.file_name().unwrap().to_str().unwrap();
+
+    // story uses incremental (default in our config helper)
+    let story_path =
+        lazyspec::cli::create::run(root, &config, "story", "Incremental Story", "author")
+            .unwrap();
+    let story_name = story_path.file_name().unwrap().to_str().unwrap();
+
+    assert!(
+        !rfc_name.starts_with("RFC-001"),
+        "rfc should use sqids, got: {rfc_name}"
+    );
+    assert!(
+        story_name.starts_with("STORY-001"),
+        "story should use incremental, got: {story_name}"
+    );
+}

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::TestFixture;
 use lazyspec::engine::document::{DocType, Status};
-use lazyspec::engine::store::{Filter, ResolveError};
+use lazyspec::engine::store::{extract_id_from_name, Filter, ResolveError};
 use std::path::PathBuf;
 
 fn setup_fixture() -> TestFixture {
@@ -682,4 +682,95 @@ fn list_includes_both_duplicate_docs() {
     let titles: Vec<&str> = all.iter().map(|d| d.title.as_str()).collect();
     assert!(titles.contains(&"First"));
     assert!(titles.contains(&"Second"));
+}
+
+// --- Mixed-format ID resolution tests (AC-1 through AC-7) ---
+
+fn setup_mixed_fixture() -> TestFixture {
+    let fixture = TestFixture::new();
+
+    fixture.write_doc(
+        "docs/rfcs/RFC-022-foo.md",
+        "---\ntitle: \"Foo\"\ntype: rfc\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: []\n---\n",
+    );
+
+    fixture.write_doc(
+        "docs/rfcs/RFC-k3f-bar.md",
+        "---\ntitle: \"Bar\"\ntype: rfc\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: []\n---\n",
+    );
+
+    fixture.write_subfolder_doc(
+        "docs/rfcs/RFC-a1b-folder-doc",
+        "---\ntitle: \"Folder Doc\"\ntype: rfc\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: []\n---\n",
+    );
+
+    fixture
+}
+
+#[test]
+fn extract_id_from_name_numeric() {
+    // AC-1
+    assert_eq!(extract_id_from_name("RFC-022-some-title.md"), "RFC-022");
+}
+
+#[test]
+fn extract_id_from_name_sqids() {
+    // AC-2
+    assert_eq!(extract_id_from_name("RFC-k3f-some-title.md"), "RFC-k3f");
+}
+
+#[test]
+fn extract_id_from_name_story_sqids() {
+    // AC-5
+    assert_eq!(extract_id_from_name("STORY-a2b-some-title.md"), "STORY-a2b");
+}
+
+#[test]
+fn resolve_shorthand_numeric_in_mixed_dir() {
+    // AC-3
+    let fixture = setup_mixed_fixture();
+    let store = fixture.store();
+
+    let doc = store.resolve_shorthand("RFC-022");
+    assert!(doc.is_ok());
+    assert_eq!(doc.unwrap().title, "Foo");
+}
+
+#[test]
+fn resolve_shorthand_sqids_in_mixed_dir() {
+    // AC-4
+    let fixture = setup_mixed_fixture();
+    let store = fixture.store();
+
+    let doc = store.resolve_shorthand("RFC-k3f");
+    assert!(doc.is_ok());
+    assert_eq!(doc.unwrap().title, "Bar");
+}
+
+#[test]
+fn resolve_shorthand_nonexistent_returns_not_found() {
+    // AC-6
+    let fixture = setup_mixed_fixture();
+    let store = fixture.store();
+
+    let result = store.resolve_shorthand("RFC-zzz");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ResolveError::NotFound(id) => assert_eq!(id, "RFC-zzz"),
+        ResolveError::Ambiguous { .. } => panic!("expected NotFound, got Ambiguous"),
+    }
+}
+
+#[test]
+fn extract_id_folder_based_sqids_via_store_load() {
+    // AC-7: extract_id on RFC-a1b-folder-doc/index.md returns RFC-a1b
+    // Since extract_id is private, we verify indirectly through doc.id after loading.
+    let fixture = setup_mixed_fixture();
+    let store = fixture.store();
+
+    let doc = store.resolve_shorthand("RFC-a1b");
+    assert!(doc.is_ok());
+    let doc = doc.unwrap();
+    assert_eq!(doc.title, "Folder Doc");
+    assert_eq!(doc.id, "RFC-a1b");
 }

--- a/tests/tui_graph_test.rs
+++ b/tests/tui_graph_test.rs
@@ -180,6 +180,7 @@ fn custom_types_populate_doc_types_and_icons() {
             dir: "docs/epics".into(),
             prefix: "EPIC".into(),
             icon: Some("⚡".into()),
+            numbering: Default::default(),
         },
         TypeDef {
             name: "task".into(),
@@ -187,6 +188,7 @@ fn custom_types_populate_doc_types_and_icons() {
             dir: "docs/tasks".into(),
             prefix: "TASK".into(),
             icon: None,
+            numbering: Default::default(),
         },
     ];
     let store = Store::load(fixture.root(), &config).unwrap();


### PR DESCRIPTION
## Summary

- Add sqids-based numbering as an alternative to sequential integers for document IDs (e.g. `RFC-k3f` instead of `RFC-022`)
- Support mixed format resolution so existing sequential docs coexist with sqids-numbered docs
- Add `fix --renumber` to convert between numbering formats
- Collision-resistant ID generation for distributed workflows where multiple branches create docs concurrently

## Details

Implements RFC-027. Includes config support (`numbering_format: sqids`), ID resolution for mixed formats, format conversion, and dry-run support for renumbering. Covers stories 064-066, iterations 072-075, and audit 003.

## Test plan

- [x] Unit tests for sqids numbering (`tests/sqids_numbering_test.rs`)
- [x] CLI fix renumber tests (`tests/cli_fix_renumber_test.rs`)
- [x] Config parsing tests updated
- [x] Store tests updated for new ID formats