### PR TITLE
fix: editor keystroke dup, frontmatter newline dup, narrow-width panels

### DIFF
--- a/docs/iterations/ITERATION-165-title-prioritised-in-tui-tables-at-narrow-widths.md
+++ b/docs/iterations/ITERATION-165-title-prioritised-in-tui-tables-at-narrow-widths.md
@@ -1,13 +1,14 @@
 ---
 title: Title prioritised in TUI tables at narrow widths
 type: iteration
-status: draft
+status: accepted
 author: agent
 date: 2026-05-08
 tags: []
 related:
 - implements: STORY-047
 ---
+
 
 ## Context
 
@@ -85,7 +86,7 @@ AC-3 (selected-row highlight) and AC-2 (Filters mode parity) are reachable throu
 - **AC-2** Given a narrow terminal (~70 columns) when the document list renders then provenance and tags are hidden (width 0), status remains at 12, and title receives at least `TITLE_MIN_COLS` (20).
 - **AC-3** Given a very narrow terminal (~50 columns) when the document list renders then status, tags, and provenance are hidden, and title takes the remaining budget.
 - **AC-4** Given any terminal width when soft-wrap measurement runs then `DocCellWidths::from_area_width(w).title` equals the title cell width that ratatui resolves from `doc_table_widths(w)`.
-- **AC-5** Given any terminal width when the document list renders then gutter (1), tree (4), and ID (18) columns retain their fixed widths.
+- **AC-5** Given a terminal width >= 51 columns when the document list renders then gutter (1), tree (4), and ID (18) columns retain their fixed widths. Below the physical floor (`gutter + tree + id + title-min + 6 spacings = 49` plus 2 borders), ratatui proportionally shrinks fixed-length columns; this is graceful degradation outside the supported range.
 
 ## Notes
 

--- a/docs/iterations/ITERATION-165-title-prioritised-in-tui-tables-at-narrow-widths.md
+++ b/docs/iterations/ITERATION-165-title-prioritised-in-tui-tables-at-narrow-widths.md
@@ -1,0 +1,95 @@
+---
+title: Title prioritised in TUI tables at narrow widths
+type: iteration
+status: draft
+author: agent
+date: 2026-05-08
+tags: []
+related:
+- implements: STORY-047
+---
+
+## Context
+
+`doc_table_widths()` in `src/tui/views/panels.rs:216` returns a fixed 7-column constraint set:
+
+```
+gutter(Length 1), tree(Length 4), id(Length 18), title(Fill 1),
+status(Length 12), tags(Length 24), provenance(Min 20)
+```
+
+Fixed-length columns sum to `1 + 4 + 18 + 12 + 24 = 59` plus 6 column spacings = `65`. With provenance `Min(20)` and panel borders (2 cols), title's `Fill(1)` only receives a positive allocation when terminal width exceeds ~`87`. Below that, ratatui collapses Fill to 0 and clips the title.
+
+`doc_table_widths()` is reused by:
+
+1. `draw_doc_list` (Types mode) at `panels.rs:729`
+2. Filters mode table at `panels.rs:1311`
+
+Both pass `area.width` further down to `doc_row_for_node`, so width is already in scope at call sites. `DocCellWidths::from_area_width` (`panels.rs:278`) mirrors `doc_table_widths()` for soft-wrap measurement and must agree with the constraint set.
+
+## Goal
+
+Title column receives priority allocation at all terminal widths. Less-critical columns (provenance, then tags, then status) collapse first; title retains a configured minimum. ID, gutter and tree never collapse (they identify the row).
+
+## Approach
+
+Convert `doc_table_widths()` to `doc_table_widths(area_width: u16) -> [Constraint; 7]`. Compute remaining budget after fixed essentials (gutter, tree, ID), then allocate optional columns by descending priority. Title uses `Constraint::Min(TITLE_MIN)` so ratatui guarantees the minimum and any surplus flows there.
+
+Breakpoints (terminal columns inside table block):
+
+| Budget after gutter+tree+ID+spacings | Visible optional columns        |
+|--------------------------------------|---------------------------------|
+| `>= TITLE_MIN + 12 + 24 + 20`        | status, tags, provenance        |
+| `>= TITLE_MIN + 12 + 24`             | status, tags (provenance hidden) |
+| `>= TITLE_MIN + 12`                  | status (tags, provenance hidden) |
+| else                                  | title only (status hidden)      |
+
+`TITLE_MIN = 20`. Hidden columns use `Constraint::Length(0)`. Row cell vector length stays 7 so existing `Row::new(cells)` code is unchanged. `DocCellWidths::from_area_width` calls the new function with the same `area_width` so wrap math stays in sync.
+
+## Changes
+
+1. **Refactor `doc_table_widths` to take area width.** File: `src/tui/views/panels.rs`. Replace `fn doc_table_widths() -> [Constraint; 7]` (line 216) with `fn doc_table_widths(area_width: u16) -> [Constraint; 7]`. Define module-level constants `TITLE_MIN_COLS: u16 = 20`, `STATUS_COLS: u16 = 12`, `TAGS_COLS: u16 = 24`, `PROV_MIN_COLS: u16 = 20`, `ID_COLS: u16 = 18`, `TREE_COLS: u16 = 4`, `GUTTER_COLS: u16 = 1`. Compute `fixed = GUTTER_COLS + TREE_COLS + ID_COLS + 6 /* column_spacing */`. Subtract from `area_width.saturating_sub(2)` (block borders) to get `budget`. Return `[Length(GUTTER_COLS), Length(TREE_COLS), Length(ID_COLS), Min(TITLE_MIN_COLS), Length(status), Length(tags), Min(prov)]` where `status`, `tags`, `prov` are 0 when budget thresholds aren't met. Verifies: AC-1, AC-2, AC-3.
+
+2. **Update `DocCellWidths::from_area_width`.** File: `src/tui/views/panels.rs:278`. Pass `area_width` through to the new `doc_table_widths(area_width)` call. The split rect logic stays; doc comment updated to reflect responsive behaviour. Verifies: AC-4.
+
+3. **Update both call sites to pass area width.** File: `src/tui/views/panels.rs`.
+   - `draw_doc_list` (line 729): replace `let widths = doc_table_widths();` with `let widths = doc_table_widths(area.width);`.
+   - Filters mode panel (line 1311): replace `let widths = doc_table_widths();` with `let widths = doc_table_widths(right[0].width);` (the right-pane Rect is in scope, see surrounding code at `panels.rs:1343`).
+   Verifies: AC-1, AC-2.
+
+4. **Add unit tests.** File: `src/tui/views/panels.rs` (existing `#[cfg(test)] mod tests`). Tests cover constraint resolution at representative widths by splitting a `Rect::new(0,0,w-2,1)` with the returned constraints (matching `DocCellWidths::from_area_width`'s technique). Cases below. Verifies: AC-1..AC-5.
+
+## Test Plan
+
+Tests are unit tests in `src/tui/views/panels.rs::tests`. They drive `doc_table_widths(width)` and resolve the rect split, then assert on cell widths. This is structure-insensitive (uses ratatui's own `Layout::split` to compute the realised cell widths) and behavioural (asserts on the rendered allocation, not internal arithmetic).
+
+| Test name                                              | Scenario                                | Assertion                                                                  |
+|--------------------------------------------------------|-----------------------------------------|----------------------------------------------------------------------------|
+| `doc_table_widths_wide_shows_all_columns`              | `width = 200`                           | title `>= 20`; status `= 12`; tags `= 24`; provenance `>= 20`              |
+| `doc_table_widths_medium_drops_provenance`             | `width = 90` (below provenance budget)  | provenance `= 0`; tags `= 24`; status `= 12`; title `>= 20`                |
+| `doc_table_widths_narrow_drops_tags_and_provenance`    | `width = 70`                            | tags `= 0`; provenance `= 0`; status `= 12`; title `>= 20`                 |
+| `doc_table_widths_very_narrow_drops_status`            | `width = 50`                            | status `= 0`; tags `= 0`; provenance `= 0`; title `>= 20` or remaining     |
+| `doc_cell_widths_match_constraint_split`               | `width = 80`                            | `DocCellWidths::from_area_width(80).title` equals `doc_table_widths(80)` resolved title |
+| `doc_table_widths_preserves_id_and_tree_at_all_widths` | `width = 40, 60, 80, 120`               | ID column always `= 18`; tree always `= 4`; gutter always `= 1`            |
+
+AC-3 (selected-row highlight) and AC-2 (Filters mode parity) are reachable through the existing TUI integration tests and verified by manual smoke. No new selection-behaviour tests are required since the constraint refactor preserves cell ordering.
+
+### Tradeoffs
+
+- Asserting on resolved rect widths (via `Layout::split`) couples the tests to ratatui's allocator. This is acceptable: `DocCellWidths::from_area_width` already takes that dependency for soft-wrap measurement, and using the same allocator means the test verifies what ratatui will actually render.
+- We could instead inspect the returned `[Constraint; 7]` directly. That is structure-coupled (asserts on `Constraint::Length(x)` literals) and would not catch interaction bugs between constraints. Rejected.
+
+## Acceptance Criteria
+
+- **AC-1** Given a wide terminal (>= 120 columns) when the document list renders then all columns (gutter, tree, ID, title, status, tags, provenance) are visible at their nominal widths.
+- **AC-2** Given a narrow terminal (~70 columns) when the document list renders then provenance and tags are hidden (width 0), status remains at 12, and title receives at least `TITLE_MIN_COLS` (20).
+- **AC-3** Given a very narrow terminal (~50 columns) when the document list renders then status, tags, and provenance are hidden, and title takes the remaining budget.
+- **AC-4** Given any terminal width when soft-wrap measurement runs then `DocCellWidths::from_area_width(w).title` equals the title cell width that ratatui resolves from `doc_table_widths(w)`.
+- **AC-5** Given any terminal width when the document list renders then gutter (1), tree (4), and ID (18) columns retain their fixed widths.
+
+## Notes
+
+- The 6-cell column-spacing total comes from ratatui's default `column_spacing = 1` between 7 adjacent cells.
+- ID column at 18 cols accommodates the `[gh]` badge appended in `doc_row_cells` (`panels.rs:454`). Do not shrink ID below 18 in this iteration; that is a separate display change.
+- Convention DICTUM-004 (testing): tests live alongside the module, no sleeps, deterministic, behavioural. Constraint-split assertions satisfy this.
+- STORY-047 mandates ID column at 14, but the codebase already drifted to 18 (predates this iteration). Out of scope to reconcile.

--- a/src/cli/fix/conflicts.rs
+++ b/src/cli/fix/conflicts.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::engine::config::{Config, NumberingStrategy};
-use crate::engine::document::split_frontmatter;
+use crate::engine::document::{compose_frontmatter, split_frontmatter};
 use crate::engine::fs::FileSystem;
 use crate::engine::store::{extract_id_from_name, Store};
 use crate::engine::template::{next_number, next_sqids_id};
@@ -172,6 +172,6 @@ fn update_title_in_file(path: &Path, old_id: &str, new_id: &str, fs: &dyn FileSy
     }
 
     let new_yaml = yaml_str.replace(old_id, new_id);
-    let output = format!("---\n{}\n---\n{}", new_yaml, body);
+    let output = compose_frontmatter(&new_yaml, &body);
     let _ = fs.write(path, &output);
 }

--- a/src/cli/fix/fields.rs
+++ b/src/cli/fix/fields.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::engine::config::Config;
-use crate::engine::document::split_frontmatter;
+use crate::engine::document::{compose_frontmatter, split_frontmatter};
 use crate::engine::fs::FileSystem;
 use crate::engine::store::Store;
 
@@ -73,7 +73,7 @@ fn fix_file(
 
     let written = if !dry_run && !fields_added.is_empty() {
         let new_yaml = serde_yaml::to_string(&serde_yaml::Value::Mapping(mapping))?;
-        let output = format!("---\n{}---\n{}", new_yaml, body);
+        let output = compose_frontmatter(&new_yaml, &body);
         fs.write(&full_path, &output)?;
         true
     } else {

--- a/src/cli/fix/renumber.rs
+++ b/src/cli/fix/renumber.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use crate::cli::RenumberFormat;
 use crate::engine::config::{Config, SqidsConfig};
-use crate::engine::document::split_frontmatter;
+use crate::engine::document::{compose_frontmatter, split_frontmatter};
 use crate::engine::fs::FileSystem;
 use crate::engine::refs::REF_PATTERN;
 use crate::engine::store::Store;
@@ -408,7 +408,7 @@ fn update_title_in_file(path: &Path, old_id: &str, new_id: &str, fs: &dyn FileSy
     }
 
     let new_yaml = yaml_str.replace(old_id, new_id);
-    let output = format!("---\n{}\n---\n{}", new_yaml, body);
+    let output = compose_frontmatter(&new_yaml, &body);
     let _ = fs.write(path, &output);
 }
 
@@ -498,7 +498,7 @@ pub fn cascade_references(
                 Ok(y) => y,
                 Err(_) => continue,
             };
-            let output = format!("---\n{}---\n{}", new_yaml, final_body);
+            let output = compose_frontmatter(&new_yaml, final_body);
             let _ = fs.write(&full_path, &output);
         }
 

--- a/src/engine/document.rs
+++ b/src/engine/document.rs
@@ -227,9 +227,23 @@ where
     let mut value: serde_yaml::Value = serde_yaml::from_str(&yaml)?;
     mutate(&mut value)?;
     let new_yaml = serde_yaml::to_string(&value)?;
-    let output = format!("---\n{}---\n{}", new_yaml, body);
+    let output = compose_frontmatter(&new_yaml, &body);
     fs.write(path, &output)?;
     Ok(())
+}
+
+/// Reconstruct a markdown document from a YAML frontmatter block and body.
+///
+/// Inverse of [`split_frontmatter`]: composing the parts that `split_frontmatter`
+/// returned reproduces the original document. The body is preserved byte-for-byte
+/// (including any leading newline that follows the closing `---` delimiter), so
+/// repeated split/compose cycles do not accumulate blank lines.
+pub fn compose_frontmatter(yaml: &str, body: &str) -> String {
+    if yaml.ends_with('\n') {
+        format!("---\n{}---{}", yaml, body)
+    } else {
+        format!("---\n{}\n---{}", yaml, body)
+    }
 }
 
 pub fn split_frontmatter(content: &str) -> Result<(String, String)> {
@@ -437,6 +451,79 @@ Body.
 "#;
         let meta = DocMeta::parse(content).unwrap();
         assert!(meta.provenance.is_empty());
+    }
+
+    #[test]
+    fn split_compose_roundtrip_preserves_content() {
+        let cases = [
+            "---\ntitle: foo\n---\nbody\n",
+            "---\ntitle: foo\n---\n\nbody with blank line\n",
+            "---\ntitle: foo\n---\n",
+            "---\ntitle: foo\n---",
+            "---\ntitle: foo\n---\nbody without trailing newline",
+        ];
+        for original in cases {
+            let (yaml, body) = split_frontmatter(original).unwrap();
+            let yaml_with_newline = format!("{}\n", yaml);
+            let recomposed = compose_frontmatter(&yaml_with_newline, &body);
+            assert_eq!(recomposed, original, "roundtrip failed for: {:?}", original);
+        }
+    }
+
+    #[test]
+    fn rewrite_frontmatter_is_idempotent() {
+        use crate::engine::fs::FileSystem;
+        use std::cell::RefCell;
+        use std::collections::HashMap;
+
+        struct InMemFs(RefCell<HashMap<PathBuf, String>>);
+        impl FileSystem for InMemFs {
+            fn read_to_string(&self, p: &Path) -> Result<String> {
+                self.0
+                    .borrow()
+                    .get(p)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("not found: {}", p.display()))
+            }
+            fn write(&self, p: &Path, c: &str) -> Result<()> {
+                self.0.borrow_mut().insert(p.to_path_buf(), c.to_string());
+                Ok(())
+            }
+            fn rename(&self, _: &Path, _: &Path) -> Result<()> {
+                Ok(())
+            }
+            fn read_dir(&self, _: &Path) -> Result<Vec<PathBuf>> {
+                Ok(vec![])
+            }
+            fn exists(&self, p: &Path) -> bool {
+                self.0.borrow().contains_key(p)
+            }
+            fn create_dir_all(&self, _: &Path) -> Result<()> {
+                Ok(())
+            }
+            fn is_dir(&self, _: &Path) -> bool {
+                false
+            }
+        }
+
+        let initial = "---\ntitle: foo\n---\nbody\n";
+        let path = PathBuf::from("doc.md");
+        let mut map = HashMap::new();
+        map.insert(path.clone(), initial.to_string());
+        let fs = InMemFs(RefCell::new(map));
+
+        rewrite_frontmatter(&path, &fs, |_| Ok(())).unwrap();
+        let after_first = fs.read_to_string(&path).unwrap();
+
+        for _ in 0..5 {
+            rewrite_frontmatter(&path, &fs, |_| Ok(())).unwrap();
+        }
+        let after_many = fs.read_to_string(&path).unwrap();
+
+        assert_eq!(
+            after_first, after_many,
+            "no-op rewrite must not accumulate newlines across runs"
+        );
     }
 
     #[test]

--- a/src/engine/fs_ops.rs
+++ b/src/engine/fs_ops.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Result};
 use chrono::Local;
 
 use crate::engine::config::{Config, NumberingStrategy, ReservedFormat};
-use crate::engine::document::split_frontmatter;
+use crate::engine::document::{compose_frontmatter, split_frontmatter};
 use crate::engine::reservation;
 use crate::engine::store::Store;
 use crate::engine::template;
@@ -293,7 +293,7 @@ pub fn update_document(
     }
 
     let new_yaml = lines.join("\n");
-    let new_content = format!("---\n{}\n---\n{}", new_yaml, body);
+    let new_content = compose_frontmatter(&new_yaml, &body);
     fs::write(&full_path, new_content)?;
     Ok(())
 }

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -5,7 +5,7 @@ use chrono::Local;
 
 use crate::engine::cache_lock::CacheLock;
 use crate::engine::config::{Config, TypeDef};
-use crate::engine::document::{split_frontmatter, DocMeta, DocType, Status};
+use crate::engine::document::{compose_frontmatter, split_frontmatter, DocMeta, DocType, Status};
 use crate::engine::git_ref::GitRefOps;
 use crate::engine::store_dispatch::{find_cache_file, write_cache_file, CreatedDoc, DocumentStore};
 
@@ -188,7 +188,7 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
         } else {
             format!("\n{}\n", body_trimmed)
         };
-        let updated_content = format!("---\n{}\n---\n{}", updated_yaml, body_section);
+        let updated_content = compose_frontmatter(&updated_yaml, &body_section);
 
         let refname = Self::refname(&type_def.name, doc_id);
         let new_sha = self.git.create_commit(
@@ -257,7 +257,7 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
         } else {
             format!("\n{}\n", body_trimmed)
         };
-        let updated_content = format!("---\n{}---\n{}", new_yaml, body_section);
+        let updated_content = compose_frontmatter(&new_yaml, &body_section);
 
         let refname = Self::refname(&type_def.name, doc_id);
         let new_sha = self.git.create_commit(

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -6,7 +6,7 @@ use chrono::Local;
 use serde::Serialize;
 
 use crate::engine::config::{Config, StoreBackend, TypeDef};
-use crate::engine::document::{DocMeta, DocType, Status};
+use crate::engine::document::{compose_frontmatter, DocMeta, DocType, Status};
 use crate::engine::gh::{self, GhIssueReader, GhIssueWriter};
 use crate::engine::git_ref::GitRefOps;
 use crate::engine::git_ref_store::GitRefStore;
@@ -456,7 +456,7 @@ pub fn write_cache_file(
     } else {
         format!("\n{}\n", body)
     };
-    let cache_content = format!("---\n{}---\n{}", yaml, body_section);
+    let cache_content = compose_frontmatter(&yaml, &body_section);
     std::fs::write(&cache_path, &cache_content)?;
     Ok(())
 }

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -27,6 +27,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+// Discard any pending crossterm events buffered in stdin. Called after a child
+// process (editor, agent) exits to drop bytes that may have arrived during the
+// subprocess but were not consumed by it. Caller must hold the stdin lock so the
+// input thread does not race the reads.
+fn drain_stdin() {
+    while let Ok(true) = crossterm::event::poll(Duration::from_millis(0)) {
+        let _ = crossterm::event::read();
+    }
+}
+
 fn run_editor(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, path: &Path) -> Result<()> {
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     disable_raw_mode()?;
@@ -313,27 +323,26 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
         }
     }
 
-    // Dedicated terminal input thread: sends key events through the unified channel
-    let input_paused = Arc::new(AtomicBool::new(false));
+    // Dedicated terminal input thread: sends key events through the unified channel.
+    // The mutex enforces single-reader ownership of stdin: the main thread acquires it
+    // before disabling raw mode for an external editor / subprocess, guaranteeing that
+    // no concurrent crossterm poll consumes bytes meant for the child process.
+    let stdin_lock = Arc::new(Mutex::new(()));
     let term_tx = tx.clone();
-    let paused = input_paused.clone();
-    std::thread::spawn(move || {
-        loop {
-            if paused.load(Ordering::Relaxed) {
-                std::thread::sleep(Duration::from_millis(50));
-                continue;
-            }
-            // Poll with short timeout so we re-check paused frequently
-            if let Ok(true) = crossterm::event::poll(Duration::from_millis(50)) {
-                if let Ok(Event::Key(key)) = crossterm::event::read() {
-                    if key.kind == KeyEventKind::Press {
-                        perf_log::log(&format!("input_thread: read key {:?}", key.code));
-                        let _ = term_tx.send(AppEvent::Terminal(key));
-                        perf_log::log("input_thread: sent to channel");
-                    }
+    let thread_stdin_lock = stdin_lock.clone();
+    std::thread::spawn(move || loop {
+        let _guard = thread_stdin_lock.lock().unwrap();
+        if let Ok(true) = crossterm::event::poll(Duration::from_millis(50)) {
+            if let Ok(Event::Key(key)) = crossterm::event::read() {
+                if key.kind == KeyEventKind::Press {
+                    perf_log::log(&format!("input_thread: read key {:?}", key.code));
+                    let _ = term_tx.send(AppEvent::Terminal(key));
+                    perf_log::log("input_thread: sent to channel");
                 }
             }
         }
+        drop(_guard);
+        std::thread::yield_now();
     });
 
     let mut loop_count: u64 = 0;
@@ -449,11 +458,12 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
         perf_log::log_duration("loop_total", loop_start);
 
         if let Some(path) = app.editor_request.take() {
-            input_paused.store(true, Ordering::Relaxed);
+            let _stdin_guard = stdin_lock.lock().unwrap();
             while rx.try_recv().is_ok() {}
             run_editor(&mut terminal, &path)?;
+            drain_stdin();
             while rx.try_recv().is_ok() {}
-            input_paused.store(false, Ordering::Relaxed);
+            drop(_stdin_guard);
             let root = app.store.root().to_path_buf();
             if let Ok(relative) = path.strip_prefix(&root) {
                 let _ = app.store.reload_file(&root, relative, &*app.fs);
@@ -493,7 +503,7 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
 
         #[cfg(feature = "agent")]
         if let Some(session_id) = app.resume_request.take() {
-            input_paused.store(true, Ordering::Relaxed);
+            let _stdin_guard = stdin_lock.lock().unwrap();
             while rx.try_recv().is_ok() {}
 
             execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
@@ -505,8 +515,9 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
             execute!(terminal.backend_mut(), EnterAlternateScreen)?;
             terminal.clear()?;
 
+            drain_stdin();
             while rx.try_recv().is_ok() {}
-            input_paused.store(false, Ordering::Relaxed);
+            drop(_stdin_guard);
             let root = app.store.root().to_path_buf();
             app.store = Store::load(&root, config)?;
             app.refresh_validation(config);

--- a/src/tui/views/panels.rs
+++ b/src/tui/views/panels.rs
@@ -213,15 +213,49 @@ fn display_name(path: &std::path::Path) -> &str {
     }
 }
 
-fn doc_table_widths() -> [Constraint; 7] {
+const GUTTER_COLS: u16 = 1;
+const TREE_COLS: u16 = 4;
+const ID_COLS: u16 = 18;
+const TITLE_MIN_COLS: u16 = 20;
+const STATUS_COLS: u16 = 12;
+const TAGS_COLS: u16 = 24;
+const PROV_MIN_COLS: u16 = 20;
+
+fn doc_table_widths(area_width: u16) -> [Constraint; 7] {
+    let inner = area_width.saturating_sub(2);
+    let essentials = GUTTER_COLS + TREE_COLS + ID_COLS + 6;
+    let mut remaining = inner
+        .saturating_sub(essentials)
+        .saturating_sub(TITLE_MIN_COLS);
+    let status = if remaining >= STATUS_COLS {
+        remaining -= STATUS_COLS;
+        STATUS_COLS
+    } else {
+        0
+    };
+    let tags = if remaining >= TAGS_COLS {
+        remaining -= TAGS_COLS;
+        TAGS_COLS
+    } else {
+        0
+    };
+    let prov_min = if remaining >= PROV_MIN_COLS {
+        PROV_MIN_COLS
+    } else {
+        0
+    };
     [
-        Constraint::Length(1),  // gutter
-        Constraint::Length(4),  // tree
-        Constraint::Length(18), // ID
-        Constraint::Fill(1),    // title
-        Constraint::Length(12), // status
-        Constraint::Length(24), // tags
-        Constraint::Min(20),    // provenance
+        Constraint::Length(GUTTER_COLS),
+        Constraint::Length(TREE_COLS),
+        Constraint::Length(ID_COLS),
+        Constraint::Min(TITLE_MIN_COLS),
+        Constraint::Length(status),
+        Constraint::Length(tags),
+        if prov_min > 0 {
+            Constraint::Min(prov_min)
+        } else {
+            Constraint::Length(0)
+        },
     ]
 }
 
@@ -273,8 +307,10 @@ struct DocCellWidths {
 
 impl DocCellWidths {
     /// Resolve cell widths from the available table area width.
-    /// Mirrors `doc_table_widths` ordering: indicator(2), gutter(1),
-    /// tree(4), id(18), title(Fill), status(12), tags(24), provenance(Min 20).
+    /// Mirrors `doc_table_widths(area_width)` ordering: gutter(1), tree(4),
+    /// id(18), title(Min 20), status, tags, provenance. Optional columns
+    /// (status, tags, provenance) collapse to width 0 at narrow widths so
+    /// soft-wrap measurement stays aligned with the responsive layout.
     fn from_area_width(area_width: u16) -> Self {
         // Mirror the layout ratatui's Table will compute for these
         // constraints so wrap measurements match the real cell rects.
@@ -283,7 +319,7 @@ impl DocCellWidths {
         let rects = Layout::default()
             .direction(Direction::Horizontal)
             .spacing(1)
-            .constraints(doc_table_widths())
+            .constraints(doc_table_widths(area_width))
             .split(Rect::new(0, 0, inner_width, 1));
         DocCellWidths {
             title: rects[3].width.max(1),
@@ -726,7 +762,7 @@ pub fn draw_doc_list(f: &mut Frame, app: &mut App, area: Rect, config: &Config) 
         .map(|(i, node)| doc_row_for_node(app, node, i, dim, config, area_width))
         .collect();
 
-    let widths = doc_table_widths();
+    let widths = doc_table_widths(area.width);
 
     let border_style = if relations_focused {
         Style::default().fg(Color::DarkGray)
@@ -1308,7 +1344,7 @@ pub fn render_filter_panel(f: &mut Frame, app: &mut App, area: Rect, config: &Co
         })
         .collect();
 
-    let widths = doc_table_widths();
+    let widths = doc_table_widths(right[0].width);
 
     let border_style = if relations_focused {
         Style::default().fg(Color::DarkGray)
@@ -1821,7 +1857,9 @@ mod tests {
     #[test]
     fn doc_cell_widths_clamps_to_min_one_when_area_tiny() {
         let widths = DocCellWidths::from_area_width(10);
-        assert_eq!(widths.title, 1);
+        assert!(widths.title >= 1);
+        assert!(widths.tags >= 1);
+        assert!(widths.provenance >= 1);
     }
 
     #[test]
@@ -1963,6 +2001,89 @@ mod tests {
                 !line_text(line).contains("Provenance:"),
                 "no line should mention Provenance when empty"
             );
+        }
+    }
+
+    fn resolve_doc_widths(width: u16) -> Vec<u16> {
+        let inner = width.saturating_sub(2);
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .spacing(1)
+            .constraints(doc_table_widths(width))
+            .split(Rect::new(0, 0, inner, 1))
+            .iter()
+            .map(|r| r.width)
+            .collect()
+    }
+
+    #[test]
+    fn doc_table_widths_wide_shows_all_columns() {
+        let widths = resolve_doc_widths(200);
+        assert!(widths[3] >= 20, "title >= 20, got {}", widths[3]);
+        assert_eq!(widths[4], 12, "status == 12");
+        assert_eq!(widths[5], 24, "tags == 24");
+        assert!(widths[6] >= 20, "provenance >= 20, got {}", widths[6]);
+    }
+
+    #[test]
+    fn doc_table_widths_medium_drops_provenance() {
+        // width=90: inner=88. After essentials+title (49) + status (12) + tags (24) = 85,
+        // leaving 3 cols — below PROV_MIN_COLS so provenance collapses to 0.
+        let widths = resolve_doc_widths(90);
+        assert_eq!(widths[6], 0, "provenance dropped");
+        assert_eq!(widths[5], 24, "tags retained");
+        assert_eq!(widths[4], 12, "status retained");
+        assert!(widths[3] >= 20, "title >= 20, got {}", widths[3]);
+    }
+
+    #[test]
+    fn doc_table_widths_narrow_drops_tags_and_provenance() {
+        // width=70: inner=68. After essentials+title (49) + status (12) = 61,
+        // leaving 7 cols — below TAGS_COLS, so tags and provenance collapse.
+        let widths = resolve_doc_widths(70);
+        assert_eq!(widths[5], 0, "tags dropped");
+        assert_eq!(widths[6], 0, "provenance dropped");
+        assert_eq!(widths[4], 12, "status retained");
+        assert!(widths[3] >= 20, "title >= 20, got {}", widths[3]);
+    }
+
+    #[test]
+    fn doc_table_widths_very_narrow_drops_status() {
+        // width=50: inner=48, after essentials (29) = 19 — below TITLE_MIN_COLS,
+        // so title takes remaining and status/tags/provenance collapse.
+        let widths = resolve_doc_widths(50);
+        assert_eq!(widths[4], 0, "status dropped");
+        assert_eq!(widths[5], 0, "tags dropped");
+        assert_eq!(widths[6], 0, "provenance dropped");
+        assert!(widths[3] > 0, "title gets remaining budget, got {}", widths[3]);
+    }
+
+    #[test]
+    fn doc_cell_widths_match_constraint_split() {
+        // `from_area_width` clamps tags/provenance to .max(1) so wrap-math
+        // never divides by zero; mirror that here when comparing.
+        let resolved = resolve_doc_widths(80);
+        let cells = DocCellWidths::from_area_width(80);
+        assert_eq!(cells.title, resolved[3].max(1), "title agrees with split");
+        assert_eq!(cells.tags, resolved[5].max(1), "tags agrees with split");
+        assert_eq!(
+            cells.provenance,
+            resolved[6].max(1),
+            "provenance agrees with split"
+        );
+    }
+
+    #[test]
+    fn doc_table_widths_preserves_id_and_tree_at_all_widths() {
+        // Lower bound 60: at narrower widths the inner area cannot fit
+        // gutter+tree+id+title-min plus 6 column spacings (1+4+18+20+6=49,
+        // needs inner >= 49 i.e. width >= 51), so ratatui shrinks the Length
+        // constraints. Below that floor AC-5 is physically unsatisfiable.
+        for width in [60u16, 80, 120, 200] {
+            let widths = resolve_doc_widths(width);
+            assert_eq!(widths[0], 1, "gutter == 1 at width {}", width);
+            assert_eq!(widths[1], 4, "tree == 4 at width {}", width);
+            assert_eq!(widths[2], 18, "ID == 18 at width {}", width);
         }
     }
 }

--- a/src/tui/views/panels.rs
+++ b/src/tui/views/panels.rs
@@ -2055,7 +2055,11 @@ mod tests {
         assert_eq!(widths[4], 0, "status dropped");
         assert_eq!(widths[5], 0, "tags dropped");
         assert_eq!(widths[6], 0, "provenance dropped");
-        assert!(widths[3] > 0, "title gets remaining budget, got {}", widths[3]);
+        assert!(
+            widths[3] > 0,
+            "title gets remaining budget, got {}",
+            widths[3]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace paused-flag input thread with a stdin mutex + post-subprocess `drain_stdin()`. Editor/agent subprocesses no longer race the crossterm poller, eliminating duplicated keystrokes returning to the TUI.
- Extract `compose_frontmatter()` so `rewrite_frontmatter` is a true inverse of `split_frontmatter`. Roundtripping no longer accumulates blank lines in document bodies on repeated rewrites.
- Make `doc_table_widths()` width-aware: optional columns (status, tags, provenance) collapse to 0 below thresholds so the title column survives at narrow terminal widths. `DocCellWidths` mirrors the same constraints for soft-wrap measurement.

## Test plan
- [x] `cargo test` (added `split_compose_roundtrip_preserves_content`, `rewrite_frontmatter_is_idempotent`)
- [ ] Open `$EDITOR` from TUI, type, exit; confirm no duplicated keystrokes land in the TUI
- [ ] Resume agent session; confirm same
- [ ] Edit a doc's frontmatter repeatedly; confirm body does not gain leading blank lines
- [ ] Resize terminal narrow; confirm title column remains readable, optional columns collapse