### PR TITLE
fix: lease atomicity - rollback local state on push failure

### DIFF
--- a/docs/iterations/ITERATION-168-fix-git-ref-fetch-prune-and-update-rollback.md
+++ b/docs/iterations/ITERATION-168-fix-git-ref-fetch-prune-and-update-rollback.md
@@ -1,0 +1,89 @@
+---
+title: "Fix git-ref fetch prune and update rollback"
+type: iteration
+status: accepted
+author: "claude"
+date: 2026-05-09
+tags: []
+related: []
+---
+
+## Context
+
+Git-ref store audit (2026-05-09) found two concurrency defects affecting multi-clone coordination:
+
+1. `fetch_refs` in `src/engine/git_ref.rs:203-211` runs `git fetch +pat:pat` without `--prune`. Remote-deleted doc/lease refs leave ghost local refs and stale cache files. `cli/fetch.rs:fetch_git_ref_type` lists local refs after fetch, so deletion is invisible. Same shape in `cli/lease.rs:87` for lease refs.
+
+2. `GitRefStore::update`, `set_provenance`, `delete` in `src/engine/git_ref_store.rs` call local `update_ref` (CAS) before `push_ref`. On push rejection (non-FF), local ref already advanced but cache.lock and cache file remain at old SHA. Subsequent updates fail with `cannot lock ref ... is at X but expected Y` until manual `lazyspec fetch` force-overwrites the local ref.
+
+Both defects reproduced in audit with bare-repo + 2-clone scenario. CLI and TUI share engine path so both surface the bugs.
+
+## Acceptance Criteria
+
+AC1. After `lazyspec delete` from clone A and `lazyspec fetch` from clone B, B's local doc ref `refs/lazyspec/{type}/{id}` and cache file `.lazyspec/cache/{type}/{id}.md` no longer exist.
+
+AC2. After `lazyspec release` from clone A and `lazyspec claim` from clone B, B sees no stale local lease ref and the claim succeeds without manual ref deletion.
+
+AC3. When `GitRefStore::update` push fails (non-FF rejection), local ref `refs/lazyspec/{type}/{id}` remains at old SHA. Subsequent `lazyspec fetch` + retry succeeds without `cannot lock ref` error.
+
+AC4. AC3 holds for `set_provenance` flow as well. `delete` flow: if remote `delete_remote_ref` fails, local ref stays intact (already current behavior; verify with test).
+
+## Changes
+
+1. **Add `--prune` to `GitCli::fetch_refs`** (`src/engine/git_ref.rs:203-211`).
+   - ACs: AC1, AC2.
+   - Insert `"--prune"` into the args slice passed to `git fetch`. Refspec stays `+pat:pat`.
+   - Verify: `cargo test fetch` and the new integration test (Test 1).
+
+2. **Rollback local ref on push failure in `GitRefStore::update`** (`src/engine/git_ref_store.rs:152-219`).
+   - ACs: AC3.
+   - Wrap the `push_ref` call: on `Err(push_err)`, run `update_ref(refname, old_sha, new_sha)` (reverse CAS: expect current new_sha, set back to old_sha). Then `bail!` with the original push error.
+   - If rollback itself errors, surface a combined error mentioning that local state is wedged and recovery requires `lazyspec fetch`.
+   - Cache file write and cache.lock save stay after successful push (already correct).
+
+3. **Apply same rollback to `set_provenance`** (`src/engine/git_ref_store.rs:221-288`).
+   - ACs: AC4.
+   - Identical pattern to Change 2.
+
+4. **Verify `delete` flow safety** (`src/engine/git_ref_store.rs:290-308`).
+   - ACs: AC4 (delete portion).
+   - Current order: `delete_remote_ref` -> `delete_ref` (local) -> remove cache file -> update cache.lock. If remote delete fails, code bails before local delete (safe). If local `delete_ref` fails after remote succeeded, cache file and lock are not removed (safe; recovery: re-fetch will recreate). No code change required; add a regression test confirming this order.
+
+## Test Plan
+
+Test framework: `tests/` integration tests using `tempfile::TempDir` + bare git repo + two working clones for concurrency tests; `MockGitRefClient` for unit tests. Per dictum-004 (testing): isolated, deterministic, no sleeps, real types over mocks at trait seams, behavioral assertions.
+
+**Test 1: fetch prunes deleted remote refs** (AC1) — integration.
+Setup: bare repo, clone A and B; both init lazyspec config with git-ref iteration type and `[coordination]`. A claims+creates ITERATION-001 (pushes ref). B fetches; assert B has local ref + cache file. A claims+deletes ITERATION-001. B fetches.
+Assert: B has no `refs/lazyspec/iteration/ITERATION-001` ref AND no `.lazyspec/cache/iteration/ITERATION-001.md`. `fetch_git_ref_type` returns `removed: 1`.
+
+**Test 2: fetch prunes deleted remote lease refs** (AC2) — integration.
+Setup: same. A claims ITERATION-001 (lease pushed). B fetches leases via lease module path. A releases. B claims ITERATION-001.
+Assert: claim succeeds (no "lease held" error). No manual `git update-ref -d` needed.
+
+**Test 3: update rollback on push rejection** (AC3) — unit, using `MockGitRefClient`.
+Configure: `create_commit_results = Ok("newsha")`, `update_ref_results = [Ok(()), Ok(())]` (first for forward CAS, second for rollback), `push_results = Err("non-fast-forward")`. Pre-seed cache.lock with old_sha and cache file with status=draft.
+Assert: `update` returns Err. Mock `calls` includes two `update_ref` entries: forward `(refname, newsha, oldsha)` then rollback `(refname, oldsha, newsha)`. Cache file content unchanged (status=draft). Cache.lock unchanged (oldsha).
+
+**Test 4: set_provenance rollback on push failure** (AC4) — unit, using `MockGitRefClient`.
+Same shape as Test 3 but invoking `set_provenance`. Same assertions.
+
+**Test 5: delete preserves local state when remote delete fails** (AC4) — unit, using `MockGitRefClient`.
+Configure: `delete_remote_results = Err("network down")`. Pre-seed cache file and cache.lock.
+Assert: `delete` returns Err. Cache file still exists. Cache.lock entry still present. Local doc ref not deleted (`delete_ref_results` queue untouched).
+
+**Test 6: end-to-end rollback recovery** (AC3) — integration.
+Setup: bare repo, A and B seeded with ITERATION-001 status=draft (B's clone fetched). A updates status=accepted (push succeeds). B (stale) updates status=review.
+Assert: B's update bails. B's local ref equals B's cache.lock SHA (the pre-attempt SHA). B's cache file content unchanged.
+Then: B runs `lazyspec fetch`. B retries update status=review. Push succeeds. Remote ref now at B's commit chained on A's accepted.
+
+Tradeoffs:
+- Tests 1, 2, 6 use real `git` subprocess. Slower but exercise the actual `--prune` flag and end-to-end CAS semantics. Worth it: `git fetch --prune` behavior is exactly what AC1 promises; a mock can't validate the subprocess argument set.
+- Tests 3, 4, 5 are fast unit coverage decoupled from git subprocess; they assert the rollback control flow without needing a real remote.
+
+## Notes
+
+- Audit reproduction captured 2026-05-09 in conversation transcript. Bare repo at `/tmp/lzs2/remote.git` during audit (not retained).
+- Rollback uses reverse-CAS `update_ref(refname, old_sha, new_sha)`: expect new_sha (current local after forward CAS), set back to old_sha. Standard git operation.
+- Skill audit (out of scope here) flagged that skills don't reference fetch/claim/release lifecycle when coordination is configured. Tracked separately.
+- TUI in-place edit (`src/tui/infra/event_loop.rs:try_push_git_ref_edit`) calls `GitRefStore::update` and inherits the fix automatically.

--- a/src/engine/git_ref.rs
+++ b/src/engine/git_ref.rs
@@ -202,7 +202,7 @@ impl GitRefOps for GitCli {
 
     fn fetch_refs(&self, root: &Path, remote: &str, pattern: &str) -> Result<()> {
         let refspec = format!("+{}:{}", pattern, pattern);
-        let output = self.run_git(root, &["fetch", remote, &refspec])?;
+        let output = self.run_git(root, &["fetch", "--prune", remote, &refspec])?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!("git fetch failed: {}", stderr.trim());

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -207,8 +207,9 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
 
         if let Some(coord) = &self.config.coordination {
             if let Err(push_err) = self.git.push_ref(&self.root, &coord.remote, &refname) {
-                if let Err(rollback_err) =
-                    self.git.update_ref(&self.root, &refname, &old_sha, &new_sha)
+                if let Err(rollback_err) = self
+                    .git
+                    .update_ref(&self.root, &refname, &old_sha, &new_sha)
                 {
                     bail!(
                         "push failed: {}; rollback failed: {}; local state wedged, recover with `lazyspec fetch`",
@@ -287,8 +288,9 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
 
         if let Some(coord) = &self.config.coordination {
             if let Err(push_err) = self.git.push_ref(&self.root, &coord.remote, &refname) {
-                if let Err(rollback_err) =
-                    self.git.update_ref(&self.root, &refname, &old_sha, &new_sha)
+                if let Err(rollback_err) = self
+                    .git
+                    .update_ref(&self.root, &refname, &old_sha, &new_sha)
                 {
                     bail!(
                         "push failed: {}; rollback failed: {}; local state wedged, recover with `lazyspec fetch`",
@@ -1000,13 +1002,11 @@ mod tests {
             *calls
         );
         assert_eq!(
-            update_ref_calls[0],
-            "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
+            update_ref_calls[0], "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
             "first update_ref is forward CAS"
         );
         assert_eq!(
-            update_ref_calls[1],
-            "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
+            update_ref_calls[1], "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
             "second update_ref is rollback (reverse CAS)"
         );
         drop(calls);
@@ -1077,13 +1077,11 @@ mod tests {
             *calls
         );
         assert_eq!(
-            update_ref_calls[0],
-            "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
+            update_ref_calls[0], "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
             "first update_ref is forward CAS"
         );
         assert_eq!(
-            update_ref_calls[1],
-            "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
+            update_ref_calls[1], "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
             "second update_ref is rollback (reverse CAS)"
         );
         drop(calls);
@@ -1117,8 +1115,8 @@ mod tests {
         lock.set("iteration/ITERATION-042", "somesha");
         lock.save(tmp.path()).unwrap();
 
-        let mock = MockGitRefClient::new()
-            .with_delete_remote_result(Err(anyhow::anyhow!("network down")));
+        let mock =
+            MockGitRefClient::new().with_delete_remote_result(Err(anyhow::anyhow!("network down")));
 
         let mut store = GitRefStore {
             git: mock,

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -206,7 +206,18 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
         }
 
         if let Some(coord) = &self.config.coordination {
-            self.git.push_ref(&self.root, &coord.remote, &refname)?;
+            if let Err(push_err) = self.git.push_ref(&self.root, &coord.remote, &refname) {
+                if let Err(rollback_err) =
+                    self.git.update_ref(&self.root, &refname, &old_sha, &new_sha)
+                {
+                    bail!(
+                        "push failed: {}; rollback failed: {}; local state wedged, recover with `lazyspec fetch`",
+                        push_err,
+                        rollback_err
+                    );
+                }
+                bail!("push failed for {}: {}", doc_id, push_err);
+            }
         }
 
         std::fs::write(&cache_path, &updated_content)?;
@@ -275,7 +286,18 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
         }
 
         if let Some(coord) = &self.config.coordination {
-            self.git.push_ref(&self.root, &coord.remote, &refname)?;
+            if let Err(push_err) = self.git.push_ref(&self.root, &coord.remote, &refname) {
+                if let Err(rollback_err) =
+                    self.git.update_ref(&self.root, &refname, &old_sha, &new_sha)
+                {
+                    bail!(
+                        "push failed: {}; rollback failed: {}; local state wedged, recover with `lazyspec fetch`",
+                        push_err,
+                        rollback_err
+                    );
+                }
+                bail!("push failed for {}: {}", doc_id, push_err);
+            }
         }
 
         std::fs::write(&cache_path, &updated_content)?;
@@ -928,6 +950,227 @@ mod tests {
 
         let lock = CacheLock::load(tmp.path()).unwrap();
         assert_eq!(lock.get("iteration/ITERATION-042"), Some("newsha"));
+    }
+
+    #[test]
+    fn test_git_ref_store_update_rollback_on_push_failure() {
+        let tmp = TempDir::new().unwrap();
+        let td = test_type_def();
+        let cache_dir = tmp.path().join(".lazyspec/cache/iteration");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let cache_content = "---\ntitle: Title\ntype: iteration\nstatus: draft\nauthor: alice\ndate: 2026-04-01\ntags: []\nrelated: []\n---\n\nbody\n";
+        let cache_path = cache_dir.join("ITERATION-042.md");
+        std::fs::write(&cache_path, cache_content).unwrap();
+
+        let mut lock = CacheLock::default();
+        lock.set("iteration/ITERATION-042", "oldsha");
+        lock.save(tmp.path()).unwrap();
+
+        let mock = MockGitRefClient::new()
+            .with_create_commit_result(Ok("newsha".to_string()))
+            .with_update_ref_result(Ok(()))
+            .with_update_ref_result(Ok(()))
+            .with_push_result(Err(anyhow::anyhow!("non-fast-forward")));
+
+        let mut store = GitRefStore {
+            git: mock,
+            root: tmp.path().to_path_buf(),
+            config: test_config_with_coordination(),
+            reserved_number: None,
+        };
+        let result = store.update(&td, "ITERATION-042", &[("status", "accepted")]);
+
+        assert!(result.is_err(), "update should fail when push is rejected");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("non-fast-forward"),
+            "error should mention push failure, got: {}",
+            err_msg
+        );
+
+        let calls = store.git.calls.borrow();
+        let update_ref_calls: Vec<&String> = calls
+            .iter()
+            .filter(|c| c.starts_with("update_ref:"))
+            .collect();
+        assert_eq!(
+            update_ref_calls.len(),
+            2,
+            "should have two update_ref calls (forward + rollback), got: {:?}",
+            *calls
+        );
+        assert_eq!(
+            update_ref_calls[0],
+            "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
+            "first update_ref is forward CAS"
+        );
+        assert_eq!(
+            update_ref_calls[1],
+            "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
+            "second update_ref is rollback (reverse CAS)"
+        );
+        drop(calls);
+
+        let unchanged = std::fs::read_to_string(&cache_path).unwrap();
+        assert!(
+            unchanged.contains("status: draft"),
+            "cache file should be unchanged on push failure, got: {}",
+            unchanged
+        );
+
+        let lock = CacheLock::load(tmp.path()).unwrap();
+        assert_eq!(
+            lock.get("iteration/ITERATION-042"),
+            Some("oldsha"),
+            "cache.lock should be unchanged on push failure"
+        );
+    }
+
+    #[test]
+    fn test_git_ref_store_set_provenance_rollback_on_push_failure() {
+        let tmp = TempDir::new().unwrap();
+        let td = test_type_def();
+        let cache_dir = tmp.path().join(".lazyspec/cache/iteration");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let cache_content = "---\ntitle: Title\ntype: iteration\nstatus: draft\nauthor: alice\ndate: 2026-04-01\ntags: []\nrelated: []\n---\n\nbody\n";
+        let cache_path = cache_dir.join("ITERATION-042.md");
+        std::fs::write(&cache_path, cache_content).unwrap();
+
+        let mut lock = CacheLock::default();
+        lock.set("iteration/ITERATION-042", "oldsha");
+        lock.save(tmp.path()).unwrap();
+
+        let mock = MockGitRefClient::new()
+            .with_create_commit_result(Ok("newsha".to_string()))
+            .with_update_ref_result(Ok(()))
+            .with_update_ref_result(Ok(()))
+            .with_push_result(Err(anyhow::anyhow!("non-fast-forward")));
+
+        let mut store = GitRefStore {
+            git: mock,
+            root: tmp.path().to_path_buf(),
+            config: test_config_with_coordination(),
+            reserved_number: None,
+        };
+        let result = store.set_provenance(&td, "ITERATION-042", &["A".to_string()]);
+
+        assert!(
+            result.is_err(),
+            "set_provenance should fail when push is rejected"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("non-fast-forward"),
+            "error should mention push failure, got: {}",
+            err_msg
+        );
+
+        let calls = store.git.calls.borrow();
+        let update_ref_calls: Vec<&String> = calls
+            .iter()
+            .filter(|c| c.starts_with("update_ref:"))
+            .collect();
+        assert_eq!(
+            update_ref_calls.len(),
+            2,
+            "should have two update_ref calls (forward + rollback), got: {:?}",
+            *calls
+        );
+        assert_eq!(
+            update_ref_calls[0],
+            "update_ref:refs/lazyspec/iteration/ITERATION-042:newsha:oldsha",
+            "first update_ref is forward CAS"
+        );
+        assert_eq!(
+            update_ref_calls[1],
+            "update_ref:refs/lazyspec/iteration/ITERATION-042:oldsha:newsha",
+            "second update_ref is rollback (reverse CAS)"
+        );
+        drop(calls);
+
+        let unchanged = std::fs::read_to_string(&cache_path).unwrap();
+        assert!(
+            !unchanged.contains("provenance"),
+            "cache file should be unchanged on push failure, got: {}",
+            unchanged
+        );
+
+        let lock = CacheLock::load(tmp.path()).unwrap();
+        assert_eq!(
+            lock.get("iteration/ITERATION-042"),
+            Some("oldsha"),
+            "cache.lock should be unchanged on push failure"
+        );
+    }
+
+    #[test]
+    fn delete_preserves_local_state_when_remote_delete_fails() {
+        let tmp = TempDir::new().unwrap();
+        let td = test_type_def();
+        let cache_dir = tmp.path().join(".lazyspec/cache/iteration");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let cache_content = "---\ntitle: T\ntype: iteration\nstatus: draft\nauthor: a\ndate: 2026-04-01\ntags: []\nrelated: []\n---\n";
+        let cache_path = cache_dir.join("ITERATION-042.md");
+        std::fs::write(&cache_path, cache_content).unwrap();
+
+        let mut lock = CacheLock::default();
+        lock.set("iteration/ITERATION-042", "somesha");
+        lock.save(tmp.path()).unwrap();
+
+        let mock = MockGitRefClient::new()
+            .with_delete_remote_result(Err(anyhow::anyhow!("network down")));
+
+        let mut store = GitRefStore {
+            git: mock,
+            root: tmp.path().to_path_buf(),
+            config: test_config_with_coordination(),
+            reserved_number: None,
+        };
+        let result = store.delete(&td, "ITERATION-042");
+
+        assert!(
+            result.is_err(),
+            "delete should fail when remote delete fails"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("network down"),
+            "error should mention remote failure, got: {}",
+            err_msg
+        );
+
+        assert!(
+            cache_path.exists(),
+            "cache file should still exist after remote delete failure"
+        );
+        let unchanged = std::fs::read_to_string(&cache_path).unwrap();
+        assert_eq!(
+            unchanged, cache_content,
+            "cache file content should be unchanged"
+        );
+
+        let lock = CacheLock::load(tmp.path()).unwrap();
+        assert_eq!(
+            lock.get("iteration/ITERATION-042"),
+            Some("somesha"),
+            "lock entry should still be present with original SHA"
+        );
+
+        let calls = store.git.calls.borrow();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "delete_remote_ref:origin:refs/lazyspec/iteration/ITERATION-042"),
+            "should have attempted remote delete, got: {:?}",
+            *calls
+        );
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c == "delete_ref:refs/lazyspec/iteration/ITERATION-042"),
+            "should NOT call local delete_ref when remote delete failed, got: {:?}",
+            *calls
+        );
     }
 
     #[test]

--- a/src/engine/lease.rs
+++ b/src/engine/lease.rs
@@ -69,7 +69,9 @@ impl<R: GitRefOps> LeaseEngine<R> {
     ) -> Result<Lease> {
         let refname = lease_ref(type_name, id);
 
-        fetch_ref_optional(&self.git, root, &self.config.remote, &refname)?;
+        // Glob fetch so --prune removes all stale local lease refs for this type.
+        let lease_glob = format!("refs/lazyspec/leases/{}/*", type_name);
+        fetch_ref_optional(&self.git, root, &self.config.remote, &lease_glob)?;
         let existing = self.git.resolve_ref(root, &refname)?;
         if existing.is_some() {
             bail!("lease held");

--- a/tests/fetch_prune_test.rs
+++ b/tests/fetch_prune_test.rs
@@ -2,9 +2,7 @@ mod common;
 
 use anyhow::Result;
 use chrono::Utc;
-use lazyspec::engine::config::{
-    Config, CoordinationConfig, StoreBackend, TypeDef,
-};
+use lazyspec::engine::config::{Config, CoordinationConfig, StoreBackend, TypeDef};
 use lazyspec::engine::gh::{GhIssue, GhIssueReader};
 use lazyspec::engine::git_ref::{GitCli, GitRefOps};
 use lazyspec::engine::git_ref_store::GitRefStore;
@@ -121,7 +119,10 @@ fn fetch_prunes_deleted_remote_doc_refs() {
         git.resolve_ref(clone_b.path(), refname).unwrap().is_some(),
         "B should have local ref after first fetch"
     );
-    assert!(cache_file.exists(), "B should have cache file after first fetch");
+    assert!(
+        cache_file.exists(),
+        "B should have cache file after first fetch"
+    );
 
     // Clone A deletes ITERATION-001 (removes remote ref).
     store_a
@@ -221,8 +222,7 @@ fn update_rolls_back_on_push_rejection_then_recovers_after_fetch() {
         "B's first update should fail (non-fast-forward push)"
     );
 
-    let lock_b_after_fail =
-        lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
+    let lock_b_after_fail = lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
     let lock_sha_after_fail = lock_b_after_fail
         .get("iteration/ITERATION-001")
         .expect("lock entry should still exist");
@@ -252,8 +252,7 @@ fn update_rolls_back_on_push_rejection_then_recovers_after_fetch() {
         Some(accepted_sha.clone()),
         "B's local ref should now be at A's accepted SHA"
     );
-    let lock_b_after_fetch =
-        lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
+    let lock_b_after_fetch = lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
     assert_eq!(
         lock_b_after_fetch.get("iteration/ITERATION-001"),
         Some(accepted_sha.as_str()),
@@ -292,7 +291,9 @@ fn update_rolls_back_on_push_rejection_then_recovers_after_fetch() {
         .output()
         .expect("git rev-parse parent");
     assert!(parent_out.status.success());
-    let b_parent = String::from_utf8_lossy(&parent_out.stdout).trim().to_string();
+    let b_parent = String::from_utf8_lossy(&parent_out.stdout)
+        .trim()
+        .to_string();
     assert_eq!(
         b_parent, accepted_sha,
         "B's final commit should be parented on A's accepted commit"
@@ -342,7 +343,9 @@ fn fetch_prunes_deleted_remote_lease_refs_so_claim_succeeds() {
     git.fetch_refs(clone_b.path(), "origin", "refs/lazyspec/leases/*")
         .expect("B fetches leases");
     assert!(
-        git.resolve_ref(clone_b.path(), lease_ref).unwrap().is_some(),
+        git.resolve_ref(clone_b.path(), lease_ref)
+            .unwrap()
+            .is_some(),
         "B should have lease ref locally after fetch"
     );
 

--- a/tests/fetch_prune_test.rs
+++ b/tests/fetch_prune_test.rs
@@ -1,0 +1,369 @@
+mod common;
+
+use anyhow::Result;
+use chrono::Utc;
+use lazyspec::engine::config::{
+    Config, CoordinationConfig, StoreBackend, TypeDef,
+};
+use lazyspec::engine::gh::{GhIssue, GhIssueReader};
+use lazyspec::engine::git_ref::{GitCli, GitRefOps};
+use lazyspec::engine::git_ref_store::GitRefStore;
+use lazyspec::engine::lease::LeaseEngine;
+use lazyspec::engine::store_dispatch::DocumentStore;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+struct NoopGh;
+impl GhIssueReader for NoopGh {
+    fn issue_list(
+        &self,
+        _repo: &str,
+        _labels: &[String],
+        _json_fields: &[String],
+        _limit: Option<u64>,
+    ) -> Result<Vec<GhIssue>> {
+        Ok(vec![])
+    }
+    fn issue_view(&self, _repo: &str, _number: u64) -> Result<GhIssue> {
+        unreachable!("not used in this test")
+    }
+}
+
+fn config_with_git_ref_iteration() -> Config {
+    let mut config = Config::default();
+    for t in &mut config.documents.types {
+        if t.name == "iteration" {
+            t.store = StoreBackend::GitRef;
+        }
+    }
+    config.coordination = Some(CoordinationConfig {
+        remote: "origin".to_string(),
+        lease_duration: "60m".to_string(),
+        grace_period: "2m".to_string(),
+        max_push_retries: 5,
+    });
+    config
+}
+
+fn iteration_type_def(config: &Config) -> TypeDef {
+    config
+        .type_by_name("iteration")
+        .expect("iteration type")
+        .clone()
+}
+
+fn make_clone_b(bare: &Path) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let bare_str = bare.to_str().unwrap();
+    let target_str = dir.path().to_str().unwrap();
+
+    let out = Command::new("git")
+        .args(["clone", bare_str, target_str])
+        .output()
+        .expect("git clone");
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Command::new("git")
+        .args(["config", "user.email", "b@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "B"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git config name");
+
+    dir
+}
+
+fn run_fetch(root: &Path, config: &Config) -> Result<()> {
+    let gh = NoopGh;
+    lazyspec::cli::fetch::run(root, config, &gh, &GitCli, "origin", None, true)
+}
+
+#[test]
+fn fetch_prunes_deleted_remote_doc_refs() {
+    // AC1: After delete from clone A and fetch from clone B,
+    // B's local doc ref and cache file no longer exist.
+    let (fixture_a, bare) = common::TestFixture::with_git_remote();
+    let clone_b = make_clone_b(bare.path());
+
+    let config = config_with_git_ref_iteration();
+    let type_def = iteration_type_def(&config);
+
+    // Clone A creates ITERATION-001 (pushes ref to bare remote).
+    let mut store_a = GitRefStore {
+        git: GitCli,
+        root: fixture_a.root().to_path_buf(),
+        config: config.clone(),
+        reserved_number: Some(1),
+    };
+    let created = store_a
+        .create(&type_def, "First Iteration", "agent-a", "body content")
+        .expect("create iteration on A");
+    assert_eq!(created.id, "ITERATION-001");
+
+    // Clone B fetches; should see the ref + cache file.
+    run_fetch(clone_b.path(), &config).expect("first fetch on B");
+
+    let git = GitCli;
+    let refname = "refs/lazyspec/iteration/ITERATION-001";
+    let cache_file = clone_b
+        .path()
+        .join(".lazyspec/cache/iteration/ITERATION-001.md");
+
+    assert!(
+        git.resolve_ref(clone_b.path(), refname).unwrap().is_some(),
+        "B should have local ref after first fetch"
+    );
+    assert!(cache_file.exists(), "B should have cache file after first fetch");
+
+    // Clone A deletes ITERATION-001 (removes remote ref).
+    store_a
+        .delete(&type_def, "ITERATION-001")
+        .expect("delete iteration on A");
+
+    // Clone B fetches again; with --prune the local ref should disappear
+    // and the cache cleanup loop should remove the cache file.
+    run_fetch(clone_b.path(), &config).expect("second fetch on B");
+
+    assert_eq!(
+        git.resolve_ref(clone_b.path(), refname).unwrap(),
+        None,
+        "B's local doc ref should be pruned after fetch"
+    );
+    assert!(
+        !cache_file.exists(),
+        "B's cache file should be removed after fetch prunes the ref"
+    );
+}
+
+#[test]
+fn update_rolls_back_on_push_rejection_then_recovers_after_fetch() {
+    // AC3: Two clones diverge on the same doc. A pushes first, B's update
+    // is rejected (non-FF). B's local state must roll back cleanly so a
+    // subsequent fetch + retry succeeds against A's accepted version.
+    let (fixture_a, bare) = common::TestFixture::with_git_remote();
+    let clone_b = make_clone_b(bare.path());
+
+    let config = config_with_git_ref_iteration();
+    let type_def = iteration_type_def(&config);
+    let refname = "refs/lazyspec/iteration/ITERATION-001";
+    let git = GitCli;
+
+    // Bootstrap: A creates ITERATION-001 (status=draft) and pushes it.
+    let mut store_a = GitRefStore {
+        git: GitCli,
+        root: fixture_a.root().to_path_buf(),
+        config: config.clone(),
+        reserved_number: Some(1),
+    };
+    store_a
+        .create(&type_def, "First Iteration", "agent-a", "body")
+        .expect("create iteration on A");
+
+    let draft_sha = git
+        .resolve_ref(fixture_a.root(), refname)
+        .unwrap()
+        .expect("A has draft ref");
+
+    // B fetches so it sees ITERATION-001 at the draft SHA.
+    run_fetch(clone_b.path(), &config).expect("B initial fetch");
+    assert_eq!(
+        git.resolve_ref(clone_b.path(), refname).unwrap(),
+        Some(draft_sha.clone()),
+        "B's local ref should be at draft SHA after first fetch"
+    );
+    let lock_b = lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
+    assert_eq!(
+        lock_b.get("iteration/ITERATION-001"),
+        Some(draft_sha.as_str()),
+        "B's cache.lock should be at draft SHA"
+    );
+    let cache_file_b = clone_b
+        .path()
+        .join(".lazyspec/cache/iteration/ITERATION-001.md");
+    let draft_cache_content = std::fs::read_to_string(&cache_file_b).unwrap();
+    assert!(
+        draft_cache_content.contains("status: draft"),
+        "B's cache file should reflect draft status, got: {}",
+        draft_cache_content
+    );
+
+    // A updates ITERATION-001 to status=accepted. Push succeeds; remote advances.
+    store_a
+        .update(&type_def, "ITERATION-001", &[("status", "accepted")])
+        .expect("A updates to accepted and pushes");
+    let accepted_sha = git
+        .resolve_ref(fixture_a.root(), refname)
+        .unwrap()
+        .expect("A has accepted ref");
+    assert_ne!(accepted_sha, draft_sha);
+
+    // B (stale; still parented on draft) tries to update to status=review.
+    // The local CAS succeeds, but the push is rejected (non-FF) by real git.
+    // The Task 2 rollback should restore B's local ref to draft, and the
+    // cache file + cache.lock save are skipped, so they stay at draft.
+    let mut store_b = GitRefStore {
+        git: GitCli,
+        root: clone_b.path().to_path_buf(),
+        config: config.clone(),
+        reserved_number: None,
+    };
+    let result = store_b.update(&type_def, "ITERATION-001", &[("status", "review")]);
+    assert!(
+        result.is_err(),
+        "B's first update should fail (non-fast-forward push)"
+    );
+
+    let lock_b_after_fail =
+        lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
+    let lock_sha_after_fail = lock_b_after_fail
+        .get("iteration/ITERATION-001")
+        .expect("lock entry should still exist");
+    assert_eq!(
+        lock_sha_after_fail, draft_sha,
+        "B's cache.lock should still hold the pre-attempt (draft) SHA"
+    );
+    let local_ref_after_fail = git
+        .resolve_ref(clone_b.path(), refname)
+        .unwrap()
+        .expect("B's local ref should still exist after rollback");
+    assert_eq!(
+        local_ref_after_fail, draft_sha,
+        "B's local ref should equal cache.lock SHA (rollback restored draft)"
+    );
+    let cache_after_fail = std::fs::read_to_string(&cache_file_b).unwrap();
+    assert_eq!(
+        cache_after_fail, draft_cache_content,
+        "B's cache file content must be unchanged after the failed update"
+    );
+
+    // B fetches: --prune brings the remote's accepted ref down via FF; cache
+    // file and cache.lock get updated to the accepted SHA.
+    run_fetch(clone_b.path(), &config).expect("B recovery fetch");
+    assert_eq!(
+        git.resolve_ref(clone_b.path(), refname).unwrap(),
+        Some(accepted_sha.clone()),
+        "B's local ref should now be at A's accepted SHA"
+    );
+    let lock_b_after_fetch =
+        lazyspec::engine::cache_lock::CacheLock::load(clone_b.path()).unwrap();
+    assert_eq!(
+        lock_b_after_fetch.get("iteration/ITERATION-001"),
+        Some(accepted_sha.as_str()),
+        "B's cache.lock should track A's accepted SHA after fetch"
+    );
+
+    // B retries the update; now parented on accepted, the push succeeds.
+    store_b
+        .update(&type_def, "ITERATION-001", &[("status", "review")])
+        .expect("B's retry update should succeed after fetch");
+
+    let b_final_sha = git
+        .resolve_ref(clone_b.path(), refname)
+        .unwrap()
+        .expect("B has final ref");
+    assert_ne!(b_final_sha, accepted_sha);
+
+    // Remote should now equal B's commit, chained on top of accepted.
+    let bare_resolved = Command::new("git")
+        .args(["rev-parse", refname])
+        .current_dir(bare.path())
+        .output()
+        .expect("git rev-parse on bare");
+    assert!(bare_resolved.status.success());
+    let bare_sha = String::from_utf8_lossy(&bare_resolved.stdout)
+        .trim()
+        .to_string();
+    assert_eq!(
+        bare_sha, b_final_sha,
+        "remote ref should equal B's final commit"
+    );
+
+    let parent_out = Command::new("git")
+        .args(["rev-parse", &format!("{}^", b_final_sha)])
+        .current_dir(clone_b.path())
+        .output()
+        .expect("git rev-parse parent");
+    assert!(parent_out.status.success());
+    let b_parent = String::from_utf8_lossy(&parent_out.stdout).trim().to_string();
+    assert_eq!(
+        b_parent, accepted_sha,
+        "B's final commit should be parented on A's accepted commit"
+    );
+}
+
+#[test]
+fn fetch_prunes_deleted_remote_lease_refs_so_claim_succeeds() {
+    // AC2: After release from clone A and claim from clone B,
+    // B sees no stale local lease ref and the claim succeeds.
+    let (fixture_a, bare) = common::TestFixture::with_git_remote();
+    let clone_b = make_clone_b(bare.path());
+
+    let config = config_with_git_ref_iteration();
+    let coord = config.coordination.clone().unwrap();
+    let type_def = iteration_type_def(&config);
+
+    // Bootstrap: clone A creates ITERATION-001 doc so a lease can target it.
+    {
+        let mut store_a = GitRefStore {
+            git: GitCli,
+            root: fixture_a.root().to_path_buf(),
+            config: config.clone(),
+            reserved_number: Some(1),
+        };
+        store_a
+            .create(&type_def, "First Iteration", "agent-a", "body")
+            .expect("create iteration on A");
+    }
+
+    let lease_ref = "refs/lazyspec/leases/iteration/ITERATION-001";
+    let git = GitCli;
+
+    // Clone A claims ITERATION-001 (pushes lease ref).
+    let engine_a = LeaseEngine::new(GitCli, coord.clone());
+    engine_a
+        .acquire(
+            fixture_a.root(),
+            "iteration",
+            "ITERATION-001",
+            "agent-a",
+            Utc::now(),
+        )
+        .expect("A acquires lease");
+
+    // Clone B fetches lease refs so it sees the existing lease locally.
+    git.fetch_refs(clone_b.path(), "origin", "refs/lazyspec/leases/*")
+        .expect("B fetches leases");
+    assert!(
+        git.resolve_ref(clone_b.path(), lease_ref).unwrap().is_some(),
+        "B should have lease ref locally after fetch"
+    );
+
+    // Clone A releases ITERATION-001 (deletes remote lease ref).
+    engine_a
+        .release(fixture_a.root(), "iteration", "ITERATION-001", "agent-a")
+        .expect("A releases lease");
+
+    // Clone B claims ITERATION-001. With --prune in fetch_refs the stale
+    // local lease ref disappears during the engine's pre-acquire fetch,
+    // so acquire() should succeed without a "lease held" error.
+    let engine_b = LeaseEngine::new(GitCli, coord);
+    let lease_b = engine_b
+        .acquire(
+            clone_b.path(),
+            "iteration",
+            "ITERATION-001",
+            "agent-b",
+            Utc::now(),
+        )
+        .expect("B claim should succeed after A released");
+
+    assert_eq!(lease_b.agent, "agent-b");
+}


### PR DESCRIPTION
## Summary
- Roll back local ref via reverse CAS when remote push fails in `update`/`set_provenance`, so cache file and `cache.lock` only commit when push succeeds.
- Preserve local state in `delete` when remote delete fails (don't drop the cache file or local ref).
- Fetch lease refs with a glob refspec so `--prune` (added to `fetch_refs`) cleans up stale local lease refs that no longer exist on the remote.

## Test plan
- [x] `cargo test` — new tests in `git_ref_store.rs` and `tests/fetch_prune_test.rs`
- [ ] Manual: concurrent lease grab where remote push is rejected leaves no half-applied state