### PR TITLE
chore: gate metrics view behind cargo feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ indicatif = "0.17"
 [features]
 default = []
 agent = []
+metrics = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/iterations/ITERATION-110-metrics-view-feature-flag.md
+++ b/docs/iterations/ITERATION-110-metrics-view-feature-flag.md
@@ -1,0 +1,107 @@
+---
+title: "Metrics view feature flag"
+type: iteration
+status: accepted
+author: "agent"
+date: 2026-03-26
+tags: []
+related: []
+---
+
+
+Gate `ViewMode::Metrics` and `draw_metrics_skeleton` behind a `metrics` cargo feature flag, following the pattern established by the `agent` feature flag. Default builds will exclude the metrics view entirely, satisfying the YAGNI concern in STORY-036 while preserving the code for future implementation (STORY-014).
+
+## Changes
+
+### Task 1: Add `metrics` feature flag to Cargo.toml
+
+**Files:**
+- Modify: `Cargo.toml`
+
+**What to implement:**
+Add `metrics = []` to the `[features]` section, alongside the existing `agent = []` entry.
+
+**How to verify:**
+`cargo check` passes. `cargo check --features metrics` passes.
+
+### Task 2: Gate `ViewMode::Metrics` enum variant and match arms
+
+**Files:**
+- Modify: `src/tui/state/app.rs`
+
+**What to implement:**
+Add `#[cfg(feature = "metrics")]` to the `Metrics` variant at line 131.
+
+In `next()` (lines 138-150):
+- Gate `ViewMode::Filters => ViewMode::Metrics` with `#[cfg(feature = "metrics")]`
+- Gate `ViewMode::Metrics => ViewMode::Graph` with `#[cfg(feature = "metrics")]`
+- Add `#[cfg(not(feature = "metrics"))]` arm: `ViewMode::Filters => ViewMode::Graph`
+
+In `name()` (lines 152-161):
+- Gate `ViewMode::Metrics => "Metrics"` with `#[cfg(feature = "metrics")]`
+
+Follow the exact same pattern used for `ViewMode::Agents` with the `agent` feature.
+
+**How to verify:**
+`cargo check` (no features) passes with no warnings. `cargo check --features metrics` passes. `cargo check --all-features` passes.
+
+### Task 3: Gate `draw_metrics_skeleton` import and call site in views.rs
+
+**Files:**
+- Modify: `src/tui/views.rs`
+
+**What to implement:**
+At line 27, move `draw_metrics_skeleton` out of the shared `use panels::{...}` import and into a separate `#[cfg(feature = "metrics")]` import, following the same pattern as `draw_agents_screen` at lines 30-31.
+
+At line 105, gate the match arm `ViewMode::Metrics => draw_metrics_skeleton(f, outer[1])` with `#[cfg(feature = "metrics")]`.
+
+**How to verify:**
+`cargo check` (no features) passes. `cargo check --features metrics` passes.
+
+### Task 4: Gate `draw_metrics_skeleton` function in panels.rs
+
+**Files:**
+- Modify: `src/tui/views/panels.rs`
+
+**What to implement:**
+Add `#[cfg(feature = "metrics")]` to the `draw_metrics_skeleton` function definition at line 965.
+
+**How to verify:**
+`cargo check --features metrics` passes. Without the feature, the function is excluded and no dead-code warning appears.
+
+### Task 5: Update test assertions for metrics-less cycle
+
+**Files:**
+- Modify: `tests/tui_view_mode_test.rs`
+- Modify: `tests/tui_graph_test.rs`
+- Modify: `tests/tui_agent_management_test.rs`
+
+**What to implement:**
+
+In `tests/tui_view_mode_test.rs`:
+- `test_view_mode_next_cycles` (line 31): gate the two Metrics assertions (lines 33-34) with `#[cfg(feature = "metrics")]`. Add `#[cfg(not(feature = "metrics"))]` assertion: `Filters.next() == Graph`.
+- `test_backtick_cycles_mode` (line 44): the third backtick press at line 53 currently expects `Metrics`. Gate that assertion with `#[cfg(feature = "metrics")]`. Add `#[cfg(not(feature = "metrics"))]` assertion expecting `Graph` instead.
+
+In `tests/tui_graph_test.rs`:
+- `test_graph_rebuilds_on_mode_switch` (line 135): the cycle currently takes 3 backtick presses to reach Graph (Types->Filters->Metrics->Graph). Without the metrics feature, it takes 2 presses (Types->Filters->Graph). Gate the third key press (line 142) and `Metrics` assertion (line 143) with `#[cfg(feature = "metrics")]`. Similarly adjust the return cycle at lines 160-163.
+
+In `tests/tui_agent_management_test.rs`:
+- `test_agents_view_mode_in_cycle` (line 43): gate the two Metrics assertions (lines 45-46) with `#[cfg(feature = "metrics")]`. Add `#[cfg(not(feature = "metrics"))]` assertion: `Filters.next() == Graph`.
+
+**How to verify:**
+`cargo test` (no features) passes. `cargo test --features metrics` passes. `cargo test --all-features` passes.
+
+## Test Plan
+
+- `cargo check` (no features): compiles without `ViewMode::Metrics` or `draw_metrics_skeleton`
+- `cargo check --features metrics`: compiles with metrics code included
+- `cargo check --all-features`: compiles with both metrics and agent features
+- `cargo test` (no features): all view-mode cycle tests pass, asserting Filters->Graph skip
+- `cargo test --features metrics`: all view-mode cycle tests pass, asserting Filters->Metrics->Graph
+- `cargo test --all-features`: full cycle including both Metrics and Agents
+
+All tests are deterministic and structure-insensitive (they test the cycle behavior, not the rendering output). No new test files needed; existing tests are updated to handle both feature configurations.
+
+## Notes
+
+Follows the exact precedent set by ITERATION-048 (agent feature flag). The `#[cfg(feature)]` / `#[cfg(not(feature))]` pattern on `next()` match arms is the critical piece, ensuring the mode cycle skips Metrics when the feature is off.

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -128,6 +128,7 @@ pub struct DocListNode {
 pub enum ViewMode {
     Types,
     Filters,
+    #[cfg(feature = "metrics")]
     Metrics,
     Graph,
     #[cfg(feature = "agent")]
@@ -138,8 +139,12 @@ impl ViewMode {
     pub fn next(self) -> Self {
         match self {
             ViewMode::Types => ViewMode::Filters,
+            #[cfg(feature = "metrics")]
             ViewMode::Filters => ViewMode::Metrics,
+            #[cfg(feature = "metrics")]
             ViewMode::Metrics => ViewMode::Graph,
+            #[cfg(not(feature = "metrics"))]
+            ViewMode::Filters => ViewMode::Graph,
             #[cfg(feature = "agent")]
             ViewMode::Graph => ViewMode::Agents,
             #[cfg(not(feature = "agent"))]
@@ -153,6 +158,7 @@ impl ViewMode {
         match self {
             ViewMode::Types => "Types",
             ViewMode::Filters => "Filters",
+            #[cfg(feature = "metrics")]
             ViewMode::Metrics => "Metrics",
             ViewMode::Graph => "Graph",
             #[cfg(feature = "agent")]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -24,9 +24,11 @@ use overlays::{
 #[cfg(feature = "agent")]
 use overlays::draw_agent_dialog;
 use panels::{
-    draw_doc_list, draw_graph, draw_metrics_skeleton, draw_preview, draw_type_panel,
+    draw_doc_list, draw_graph, draw_preview, draw_type_panel,
     render_filter_panel, render_fullscreen_document,
 };
+#[cfg(feature = "metrics")]
+use panels::draw_metrics_skeleton;
 #[cfg(feature = "agent")]
 use panels::draw_agents_screen;
 
@@ -102,6 +104,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             draw_preview(f, app, right[1]);
         }
         ViewMode::Filters => render_filter_panel(f, app, outer[1]),
+        #[cfg(feature = "metrics")]
         ViewMode::Metrics => draw_metrics_skeleton(f, outer[1]),
         ViewMode::Graph => draw_graph(f, app, outer[1]),
         #[cfg(feature = "agent")]

--- a/src/tui/views/panels.rs
+++ b/src/tui/views/panels.rs
@@ -962,6 +962,7 @@ pub fn draw_agents_screen(f: &mut Frame, app: &App, area: Rect) {
     );
 }
 
+#[cfg(feature = "metrics")]
 pub fn draw_metrics_skeleton(f: &mut Frame, area: Rect) {
     let layout = Layout::default()
         .direction(Direction::Horizontal)

--- a/tests/tui_agent_management_test.rs
+++ b/tests/tui_agent_management_test.rs
@@ -42,8 +42,13 @@ fn setup_agents_mode(fixture: &TestFixture, records: Vec<AgentRecord>) -> App {
 #[test]
 fn test_agents_view_mode_in_cycle() {
     assert_eq!(ViewMode::Types.next(), ViewMode::Filters);
-    assert_eq!(ViewMode::Filters.next(), ViewMode::Metrics);
-    assert_eq!(ViewMode::Metrics.next(), ViewMode::Graph);
+    #[cfg(feature = "metrics")]
+    {
+        assert_eq!(ViewMode::Filters.next(), ViewMode::Metrics);
+        assert_eq!(ViewMode::Metrics.next(), ViewMode::Graph);
+    }
+    #[cfg(not(feature = "metrics"))]
+    assert_eq!(ViewMode::Filters.next(), ViewMode::Graph);
     assert_eq!(ViewMode::Graph.next(), ViewMode::Agents);
     assert_eq!(ViewMode::Agents.next(), ViewMode::Types);
 }

--- a/tests/tui_editor_test.rs
+++ b/tests/tui_editor_test.rs
@@ -73,8 +73,9 @@ fn e_key_sets_editor_request_in_graph_mode() {
     let store = fixture.store();
     let mut app = App::new(store, &fixture.config(), ratatui_image::picker::Picker::halfblocks(), Box::new(lazyspec::engine::fs::RealFileSystem));
 
-    // Cycle to Graph mode: Types -> Filters -> Metrics -> Graph
+    // Cycle to Graph mode: Types -> Filters -> [Metrics] -> Graph
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
+    #[cfg(feature = "metrics")]
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     assert_eq!(app.view_mode, ViewMode::Graph);

--- a/tests/tui_graph_test.rs
+++ b/tests/tui_graph_test.rs
@@ -135,12 +135,15 @@ fn test_graph_enter_jumps_to_types_mode() {
 fn test_graph_rebuilds_on_mode_switch() {
     let (fixture, mut app) = setup_graph_fixture();
 
-    // Cycle from Types -> Filters -> Metrics -> Graph
+    // Cycle from Types -> Filters -> [Metrics] -> Graph
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     assert_eq!(app.view_mode, ViewMode::Filters);
 
-    app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
-    assert_eq!(app.view_mode, ViewMode::Metrics);
+    #[cfg(feature = "metrics")]
+    {
+        app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
+        assert_eq!(app.view_mode, ViewMode::Metrics);
+    }
 
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     assert_eq!(app.view_mode, ViewMode::Graph);
@@ -157,9 +160,10 @@ fn test_graph_rebuilds_on_mode_switch() {
     }
     assert_eq!(app.view_mode, ViewMode::Types);
 
-    // Cycle back: Types -> Filters -> Metrics -> Graph
+    // Cycle back: Types -> Filters -> [Metrics] -> Graph
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
+    #[cfg(feature = "metrics")]
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     assert_eq!(app.view_mode, ViewMode::Graph);
     assert_eq!(

--- a/tests/tui_view_mode_test.rs
+++ b/tests/tui_view_mode_test.rs
@@ -30,8 +30,13 @@ fn test_app_defaults_to_types_mode() {
 #[test]
 fn test_view_mode_next_cycles() {
     assert_eq!(ViewMode::Types.next(), ViewMode::Filters);
-    assert_eq!(ViewMode::Filters.next(), ViewMode::Metrics);
-    assert_eq!(ViewMode::Metrics.next(), ViewMode::Graph);
+    #[cfg(feature = "metrics")]
+    {
+        assert_eq!(ViewMode::Filters.next(), ViewMode::Metrics);
+        assert_eq!(ViewMode::Metrics.next(), ViewMode::Graph);
+    }
+    #[cfg(not(feature = "metrics"))]
+    assert_eq!(ViewMode::Filters.next(), ViewMode::Graph);
     #[cfg(feature = "agent")]
     {
         assert_eq!(ViewMode::Graph.next(), ViewMode::Agents);
@@ -49,8 +54,16 @@ fn test_backtick_cycles_mode() {
     app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
     assert_eq!(app.view_mode, ViewMode::Filters);
 
-    app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
-    assert_eq!(app.view_mode, ViewMode::Metrics);
+    #[cfg(feature = "metrics")]
+    {
+        app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
+        assert_eq!(app.view_mode, ViewMode::Metrics);
+    }
+    #[cfg(not(feature = "metrics"))]
+    {
+        app.handle_key(KeyCode::Char('`'), KeyModifiers::NONE, fixture.root(), &fixture.config());
+        assert_eq!(app.view_mode, ViewMode::Graph);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The metrics view (`ViewMode::Metrics`) is an unimplemented placeholder that renders empty skeleton blocks. Rather than deleting it outright, this gates it behind a `metrics` cargo feature flag so default builds exclude it while the code stays available for future implementation.

Follows the same `#[cfg(feature = ...)]` pattern established by the `agent` feature flag.

## What changed

- `metrics = []` feature added to `Cargo.toml`
- `ViewMode::Metrics` variant, match arms, and `draw_metrics_skeleton` all gated with `#[cfg(feature = "metrics")]`
- Mode cycle skips from Filters directly to Graph when the feature is off
- Test assertions updated across 4 test files to handle both configurations

## Verification

`cargo check`, `cargo test`, and their `--features metrics` / `--all-features` variants all pass.