### PR TITLE
fix: lease remote-first push + heartbeat throttle + CC hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sqids = "0.4"
 pulldown-cmark = "0.13"
 indicatif = "0.17"
 textwrap = "0.16"
+tempfile = "3"
 
 [features]
 default = []
@@ -37,4 +38,3 @@ agent = []
 metrics = []
 
 [dev-dependencies]
-tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -80,17 +80,16 @@ Add the appropriate line to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) t
 
 Lazyspec includes a set of agent skills that enforce its workflow:
 
-| Skill              | Purpose                                                              |
-| ------------------ | -------------------------------------------------------------------- |
-| `plan-work`        | Detect existing artifacts and determine the right entry point       |
+| Skill              | Purpose                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `plan-work`        | Detect existing artifacts and determine the right entry point          |
 | `write-rfc`        | Propose a design with intent, interface sketches, and identify stories |
-| `create-story`     | Create stories with acceptance criteria linked to an RFC             |
-| `resolve-context`  | Gather full document chain (RFC -> Story -> Iteration) before work  |
-| `create-iteration` | Plan an iteration with task breakdown and test plan                 |
-| `build`            | Implement tasks from an iteration with subagent dispatch             |
-| `review-iteration` | Two-stage review -- AC compliance first, then code quality           |
-| `create-audit`     | Criteria-based review (health check, security, accessibility, etc.)  |
-
+| `create-story`     | Create stories with acceptance criteria linked to an RFC               |
+| `resolve-context`  | Gather full document chain (RFC -> Story -> Iteration) before work     |
+| `create-iteration` | Plan an iteration with task breakdown and test plan                    |
+| `build`            | Implement tasks from an iteration with subagent dispatch               |
+| `review-iteration` | Two-stage review -- AC compliance first, then code quality             |
+| `create-audit`     | Criteria-based review (health check, security, accessibility, etc.)    |
 
 ## Usage
 
@@ -170,6 +169,61 @@ All three subcommands accept `--json`. Shapes:
 - `list` (no id): `{ "documents": [{ "id": "...", "path": "...", "provenance": [...] }, ...] }`
 
 `add` rejects empty citations. `remove` is exact-match and errors when the citation is absent.
+
+## Coordination
+
+### Claude Code Hooks
+
+Lazyspec ships hook snippets that claim, heartbeat, and release a lease on `$ASSIGNED_TASK` across a Claude Code session. The orchestrator (daemon, manual `export`, etc.) sets the env var; hooks no-op silently when it is unset, so the snippet is safe to install unconditionally.
+
+Drop into `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec claim \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec heartbeat \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --min-interval 15m --json || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec release \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The standalone file lives at [`hooks/claude-code-settings.json`](hooks/claude-code-settings.json).
+
+**`$ASSIGNED_TASK` contract.** Orchestrator sets it to a doc id (e.g. `ITERATION-170`). If unset, the `[ -n "$ASSIGNED_TASK" ]` guard short-circuits and no `lazyspec` invocation happens.
+
+**Throttle.** `--min-interval 15m` matches the default `lease_duration / 4` (lease defaults to 60m). If you tune `lease_duration` in `.lazyspec.toml`, tune this to roughly a quarter of it.
+
+**Error tolerance.** `|| true` swallows non-zero exits from `lazyspec` (e.g. lease already released, network blip), so a session never fails to end because of a coordination error.
+
+See [RFC-035](docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md) for the design rationale.
 
 </details>
 
@@ -281,10 +335,10 @@ severity = "error"
 
 Document numbers are assigned automatically during `create`. Three strategies are available per type:
 
-| Strategy      | Behaviour |
-|---------------|-----------|
-| `incremental` | Next sequential integer from existing files (default) |
-| `sqids`       | Short hash-like IDs derived from a timestamp, configured via `[numbering.sqids]` |
+| Strategy      | Behaviour                                                                                 |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `incremental` | Next sequential integer from existing files (default)                                     |
+| `sqids`       | Short hash-like IDs derived from a timestamp, configured via `[numbering.sqids]`          |
 | `reserved`    | Reserves numbers on a git remote before creating files, preventing distributed collisions |
 
 Reserved numbering uses git custom refs (`refs/reservations/*`) to coordinate across branches. It wraps either incremental or sqids formatting with an atomic push-based lock, so two people never get the same number.

--- a/docs/audits/AUDIT-016-distributed-lease-protocol-safety-review.md
+++ b/docs/audits/AUDIT-016-distributed-lease-protocol-safety-review.md
@@ -1,0 +1,291 @@
+---
+title: Distributed lease protocol safety review
+type: audit
+status: draft
+author: jkaloger
+date: 2026-05-11
+tags:
+- leasing
+- distributed
+- safety
+related:
+- related-to: RFC-035
+---
+
+## Scope
+
+Distributed safety review of the lease engine introduced by RFC-035. Covers `acquire`, `release`, `heartbeat`, `force_acquire`, and `query` against the protocol's stated safety properties (linearization at remote, fetch-before-check, clock-skew tolerance, partition behaviour, initial-ref CAS).
+
+Subjects:
+
+- `src/engine/lease.rs` — protocol logic
+- `src/engine/git_ref.rs` — `GitRefOps` implementation (CAS primitives, push semantics)
+- RFC-035 §"Distributed Safety Properties" — claims being audited
+
+Audit type: protocol-simulation safety review. Six simulation scenarios run as parallel subagents over an extracted operation model (concurrent acquire, stale local state, clock skew, crash between steps, heartbeat vs force-acquire, network partition).
+
+## Protocol model (as implemented)
+
+```
+acquire(type, id, agent, now):
+  1. fetch_refs(REMOTE, "refs/lazyspec/leases/{type}/*", --prune)  # REMOTE, glob fetch+prune
+  2. resolve_ref(refname) -> existing                              # LOCAL
+  3. if existing != None: bail "lease held"                        # LOCAL gate
+  4. create_ref_commit(refname, [lease.json])                      # LOCAL: update-ref refname commit_sha 0000...0000
+  5. push_ref(REMOTE, refname)                                     # REMOTE: plain `git push` (NO --force, NO --force-with-lease)
+
+release(type, id, agent):
+  1. fetch_refs(REMOTE, refname)                                   # REMOTE, single-ref fetch (no prune scope)
+  2. resolve_ref(refname) -> sha                                   # LOCAL
+  3. read_ref_blob, verify holder                                  # LOCAL gate
+  4. delete_remote_ref(REMOTE, refname) via `git push :refname`    # REMOTE blind delete (no CAS)
+  5. delete_ref(refname)                                           # LOCAL blind delete
+
+heartbeat(type, id, agent, now):
+  1. resolve_ref(refname) -> old_sha                               # LOCAL ONLY, NO FETCH
+  2. read_ref_blob, verify holder                                  # LOCAL gate
+  3. create_commit(parent=old_sha) -> new_sha                      # LOCAL
+  4. update_ref(refname, new_sha, old_sha)                         # LOCAL CAS (already mutates local)
+  5. push_ref(REMOTE, refname)                                     # REMOTE: plain push, no CAS
+
+force_acquire(type, id, agent, now):
+  1. fetch_refs(REMOTE, refname)                                   # REMOTE
+  2. resolve_ref, read_ref_blob                                    # LOCAL
+  3. read_commit_timestamp(sha) -> last_touched                    # client-side committer date, baked into commit SHA
+  4. if now <= last_touched + duration + grace: bail               # LOCAL gate, caller's local clock
+  5. create_commit(parent=sha)                                     # LOCAL
+  6. push_ref_with_lease(REMOTE, expected_old=sha)                 # REMOTE CAS via --force-with-lease
+  7. update_ref(refname, new_sha, sha)                             # LOCAL CAS (after remote)
+```
+
+Asymmetries that drive the findings below:
+
+- `acquire`: relies on plain-push rejection of non-fast-forward against an existing remote ref for mutual exclusion. No explicit remote CAS at step 5.
+- `release`: deletes remote without CAS. Verification is against the LOCAL blob.
+- `heartbeat`: no fetch. Local-CAS mutates local state BEFORE the remote push. Remote push has no CAS. Pushing to a deleted remote ref CREATES it.
+- `force_acquire`: only operation that performs remote CAS (via `--force-with-lease`) and orders remote-before-local.
+- `read_commit_timestamp` is the committer date of the lease commit, written by the client at `commit-tree` time. `GIT_COMMITTER_DATE` is not set anywhere in the codebase.
+
+## Criteria
+
+RFC-035 §"Distributed Safety Properties":
+
+1. Linearization points: all writes use CAS at the git ref level.
+2. Fetch-before-check: lease gate fetches from remote before checking lease state.
+3. Clock-skew tolerance: `grace_period` absorbs NTP drift; commit timestamps used as expiry reference (RFC says "server-side, written at push time").
+4. Network partition: local commits succeed, push fails, agent continues locally with a warning, coordination resumes on heal.
+5. Initial ref creation: CAS with all-zeros SHA prevents two agents both seeing "ref does not exist" and both creating.
+
+Each finding tags which property it violates.
+
+## Findings
+
+### Finding 1: Phantom lease resurrection via heartbeat
+
+**Severity:** critical
+**Location:** `src/engine/lease.rs:139-171` (`heartbeat`), `src/engine/git_ref.rs:213-220` (`push_ref`)
+**Property violated:** 1 (linearization at remote), 2 (fetch-before-check).
+
+**Description.** Heartbeat does not fetch. Its remote push is a plain `git push origin refname` with no CAS. When the remote ref no longer exists (because another agent legitimately force-acquired and then released, or because the holder's own release partially failed), the heartbeat push CREATES the remote ref pointing at the heartbeating agent's stale lease commit. The agent silently resurrects a lease nobody granted.
+
+Reachable interleaving:
+
+1. Agent A acquires STORY-001. Lease ref exists on remote.
+2. A's lease expires. Agent B `force_acquire`s; remote ref now points at B's commit.
+3. B `release`s; remote ref deleted.
+4. A is still alive (orchestrator's heartbeat timer was not cancelled, or A never observed step 2). A's local ref still points at A's original lease commit.
+5. A's heartbeat fires: local resolve returns A's sha, local blob still says holder=A, local CAS succeeds, push to non-existent remote ref CREATES it.
+6. Daemon C polls, sees the (resurrected) lease, skips dispatching STORY-001.
+
+Window: the entire heartbeat interval between B's release and A's next fetch. Heartbeat performs no fetches, so the window is unbounded in normal operation.
+
+**Recommendation.** Change heartbeat step 5 from `git push` to `git push --force-with-lease=refname:<old_sha>`. `--force-with-lease` with a non-zero expected sha requires the remote ref to currently equal `old_sha`; an absent remote ref fails the lease and the push is rejected. Equivalent framing: heartbeat is an UPDATE, never a CREATE. This single change also closes finding 5 (heartbeat-vs-force-acquire local divergence on the B-then-A push ordering).
+
+---
+
+### Finding 2: Lease squat via `GIT_COMMITTER_DATE`
+
+**Severity:** critical
+**Location:** `src/engine/git_ref.rs:112-165` (`create_commit`), `src/engine/lease.rs:190-196` (force-acquire gate)
+**Property violated:** 3 (clock-skew tolerance; the RFC claim that timestamps are "server-side, written at push time" is false — committer date is client-side, baked into the commit SHA).
+
+**Description.** The force-acquire gate is `now <= last_touched + duration + grace` where `last_touched = read_commit_timestamp(sha)` is the committer date in the commit object. `GIT_COMMITTER_DATE` is honoured by `git commit-tree` and is not pinned by the codebase. An agent (malicious or misconfigured) can write a lease commit with `GIT_COMMITTER_DATE=+99h`, after which every other agent's force-acquire gate evaluates `now <= +99h + 62m` and bails. The lease becomes effectively permanent until the squatting agent releases it.
+
+`lease.expires` is also written by the holder, also client-clock-derived, but it is currently IGNORED by force-acquire — the gate consults only the commit timestamp.
+
+**Recommendation.** Three layered defences, in priority order:
+
+1. Bound trust in committer dates: reject leases where `commit_ts > local_now + max_allowed_skew` (e.g. 5m). Cheap, defeats the squat scenario.
+2. Cross-gate against `lease.expires` from the blob in addition to commit timestamp; take the max-conservative reading. An attacker now must forge two values.
+3. Long-term: derive expiry from a server-issued signal (e.g. ref-update reflog timestamp, or a separate `refs/lazyspec/expiry/{type}/{id}` ref whose ref-update transaction time is queryable). Note that the RFC's stated mechanism ("commit timestamps, server-side, written at push time") is not implementable with stock git — commit objects are immutable and their timestamps are part of the SHA. The RFC's claim should be corrected.
+
+---
+
+### Finding 3: Asymmetric-partition split-brain with blind release delete
+
+**Severity:** critical
+**Location:** `src/engine/lease.rs:114-137` (`delete_lease`), `src/engine/lease.rs:139-171` (`heartbeat`)
+**Property violated:** 4 (partition behaviour) compounded by 1 (no remote CAS on release).
+
+**Description.** An asymmetric partition where A can fetch but not push admits silent lease theft:
+
+1. A holds the lease. Asymmetric partition begins: A's pushes fail, fetches still work (or A simply doesn't fetch — heartbeat never does).
+2. A heartbeats: local CAS succeeds and mutates local state; push fails with Err. Local now diverges from remote. The function returns Err but the local mutation persists.
+3. From the remote's perspective, A's lease commit timestamp is stale. B force-acquires legitimately (remote = B's commit).
+4. B releases; remote = absent.
+5. Partition heals. A calls `release`. Step 1 fetches a single ref (`fetch_ref_optional(... refname)`), no prune scope. The local ref still points at A's drifted heartbeat chain; if the remote ref is absent, `fetch` of a missing ref does not delete the local ref. A's `resolve_ref` returns the stale local sha.
+6. A reads the local blob (still says holder=A), passes the holder check, and executes `delete_remote_ref` — a blind `git push origin :refname`. Whatever the remote currently holds (a new lease from agent C, who acquired after B released) is deleted.
+
+The blind remote delete is the proximate cause. The heartbeat's local-before-push ordering is the upstream cause that creates the divergence.
+
+**Recommendation.**
+
+1. `release` must use CAS on the remote delete: `git push --force-with-lease=refname:<verified_sha> origin :refname`. The verified sha should come from a `fetch + resolve` round-trip immediately before, not from local stale state.
+2. `release` must fetch with the same glob-prune refspec as `acquire` (`refs/lazyspec/leases/{type}/*`, not a single ref), so absent remote refs prune local stale state.
+3. Reorder `heartbeat`: push BEFORE local update_ref (mirror `force_acquire`'s order). Combined with finding 1's `--force-with-lease`, local state never advances past what the remote accepts.
+
+---
+
+### Finding 4: Clock-skew split-brain beyond `duration + grace`
+
+**Severity:** high
+**Location:** `src/engine/lease.rs:173-211` (`force_acquire`), commit-time derivation
+**Property violated:** 3 (clock-skew tolerance).
+
+**Description.** Define `Δ = clock_skew(force_acquirer) − clock_skew(holder)`. The force-acquire gate triggers when `now_force_acquirer > commit_ts_holder + duration + grace`. In true time, the holder believes the lease is valid until `acquired_true + duration`. Force-acquire fires prematurely when `Δ > duration + grace` — in the default configuration (60m + 2m), 62 minutes of skew between two machines admits split-brain for the difference window.
+
+This is a property of the protocol, not an implementation bug. The RFC asserts `grace_period` "absorbs NTP drift", which is true for tight NTP (sub-second to minutes) but is not a safety guarantee in the presence of pathological skew (laptop suspended for an hour, VM clock drift, deliberate skew). Finding 2 makes adversarial skew trivial.
+
+**Recommendation.** Document the skew budget explicitly: split-brain is reachable iff `|Δ_clocks| > duration + grace_period`. Either:
+
+- Tighten the operational requirement (NTP mandatory; clamp `duration` to a multiple of expected drift).
+- Pair with finding 2's mitigation: reject leases whose `commit_ts` is more than `max_skew` in the future. This bounds Δ from one side.
+- Surface skew in `lazyspec leases` output (compare commit timestamp to local clock; warn if delta exceeds a threshold).
+
+---
+
+### Finding 5: `force_acquire` crash window self-locks the acquirer
+
+**Severity:** high
+**Location:** `src/engine/lease.rs:198-210`
+**Property violated:** crash-safety (implicit in property 1).
+
+**Description.** `force_acquire` pushes (step 6) BEFORE updating the local ref (step 7). If the process crashes between push success and local `update_ref`, the remote points at the acquirer's lease but the local ref still points at the previous holder's commit. On recovery:
+
+- The same agent's next `heartbeat` resolves the local (stale) sha, reads the previous holder's `lease.json`, finds holder mismatch (`holder != self`), and bails with "lease held by X".
+- The agent that ACTUALLY holds the remote lease cannot heartbeat against its own remote state without manual intervention (clear local ref, refetch).
+
+The lease is "owned by no one operationally" until expiry-plus-grace elapses on commit time, at which point another `force_acquire` succeeds.
+
+This is the right ordering for the remote (remote-first ensures local divergence on push failure is benign) but exposes a crash window.
+
+**Recommendation.** On the next operation start by the same agent, run a recovery probe: fetch the lease ref, compare local vs remote. If they differ and remote holder matches `self`, reconcile local. Cheap implementation: heartbeat should fetch as a first step (also fixes finding 1's defence in depth).
+
+---
+
+### Finding 6: Heartbeat-vs-force-acquire local divergence (orphan refs)
+
+**Severity:** medium
+**Location:** `src/engine/lease.rs:139-171`
+**Property violated:** 1 (no remote CAS) and operational hygiene.
+
+**Description.** When A heartbeats while B has force-acquired the lease:
+
+- B's push-with-lease succeeds first: A's subsequent push is rejected non-fast-forward; A's heartbeat returns Err but A's LOCAL ref has already advanced (step 4 ran before step 5). Each subsequent heartbeat extends A's local chain further from remote.
+- On A's next release attempt, the fetch updates local to B's commit. Holder check fails. A bails forever. A's orchestrator never observes that A lost the lease unless it inspects the Err.
+
+This is not a safety violation (B legitimately holds remote, A holds nothing). It is an operational liveness/observability gap: A wastes work, accumulates orphan commits in the local repo, and produces confusing logs.
+
+**Recommendation.** On heartbeat push failure (non-fast-forward), fetch, reset local ref to remote, re-evaluate holder. If `holder != self`, drop the lease cleanly and surface the event to the caller. Finding 1's `--force-with-lease` push closes the safety side of this finding; the liveness side requires the additional fetch-on-failure handler.
+
+---
+
+### Finding 7: `acquire` crash between local update-ref and remote push
+
+**Severity:** medium
+**Location:** `src/engine/lease.rs:62-91`
+**Property violated:** crash-safety.
+
+**Description.** `acquire` updates the local ref (step 4) before pushing (step 5). A crash between the two leaves the local ref pointing at an unpushed lease commit. The next operation by the same agent:
+
+- `heartbeat`: resolves the local sha, reads the local blob (holder matches), creates a heartbeat commit, pushes — to a non-existent remote ref → CREATES it. The agent retroactively wins an acquire it never completed, without re-running the acquire gate (no fetch, no expiry check).
+- `release` or further `acquire`: the next `acquire`'s glob-fetch-with-prune cleans the stale local ref (because remote has nothing matching). Self-healing IF the next op is acquire.
+
+The hazard is the heartbeat path. If another agent acquired in the crash window, that agent's push happened first; A's heartbeat push is then non-fast-forward and rejected — safe. The unsafe case is the empty-remote window: no other actor acquired, A's heartbeat resurrects the lease.
+
+**Recommendation.** Push first, then local update-ref (mirror `force_acquire`). On push failure, do not advance local. Alternatively, on agent startup, audit local lease refs that have no remote counterpart and prune them.
+
+---
+
+### Finding 8: `release` does not glob-fetch with prune
+
+**Severity:** medium
+**Location:** `src/engine/lease.rs:122-127`, contrast with `src/engine/lease.rs:73-74`
+**Property violated:** 2 (fetch-before-check is weaker on release than on acquire).
+
+**Description.** `acquire` uses a glob refspec `refs/lazyspec/leases/{type}/*` so that `git fetch --prune` removes stale local refs whose remote counterparts are gone. `release` and `heartbeat`/`force_acquire`'s delete path use a single-ref fetch (`fetch_ref_optional(... refname)`). A single-ref fetch with `--prune` only prunes within the explicit refspec, not across the namespace; if the remote ref is absent, the local ref is NOT pruned. This is the precondition for finding 3.
+
+**Recommendation.** `delete_lease` and `force_acquire` should fetch the same glob refspec used by `acquire` so absent-on-remote refs are pruned locally before resolution.
+
+---
+
+### Finding 9: `release` blind delete (no CAS)
+
+**Severity:** medium (narrow), high (when triggered)
+**Location:** `src/engine/lease.rs:133-136`, `src/engine/git_ref.rs:222-230`
+**Property violated:** 1 (linearization at remote).
+
+**Description.** `delete_remote_ref` is `git push origin :refname` — deletes the remote ref regardless of its current value. Verification is against the LOCAL blob (`lease.agent == expected_agent`). If local is stale (finding 3 + finding 8), a release operation can delete another agent's legitimate lease.
+
+The current `fetch_ref_optional` only swallows "couldn't find remote ref" — network errors bubble. So the practical likelihood requires either an asymmetric partition (finding 3), an alternates corruption that returns success-but-stale, or a prune-scope gap (finding 8). With finding 8 unaddressed, the trigger is reachable in normal operation.
+
+**Recommendation.** `delete_remote_ref` should grow an `expected_old` parameter and use `git push --force-with-lease=refname:<sha> origin :refname`. The CLI primitive exists; `push_ref_with_lease` is already implemented for `force_acquire`. The release path should plumb the verified sha through.
+
+---
+
+### Finding 10: Partition narrative mismatches implementation
+
+**Severity:** low (documentation), but compounds findings 1/3/5
+**Location:** RFC-035 §"Network partition behaviour" vs `src/engine/lease.rs`
+**Property violated:** 4 (RFC claim vs implementation).
+
+**Description.** RFC-035 states: "During a partition, local ref commits succeed but push fails. The lease gate falls back to local refs with a warning, allowing the agent to continue working locally." This narrative is implemented ONLY in `query` (`lease.rs:214-219`, which prints `eprintln!` and proceeds with local list). It is NOT implemented in `acquire`, `release`, `heartbeat`, or `force_acquire`:
+
+- `acquire`/`release`/`force_acquire`: network errors from `fetch_ref_optional` bubble; the operation fails hard.
+- `heartbeat`: never fetches, so it has no partition signal. Local-CAS mutates local state before the push fails. The function returns Err but local has already advanced — the worst-of-both-worlds outcome that drives finding 6 and feeds finding 3.
+
+**Recommendation.** Either (a) implement the RFC narrative consistently — add an explicit "local-only mode" that surfaces a structured warning and a `pushed: false` flag, so the daemon can choose policy; or (b) revise RFC-035 to state that lease operations require remote connectivity and document the operational consequences. The `query` path's current "warning + local fallback" should be considered the exception, not the design contract.
+
+---
+
+### Finding 11: `acquire` initial-create relies on side-effect of plain push
+
+**Severity:** low (UX/diagnostics; safety holds)
+**Location:** `src/engine/lease.rs:87-89`, `src/engine/git_ref.rs:213-220`
+**Property violated:** 5 (initial ref CAS).
+
+**Description.** RFC-035 specifies "CAS with all-zeros SHA" for initial ref creation. The implementation uses plain `git push origin refname`, which succeeds when the remote ref is absent and fails as non-fast-forward when it exists. Safety holds — the remote serializes ref updates and the second concurrent push is rejected. But:
+
+- The implementation conflates "remote rejected because the ref already exists" with "network/push failed for some other reason". Error class is muddied.
+- The RFC's "all-zeros SHA" wording suggests explicit CAS at the push, which is `--force-with-lease=refname:0000...0000`. The current code uses CAS only at the LOCAL update-ref (`create_ref_commit` calls `update-ref refname commit_sha 0000...0000` locally) — local mutual exclusion within one clone, not across clones.
+
+**Recommendation.** Either (a) route the initial acquire push through `push_ref_with_lease(expected_old=None)` (which already exists and emits `--force-with-lease=refname` with no expected value — but semantically this is closer to "I expect nothing specific"; needs the zero-sha form) or (b) extend `push_ref_with_lease` to accept a `Some("0000...0000")` and document this as the canonical initial-acquire form. Distinguishes "lease held" from "push failed" errors cleanly.
+
+---
+
+## Summary
+
+The lease engine has the right shape for one operation (`force_acquire`: remote CAS, remote-before-local, fetch-before-gate) and an inconsistent shape elsewhere. The recurring root cause is that `heartbeat` and `release` perform remote writes without CAS, and `heartbeat` skips the fetch entirely. This creates three reachable split-brain or resurrection paths (findings 1, 3, plus the time-skew variant in 4) and several smaller hygiene issues.
+
+Priority order if all findings are taken:
+
+1. Finding 1 (heartbeat must `--force-with-lease`; closes findings 1 and most of 6).
+2. Finding 3 (release must fetch-with-prune and delete-with-CAS; closes findings 8 and 9; closes finding 3 split-brain).
+3. Finding 2 (committer-date sanity check; closes the squat vector and bounds finding 4).
+4. Finding 5/7 (crash-window cleanup; small recovery probe at op start, or fetch-on-heartbeat).
+5. Finding 10 (RFC alignment; either implement the narrative or revise it).
+6. Finding 11 (explicit zero-sha CAS for initial acquire; cosmetic but improves error classes).
+
+Findings 1, 2, and 3 are independently CRITICAL. They are reachable in normal operation (not edge cases requiring exotic failure modes) and the failure mode is silent: agents and the daemon observe a "valid" lease state that violates the protocol's safety invariant. A single root-cause fix (`--force-with-lease` on every remote write that targets an existing ref, with explicit zero-sha for creates) closes most of the surface.
+
+Findings are presented for triage. Use `/create-iteration` against any subset the user selects.

--- a/docs/iterations/ITERATION-169-heartbeat-min-interval-throttle.md
+++ b/docs/iterations/ITERATION-169-heartbeat-min-interval-throttle.md
@@ -1,7 +1,7 @@
 ---
 title: Heartbeat --min-interval throttle
 type: iteration
-status: draft
+status: accepted
 author: agent
 date: 2026-05-11
 tags:

--- a/docs/iterations/ITERATION-169-heartbeat-min-interval-throttle.md
+++ b/docs/iterations/ITERATION-169-heartbeat-min-interval-throttle.md
@@ -1,0 +1,77 @@
+---
+title: Heartbeat --min-interval throttle
+type: iteration
+status: draft
+author: agent
+date: 2026-05-11
+tags:
+- leasing
+- cli
+related:
+- implements: STORY-120
+---
+
+## Context
+
+STORY-120 ACs 4-7. Hook fires per tool call. Full heartbeat = fetch+commit+push every call. Need throttle so hook stays one-liner.
+
+State file `.lazyspec/state/heartbeat-{type}-{id}`. Contents: RFC3339 UTC. Atomic write (temp+rename). One file per task. Gitignored.
+
+Out of slice: hook scripts (ACs 1-3, 8-9). Separate iteration.
+
+## Changes
+
+1. **Add `--min-interval` flag to `Commands::Heartbeat`** — `src/cli.rs:323-333`. Field `min_interval: Option<String>` after `agent_id`. Doc: "Skip heartbeat if last run within duration (e.g. 15m). State in .lazyspec/state/".
+
+2. **Plumb flag in main.rs** — `src/main.rs:443-462`. Add `min_interval` to destructure + pass through to `run_heartbeat`.
+
+3. **Throttle logic in `run_heartbeat`** — `src/cli/lease.rs:203-226`. Signature gains `min_interval: Option<&str>`. Before engine call:
+   - If `min_interval` None → run unconditionally (preserves AC6).
+   - Parse via `crate::engine::lease::parse_duration`.
+   - State path: `root.join(".lazyspec/state").join(format!("heartbeat-{}-{}", type_name, doc_id))`.
+   - Read file if exists. Parse RFC3339. If `now - last < interval` → skip path: JSON emits `{"skipped": true, "reason": "throttled", "last": "<ts>"}`, non-JSON prints `Heartbeat ITERATION-042 skipped (throttled, last <ts>)`. Return Ok.
+   - Else run engine heartbeat. On success: ensure dir, write current `Utc::now().to_rfc3339()` to temp file, rename.
+   - State file write failure → log warn to stderr, don't fail the operation.
+
+4. **Gitignore `.lazyspec/state/`** — `src/cli/init.rs:69`. Extend `GITIGNORE_ENTRIES` with `.lazyspec/state/`. Predicate at line 72 must trigger when EITHER github-issues OR coordination is configured. Add `has_coordination()` or use `config.coordination.is_some()`. Simplest: gate the gitignore write on `has_github_issues_types() || config.coordination.is_some()`.
+
+5. **Unit tests** — `src/cli/lease.rs` test mod. New tests below.
+
+## Test Plan
+
+Test seam: `run_heartbeat` already injects `LeaseEngine<R: GitRefOps>` via `require_coordination`. For state-file tests, use `TempDir` for root; production `GitCli` not exercised. Engine path mocked through `MockGitRefClient` (existing pattern, lease.rs:236).
+
+Refactor: extract `run_heartbeat_with<R: GitRefOps>(root, config, engine, doc_id, agent_id, min_interval, json)` mirroring `check_lease_gate_with`. Public `run_heartbeat` builds real engine and delegates. Lets tests pass a mock engine and a real `TempDir`.
+
+Tests (unit, `#[cfg(test)] mod tests` in lease.rs):
+
+1. `heartbeat_without_min_interval_runs_unconditionally` — AC6. No state file. Mock engine returns lease. Assert engine called.
+
+2. `heartbeat_skips_when_last_run_within_interval` — AC4. Pre-seed `.lazyspec/state/heartbeat-iteration-ITERATION-042` with `now - 5m`. min_interval=15m. Assert: engine NOT called (mock records zero heartbeat calls), JSON output contains `"skipped":true`.
+
+3. `heartbeat_runs_when_state_file_older_than_interval` — AC5. Pre-seed state with `now - 30m`. min_interval=15m. Assert engine called, state file timestamp updated to ~now.
+
+4. `heartbeat_runs_when_state_file_absent` — AC5. No state file. min_interval=15m. Engine called. State file created with current timestamp.
+
+5. `heartbeat_state_file_written_atomically` — assert no `.tmp` residue after run; final file present.
+
+6. `heartbeat_state_write_failure_does_not_fail_command` — chmod state dir read-only, run heartbeat. Engine call succeeds, command exits 0, stderr warns. (Skip on platforms where chmod doesn't apply; gate on `#[cfg(unix)]`.)
+
+7. `heartbeat_skipped_path_emits_json_skipped_true` — AC4 JSON shape exactness.
+
+Gitignore tests in `src/cli/init.rs`:
+
+8. `gitignore_includes_state_when_coordination_configured` — config with coordination present, no github-issues types. Assert `.lazyspec/state/` line in output.
+
+9. `gitignore_includes_state_when_git_ref_type_configured` — git-ref type + coordination, no github-issues. Same assertion.
+
+10. `gitignore_omits_state_when_no_coordination_and_no_github_issues` — filesystem-only, no coordination. No `.lazyspec/state/` entry.
+
+All tests: `tempfile::TempDir`, fixed timestamps (no `Utc::now()` in assertions; inject via test helper that overrides via param). For throttle, take `now: DateTime<Utc>` as a parameter on the testable helper.
+
+## Notes
+
+- State filename uses `{type}-{id}` to avoid collision if two task ids ever share a prefix across types. Cheap; if `id` already encodes type (e.g. `ITERATION-042`), the type prefix is redundant but harmless.
+- `parse_duration` already exists in `src/engine/lease.rs:18`. Reuse.
+- Atomic write pattern: `tempfile::NamedTempFile::new_in(state_dir)?.persist(target)?` or manual temp+rename. Pick the simpler one.
+- AC4 says JSON output `{"skipped": true, "reason": "throttled"}`. Engine `Lease` serialization is unaffected on run-path; only skip-path emits this shape. CLI must distinguish at the `println!` site.

--- a/docs/iterations/ITERATION-170-claude-code-hook-snippets-and-setup-docs.md
+++ b/docs/iterations/ITERATION-170-claude-code-hook-snippets-and-setup-docs.md
@@ -1,0 +1,101 @@
+---
+title: Claude Code hook snippets and setup docs
+type: iteration
+status: accepted
+author: agent
+date: 2026-05-11
+tags:
+- hooks
+- claude-code
+- docs
+related:
+- implements: STORY-120
+---
+
+
+
+## Context
+
+STORY-120 ACs 1,2,3,8,9. ITERATION-169 shipped throttle (ACs 4-7). Remaining: hook snippet wiring + docs. No Rust code. Pure doc + example.
+
+Hook = inline shell one-liner in `.claude/settings.json`. Env-only `$ASSIGNED_TASK`. Unset → no-op silent. Post-tool-use + session-end non-zero must not abort session. Hardcoded `--min-interval 15m` (lease/4 of default 60m), doc note to tune.
+
+Claude Code hook schema (verified `.claude/settings.json` in-repo):
+
+```json
+{ "hooks": { "<EventName>": [ { "hooks": [ { "type": "command", "command": "..." } ] } ] } }
+```
+
+Events: `SessionStart`, `PostToolUse`, `SessionEnd`.
+
+## Changes
+
+1. **README hook setup section** — `README.md`. New `### Claude Code Hooks` under `## Skills` (line 79) or new `## Coordination` section near end. Pick: insert after `## Skills` block, before `## Usage` (line 95). Content:
+   - Heading + 2-line intro.
+   - `.claude/settings.json` snippet (full 3 hooks, copy-pasteable).
+   - `$ASSIGNED_TASK` contract: orchestrator sets it, unset → hooks no-op.
+   - `--min-interval 15m` note: tune to `lease_duration / 4`.
+   - Non-zero exit guard: `|| true` on PostToolUse/SessionEnd.
+
+   Snippet shape:
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [{
+         "hooks": [{
+           "type": "command",
+           "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec claim \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+         }]
+       }],
+       "PostToolUse": [{
+         "hooks": [{
+           "type": "command",
+           "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec heartbeat \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --min-interval 15m --json || true"
+         }]
+       }],
+       "SessionEnd": [{
+         "hooks": [{
+           "type": "command",
+           "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec release \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+         }]
+       }]
+     }
+   }
+   ```
+
+   `[ -n "$VAR" ] && ... || true` covers ACs 1,2,3,8: env guard short-circuits when unset (AC2), `|| true` swallows non-zero from `lazyspec` so session-end never aborts (AC8). Same pattern for all three; SessionStart can technically drop `|| true` but keep it uniform.
+
+   Cross-reference RFC-035 for design rationale.
+
+2. **Example settings file** — `hooks/claude-code-settings.json` (new, top-level `hooks/` dir). Same JSON as snippet above. Linkable from README. `jq . hooks/claude-code-settings.json` must succeed. Future hook artefacts (other agents, daemon hook helpers) land alongside.
+
+3. **RFC-035 hook section update** — `docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md`. Existing snippet shows bare `lazyspec claim $ASSIGNED_TASK ...` with no env guard, no `--min-interval`, no `|| true`. Update to match README. Add 1-line note: see README + `examples/claude-code-hooks.json`. AC9 satisfied for `docs/` side.
+
+4. **STORY-120 status** — promote `draft` → `accepted` once all ACs verified. Done after review.
+
+## Test Plan
+
+Doc-only iteration. No Rust unit tests. Verification = lint + manual smoke.
+
+1. **AC2 (no-op when unset)** — copy snippet to throwaway shell, `unset ASSIGNED_TASK; bash -c '<command>'; echo $?`. Expect exit 0, no `lazyspec` invocation (verify by adding `set -x` or strace-equivalent; or: replace `lazyspec` in PATH with a fail-loud stub and confirm not called). Document expected output in iteration Notes.
+
+2. **AC1 (SessionStart claim)** — `ASSIGNED_TASK=ITERATION-170 CLAUDE_SESSION_ID=test-1 bash -c '<SessionStart command>'`. Expect `lazyspec claim` runs. Repo must have coordination configured for full exercise; smoke = command resolves and lazyspec gets called.
+
+3. **AC3 (PostToolUse heartbeat with throttle)** — same as AC1 but `lazyspec heartbeat ... --min-interval 15m`. Verifies throttle flag plumbed (already tested in ITERATION-169).
+
+4. **AC8 (SessionEnd release, non-zero tolerated)** — `ASSIGNED_TASK=DOES-NOT-EXIST CLAUDE_SESSION_ID=test-1 bash -c '<SessionEnd command>'`. `lazyspec release` exits non-zero; hook line exits 0 due to `|| true`.
+
+5. **AC9 (docs present)** — manual: grep README + RFC-035 for the snippet. `jq . hooks/claude-code-settings.json` parses.
+
+6. **`lazyspec validate --json`** — passes on iteration + story + RFC-035 after edits.
+
+No automated test seam exists for shell snippets in `.claude/settings.json`. Tradeoff: skip CI coverage; rely on manual smoke + future user-reported breakage. Alternative (rejected): a bats-style test runner — adds dep + CI surface for one-time snippet validation. Not worth it.
+
+## Notes
+
+- Hook command is shell one-liner, not script file. RFC-035 keeps it inline so it stays a copy-paste. No `*.sh` script shipped — `hooks/` holds JSON examples only.
+- `|| true` chosen over `; exit 0` for terseness. Both work.
+- `[ -n "$VAR" ]` chosen over `${VAR:?}` style. POSIX-compatible, no extra deps. Works in bash/zsh/dash.
+- `init` left alone. User declined auto-writing `.claude/settings.json`. Reader copy-pastes from README.
+- `--min-interval 15m` hardcoded. If lease_duration tuned, user edits snippet. Future: `lazyspec hooks emit` could template the snippet from config — out of scope.

--- a/docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
+++ b/docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
@@ -275,14 +275,43 @@ Claude Code hooks automate the coordination lifecycle:
 // .claude/settings.json
 {
   "hooks": {
-    "session-start": "lazyspec claim $ASSIGNED_TASK --agent-id $CLAUDE_SESSION_ID",
-    "post-tool-use": "lazyspec heartbeat $ASSIGNED_TASK --agent-id $CLAUDE_SESSION_ID",
-    "session-end": "lazyspec release $ASSIGNED_TASK --agent-id $CLAUDE_SESSION_ID"
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec claim \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec heartbeat \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --min-interval 15m --json || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec release \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ]
   }
 }
 ```
 
-The orchestrator sets `$ASSIGNED_TASK` when spawning the agent. The hooks handle claim, heartbeat, and release without the agent needing to know about coordination.
+The orchestrator sets `$ASSIGNED_TASK` when spawning the agent. The hooks handle claim, heartbeat, and release without the agent needing to know about coordination. The `[ -n "$ASSIGNED_TASK" ]` guard makes the snippet a no-op when the env var is unset (safe to install unconditionally); `|| true` swallows non-zero exits so a session never fails to end on a coordination error. `--min-interval 15m` matches the default `lease_duration / 4` (lease default 60m) -- tune if `lease_duration` changes.
+
+See README § Claude Code Hooks and [`hooks/claude-code-settings.json`](../../hooks/claude-code-settings.json) for the canonical snippet.
 
 ### Git Ref Operations Trait
 

--- a/docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
+++ b/docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
@@ -317,11 +317,11 @@ The existing reservation module can be migrated to use `GitRefOps` in a follow-u
 
 The distributed lease protocol relies on the following safety properties:
 
-- **Linearization points**: All document writes use CAS (`git update-ref <ref> <new> <old>`) as their linearization point. Lease operations use `push --force-with-lease` for atomic ref swaps. These ensure that concurrent operations are serialized at the git ref level.
-- **Fetch-before-check**: The lease gate fetches from remote before checking lease state, adding one remote round-trip per gated write. This ensures the lease check operates on the latest remote state rather than potentially stale local refs.
-- **Clock skew tolerance**: The `grace_period` (default 2 minutes) absorbs NTP drift between agents. Force-acquire uses commit timestamps (server-side, written at push time) as the expiry reference rather than relying on the acquiring agent's local clock.
-- **Network partition behavior**: During a partition, local ref commits succeed but push fails. The lease gate falls back to local refs with a warning, allowing the agent to continue working locally. Coordination resumes when connectivity is restored and the next push succeeds.
-- **Initial ref creation**: Uses CAS with all-zeros SHA (`0000000000000000000000000000000000000000`) as the expected old value, preventing a TOCTOU race where two agents both see "ref does not exist" and both attempt to create it. Only one push succeeds; the other gets a ref-update rejection.
+- **Linearization point at the remote**: Every lease mutation (`acquire`, `heartbeat`, `release`, `force_acquire`) writes to the remote ref with explicit CAS via `git push --force-with-lease=ref:<expected_old>` before the local ref advances. The local `git update-ref <ref> <new> <old>` is a follow-up cache update, not the linearization point. Operations push first, then update local on success; local never advances past what the remote accepted.
+- **Fetch-before-check (glob, with prune)**: `acquire`, `heartbeat`, `release`, `force_acquire` all fetch `refs/lazyspec/leases/{type}/*` with `--prune` before reading local state. Single-ref fetches leave stale local refs surviving when their remote counterparts have been deleted; glob fetch with prune clears them. The fetch is best-effort: a missing remote ref is benign (treated as "no lease"), other errors propagate.
+- **Clock skew tolerance**: The `grace_period` (default 2m) absorbs NTP drift between honest agents. Force-acquire computes expiry from the commit's committer timestamp; that timestamp is client-written and baked into the commit SHA, so it cannot be rewritten server-side. To bound adversarial or pathological skew, `force_acquire` also rejects leases whose commit timestamp is more than `max_clock_skew` (default 5m) ahead of the caller's local clock. Operationally, agents must be reasonably NTP-synchronized: split-brain is reachable iff `|Δ_clocks| > duration + grace_period`.
+- **Network partition behavior**: Lease mutations require the remote (fetch failures and push failures both abort the operation). The implementation does not silently fall back to local-only writes — a heartbeat under partition returns `Err` rather than advancing local state; an acquire under partition fails before producing any commit. The read-only `query()` is the one exception: a failed fetch is logged and the cached local view is returned. The agent layer is expected to handle these errors (retry with backoff, surface to the daemon, etc.) rather than the engine guessing a partition-tolerance policy.
+- **Initial ref creation**: `acquire` pushes with `--force-with-lease=ref:0000000000000000000000000000000000000000`, requiring the remote ref to be absent. Two agents racing both see "ref does not exist" locally; only one push lands first and creates the ref, the other's CAS expectation (`expected_old = zero`) no longer matches and the push is rejected with a clear stale-info error.
 
 ### Fetch Refspecs
 
@@ -348,6 +348,7 @@ Shallow clones are detected and warned against (`git rev-parse --is-shallow-repo
     lease_duration: String,   // default "60m"
     grace_period: String,     // default "2m"
     max_push_retries: u8,     // default 5
+    max_clock_skew: String,   // default "5m" - bound on committer-date trust during force_acquire
 }
 
 ```toml
@@ -380,6 +381,7 @@ remote = "origin"
 lease_duration = "60m"
 grace_period = "2m"
 max_push_retries = 5
+max_clock_skew = "5m"
 ```
 
 ### Graceful Degradation

--- a/docs/stories/STORY-120-claude-code-lease-hooks-and-heartbeat-throttle.md
+++ b/docs/stories/STORY-120-claude-code-lease-hooks-and-heartbeat-throttle.md
@@ -1,0 +1,78 @@
+---
+title: "Claude Code lease hooks and heartbeat throttle"
+type: story
+status: draft
+author: "jkaloger"
+date: 2026-05-11
+tags:
+- hooks
+- leasing
+- claude-code
+related:
+- implements: docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
+---
+
+## Context
+
+RFC-035 §"Claude Code Hooks" specifies session-start/post-tool-use/session-end hooks that drive lease claim, heartbeat, and release without the agent needing to know about coordination. The engine (Story 108) and storage backend (Story 109) are built. The hook layer is not.
+
+PostToolUse fires per tool invocation. With a 60-minute default lease, that's many redundant fetch/push round-trips per agent. A `--min-interval` flag on `lazyspec heartbeat` lets the hook stay a one-liner while keeping network cost bounded.
+
+Hook task resolution is env-only: `$ASSIGNED_TASK` is set by an orchestrator (future daemon, or manual export). When unset, the hook is a silent no-op so it is safe to install unconditionally via `lazyspec init`. Interactive sessions without an orchestrator are unaffected.
+
+## Acceptance Criteria
+
+- **Given** `$ASSIGNED_TASK=ITERATION-042` and `$CLAUDE_SESSION_ID=abc` are set
+  **When** the `session-start` hook runs
+  **Then** `lazyspec claim ITERATION-042 --agent-id abc --json` executes and exits 0 on success.
+
+- **Given** `$ASSIGNED_TASK` is unset
+  **When** any of the three hooks fires
+  **Then** the hook exits 0 silently with no `lazyspec` invocation and no error output.
+
+- **Given** `$ASSIGNED_TASK=ITERATION-042` and `$CLAUDE_SESSION_ID=abc` are set
+  **When** the `post-tool-use` hook fires
+  **Then** `lazyspec heartbeat ITERATION-042 --agent-id abc --min-interval <lease_duration/4> --json` executes.
+
+- **Given** `lazyspec heartbeat ITERATION-042 --min-interval 15m` was called less than 15 minutes ago and recorded a timestamp at `.lazyspec/state/heartbeat-ITERATION-042`
+  **When** `lazyspec heartbeat ITERATION-042 --min-interval 15m` is invoked again
+  **Then** the command exits 0 with `{"skipped": true, "reason": "throttled"}` on the JSON path and performs no fetch, commit, or push.
+
+- **Given** `.lazyspec/state/heartbeat-ITERATION-042` does not exist or is older than `--min-interval`
+  **When** `lazyspec heartbeat ITERATION-042 --min-interval 15m` runs and the heartbeat succeeds
+  **Then** the state file is written with the current timestamp.
+
+- **Given** `--min-interval` is omitted
+  **When** `lazyspec heartbeat` is called
+  **Then** the heartbeat runs unconditionally (no state read, no throttle).
+
+- **Given** `lazyspec init` runs in a project with at least one lease-using type
+  **When** `.gitignore` is written
+  **Then** `.lazyspec/state/` is present in the ignore list.
+
+- **Given** `$ASSIGNED_TASK=ITERATION-042` and `$CLAUDE_SESSION_ID=abc` are set
+  **When** the `session-end` hook fires
+  **Then** `lazyspec release ITERATION-042 --agent-id abc --json` executes; a non-zero exit (e.g. lease not held) does not abort the session-end path.
+
+- **Given** documentation under `docs/` and the project README
+  **When** a reader looks for hook setup
+  **Then** there is a documented snippet of `.claude/settings.json` covering all three hooks and the `$ASSIGNED_TASK` contract.
+
+## Scope
+
+### In Scope
+
+- `lazyspec heartbeat --min-interval <duration>` flag. Reads/writes `.lazyspec/state/heartbeat-{type}-{id}` (or single file keyed by task id; pick one). Skips remote round-trip when last call was within the interval. `--json` reports skip vs run.
+- `.gitignore` entry for `.lazyspec/state/` added by `lazyspec init` when any lease-using type is configured.
+- Three hook scripts (shell or executable) wired in a `.claude/settings.json` snippet: `session-start`, `post-tool-use`, `session-end`. Env-only `$ASSIGNED_TASK` resolution.
+- Hook scripts no-op when `$ASSIGNED_TASK` is unset. Non-zero `lazyspec` exit in `post-tool-use`/`session-end` must not crash the surrounding session (hook returns 0).
+- README + hook-setup documentation covering install path, env contract, and behaviour when unset.
+
+### Out of Scope
+
+- Auto-detection of `$ASSIGNED_TASK` from a file (`.lazyspec/current-task`) or any non-env source.
+- Daemon/orchestrator that produces `$ASSIGNED_TASK` and spawns Claude Code sessions.
+- TUI lease indicators or claim affordance (separate story).
+- Heartbeat outcome refactor (`Held` / `Lost` / `TransientFailure` enum) — folds in once hook usage demonstrates the need.
+- Recovery probe / fetch-on-failure inside `heartbeat` (audit findings 5/6 liveness).
+- `lazyspec start` interactive task-setting command.

--- a/docs/stories/STORY-120-claude-code-lease-hooks-and-heartbeat-throttle.md
+++ b/docs/stories/STORY-120-claude-code-lease-hooks-and-heartbeat-throttle.md
@@ -1,7 +1,7 @@
 ---
 title: "Claude Code lease hooks and heartbeat throttle"
 type: story
-status: draft
+status: accepted
 author: "jkaloger"
 date: 2026-05-11
 tags:
@@ -11,6 +11,7 @@ tags:
 related:
 - implements: docs/rfcs/RFC-035-git-ref-document-storage-with-lease-based-claiming.md
 ---
+
 
 ## Context
 

--- a/hooks/claude-code-settings.json
+++ b/hooks/claude-code-settings.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec claim \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec heartbeat \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --min-interval 15m --json || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ASSIGNED_TASK\" ] && lazyspec release \"$ASSIGNED_TASK\" --agent-id \"$CLAUDE_SESSION_ID\" --json || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -327,6 +327,9 @@ pub enum Commands {
         /// Agent identity (defaults to auto-resolved agent ID)
         #[arg(long)]
         agent_id: Option<String>,
+        /// Skip heartbeat if last run within duration (e.g. 15m). State in .lazyspec/state/
+        #[arg(long)]
+        min_interval: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -66,10 +66,14 @@ fn ensure_github_labels(config: &Config, root: &Path) {
     }
 }
 
-const GITIGNORE_ENTRIES: &[&str] = &[".lazyspec/cache/", ".lazyspec/issue-map.json"];
+const GITIGNORE_ENTRIES: &[&str] = &[
+    ".lazyspec/cache/",
+    ".lazyspec/issue-map.json",
+    ".lazyspec/state/",
+];
 
 fn ensure_gitignore(config: &Config, root: &Path) -> Result<()> {
-    if !config.documents.has_github_issues_types() {
+    if !config.documents.has_github_issues_types() && config.coordination.is_none() {
         return Ok(());
     }
 
@@ -179,7 +183,7 @@ by agent skills. For example, a dictum about testing philosophy would have
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::config::{StoreBackend, TypeDef};
+    use crate::engine::config::{CoordinationConfig, StoreBackend, TypeDef};
 
     fn gh_issues_config() -> Config {
         let mut config = Config::default();
@@ -187,6 +191,30 @@ mod tests {
             TypeDef::test_fixture("rfc", StoreBackend::Filesystem),
             TypeDef::test_fixture("story", StoreBackend::GithubIssues),
         ];
+        config
+    }
+
+    fn coordination_config() -> CoordinationConfig {
+        CoordinationConfig {
+            remote: "origin".to_string(),
+            lease_duration: "60m".to_string(),
+            grace_period: "2m".to_string(),
+            max_push_retries: 5,
+            max_clock_skew: "5m".to_string(),
+        }
+    }
+
+    fn coordination_only_config() -> Config {
+        let mut config = Config::default();
+        // default types are all Filesystem; ensure no github-issues types are present.
+        config.documents.types = vec![TypeDef::test_fixture("rfc", StoreBackend::Filesystem)];
+        config.coordination = Some(coordination_config());
+        config
+    }
+
+    fn gh_issues_and_coordination_config() -> Config {
+        let mut config = gh_issues_config();
+        config.coordination = Some(coordination_config());
         config
     }
 
@@ -260,5 +288,35 @@ mod tests {
         ensure_gitignore(&config, dir.path()).unwrap();
 
         assert!(!dir.path().join(".gitignore").exists());
+    }
+
+    #[test]
+    fn gitignore_includes_state_when_coordination_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = coordination_only_config();
+
+        ensure_gitignore(&config, dir.path()).unwrap();
+
+        let contents = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(
+            contents.contains(".lazyspec/state/"),
+            "expected .lazyspec/state/ in gitignore, got:\n{}",
+            contents
+        );
+    }
+
+    #[test]
+    fn gitignore_includes_state_when_github_issues_and_coordination() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = gh_issues_and_coordination_config();
+
+        ensure_gitignore(&config, dir.path()).unwrap();
+
+        let contents = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(
+            contents.contains(".lazyspec/state/"),
+            "expected .lazyspec/state/ in gitignore, got:\n{}",
+            contents
+        );
     }
 }

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -297,6 +297,7 @@ mod tests {
                 lease_duration: "60m".to_string(),
                 grace_period: "2m".to_string(),
                 max_push_retries: 5,
+                max_clock_skew: "5m".to_string(),
             }),
         }
     }

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -239,6 +239,7 @@ fn write_heartbeat_state(state_path: &Path, now: DateTime<Utc>) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_heartbeat_with<R: GitRefOps>(
     root: &Path,
     config: &Config,

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -3,9 +3,10 @@ use crate::engine::config::Config;
 use crate::engine::git_ref::{GitCli, GitRefOps};
 use crate::engine::lease::{fetch_ref_optional, Lease, LeaseEngine};
 use anyhow::{bail, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 fn extract_doc_id(input: &str, config: &Config) -> Option<String> {
     for t in &config.documents.types {
@@ -205,15 +206,95 @@ pub fn run_heartbeat(
     config: &Config,
     doc_id: &str,
     agent_id: Option<&str>,
+    min_interval: Option<&str>,
     json: bool,
 ) -> Result<()> {
     let engine = require_coordination(config)?;
+    run_heartbeat_with(
+        root,
+        config,
+        &engine,
+        doc_id,
+        agent_id,
+        min_interval,
+        Utc::now(),
+        json,
+    )
+}
+
+fn heartbeat_state_path(root: &Path, type_name: &str, doc_id: &str) -> PathBuf {
+    root.join(".lazyspec/state")
+        .join(format!("heartbeat-{}-{}", type_name, doc_id))
+}
+
+fn write_heartbeat_state(state_path: &Path, now: DateTime<Utc>) -> Result<()> {
+    let dir = state_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("state path has no parent"))?;
+    std::fs::create_dir_all(dir)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(now.to_rfc3339().as_bytes())?;
+    tmp.persist(state_path)
+        .map_err(|e| anyhow::anyhow!("persist failed: {}", e))?;
+    Ok(())
+}
+
+pub fn run_heartbeat_with<R: GitRefOps>(
+    root: &Path,
+    config: &Config,
+    engine: &LeaseEngine<R>,
+    doc_id: &str,
+    agent_id: Option<&str>,
+    min_interval: Option<&str>,
+    now: DateTime<Utc>,
+    json: bool,
+) -> Result<()> {
     let type_name = resolve_doc_type(config, doc_id)?;
     let agent = match agent_id {
         Some(id) => id.to_string(),
         None => resolve_agent_id(root)?,
     };
-    let lease = engine.heartbeat(root, type_name, doc_id, &agent, Utc::now())?;
+
+    if let Some(s) = min_interval {
+        let interval = crate::engine::lease::parse_duration(s)?;
+        let state_path = heartbeat_state_path(root, type_name, doc_id);
+        match std::fs::read_to_string(&state_path) {
+            Ok(raw) => {
+                let last = DateTime::parse_from_rfc3339(raw.trim())?.with_timezone(&Utc);
+                if now - last < interval {
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "skipped": true,
+                                "reason": "throttled",
+                                "last": last.to_rfc3339(),
+                            })
+                        );
+                    } else {
+                        println!(
+                            "Heartbeat {} skipped (throttled, last {})",
+                            doc_id,
+                            last.to_rfc3339()
+                        );
+                    }
+                    return Ok(());
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let lease = engine.heartbeat(root, type_name, doc_id, &agent, now)?;
+
+    if min_interval.is_some() {
+        let state_path = heartbeat_state_path(root, type_name, doc_id);
+        if let Err(e) = write_heartbeat_state(&state_path, now) {
+            eprintln!("warning: failed to write heartbeat state file: {}", e);
+        }
+    }
+
     if json {
         println!("{}", serde_json::to_string_pretty(&lease)?);
     } else {
@@ -515,5 +596,241 @@ mod tests {
         let calls = mock.calls.borrow();
         assert!(calls[0].starts_with("fetch_refs:"));
         assert!(calls[1].starts_with("list_refs:"));
+    }
+
+    // --- heartbeat throttle tests ---
+    //
+    // Note: AC4 specifies a JSON shape `{"skipped":true,"reason":"throttled","last":"<rfc3339>"}`
+    // for the throttled-skip case. Stdout capture isn't available without a new dev-dep
+    // (`gag`/`assert_cmd` are not in Cargo.toml). The throttle path is covered behaviourally
+    // by `heartbeat_skips_when_last_run_within_interval` (engine never called, state file
+    // untouched). JSON-shape coverage is deferred to an integration test.
+
+    use chrono::TimeZone;
+
+    fn engine_for(config: &Config, mock: MockGitRefClient) -> LeaseEngine<MockGitRefClient> {
+        LeaseEngine::new(mock, config.coordination.clone().unwrap())
+    }
+
+    fn fixed_now() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap()
+    }
+
+    fn succeeding_mock() -> MockGitRefClient {
+        MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("sha-old".to_string())))
+            .with_read_blob_result(Ok(make_lease_json("agent-a")))
+            .with_create_commit_result(Ok("sha-new".to_string()))
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()))
+    }
+
+    #[test]
+    fn heartbeat_without_min_interval_runs_unconditionally() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let engine = engine_for(&config, succeeding_mock());
+        let now = fixed_now();
+
+        let result = run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            None,
+            now,
+            true,
+        );
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+        assert!(
+            !engine.git.calls.borrow().is_empty(),
+            "engine should be called when min_interval is None"
+        );
+        assert!(
+            !dir.path().join(".lazyspec/state").exists(),
+            "no state I/O when min_interval is None"
+        );
+    }
+
+    #[test]
+    fn heartbeat_skips_when_last_run_within_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let now = fixed_now();
+        let last = now - Duration::minutes(5);
+
+        let state_dir = dir.path().join(".lazyspec/state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let state_path = state_dir.join("heartbeat-rfc-RFC-001");
+        std::fs::write(&state_path, last.to_rfc3339()).unwrap();
+
+        // Mock has no results queued; if engine is called, pop_or_default will return defaults
+        // (e.g. resolve -> Ok(None)) which would make heartbeat fail with "no lease found".
+        // So either path -- success or err -- shows engine ran. We assert mock.calls is empty.
+        let engine = engine_for(&config, MockGitRefClient::new());
+
+        let result = run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            Some("15m"),
+            now,
+            true,
+        );
+
+        assert!(result.is_ok(), "throttled skip should be Ok");
+        assert!(
+            engine.git.calls.borrow().is_empty(),
+            "engine must not be called on throttle: {:?}",
+            engine.git.calls.borrow()
+        );
+        let written = std::fs::read_to_string(&state_path).unwrap();
+        assert_eq!(
+            written,
+            last.to_rfc3339(),
+            "state file should be unchanged on skip"
+        );
+    }
+
+    #[test]
+    fn heartbeat_runs_when_state_file_older_than_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let now = fixed_now();
+        let last = now - Duration::minutes(30);
+
+        let state_dir = dir.path().join(".lazyspec/state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let state_path = state_dir.join("heartbeat-rfc-RFC-001");
+        std::fs::write(&state_path, last.to_rfc3339()).unwrap();
+
+        let engine = engine_for(&config, succeeding_mock());
+
+        let result = run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            Some("15m"),
+            now,
+            true,
+        );
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+        assert!(
+            !engine.git.calls.borrow().is_empty(),
+            "engine should have been called when state is stale"
+        );
+        let written = std::fs::read_to_string(&state_path).unwrap();
+        assert_eq!(
+            written,
+            now.to_rfc3339(),
+            "state file should be updated to `now` after a successful heartbeat"
+        );
+    }
+
+    #[test]
+    fn heartbeat_runs_when_state_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let now = fixed_now();
+
+        let engine = engine_for(&config, succeeding_mock());
+
+        let result = run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            Some("15m"),
+            now,
+            true,
+        );
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+        assert!(
+            !engine.git.calls.borrow().is_empty(),
+            "engine should be called when state file is absent"
+        );
+        let state_path = dir.path().join(".lazyspec/state/heartbeat-rfc-RFC-001");
+        assert!(state_path.exists(), "state file should be written");
+        let written = std::fs::read_to_string(&state_path).unwrap();
+        assert_eq!(written, now.to_rfc3339());
+    }
+
+    #[test]
+    fn heartbeat_state_file_written_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let now = fixed_now();
+        let engine = engine_for(&config, succeeding_mock());
+
+        run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            Some("15m"),
+            now,
+            true,
+        )
+        .unwrap();
+
+        let state_dir = dir.path().join(".lazyspec/state");
+        let entries: Vec<_> = std::fs::read_dir(&state_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one file in state dir, found {:?}",
+            entries
+        );
+        assert_eq!(entries[0], "heartbeat-rfc-RFC-001");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn heartbeat_state_write_failure_does_not_fail_command() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_coordination();
+        let now = fixed_now();
+
+        let state_dir = dir.path().join(".lazyspec/state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let engine = engine_for(&config, succeeding_mock());
+
+        let result = run_heartbeat_with(
+            dir.path(),
+            &config,
+            &engine,
+            "RFC-001",
+            Some("agent-a"),
+            Some("15m"),
+            now,
+            true,
+        );
+
+        // Restore perms so TempDir cleanup succeeds.
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            result.is_ok(),
+            "state write failure should not fail command, got {:?}",
+            result.err()
+        );
     }
 }

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -91,6 +91,10 @@ fn default_coordination_max_push_retries() -> u8 {
     5
 }
 
+fn default_coordination_max_clock_skew() -> String {
+    "5m".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CoordinationConfig {
     #[serde(default = "default_coordination_remote")]
@@ -101,6 +105,8 @@ pub struct CoordinationConfig {
     pub grace_period: String,
     #[serde(default = "default_coordination_max_push_retries")]
     pub max_push_retries: u8,
+    #[serde(default = "default_coordination_max_clock_skew")]
+    pub max_clock_skew: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]

--- a/src/engine/git_ref.rs
+++ b/src/engine/git_ref.rs
@@ -664,8 +664,14 @@ mod tests {
     #[test]
     fn mock_push_ref_with_lease_records_call_with_expected_old() {
         let mock = MockGitRefClient::new().with_push_with_lease_result(Ok(()));
-        mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", "newsha", Some("abc123"))
-            .unwrap();
+        mock.push_ref_with_lease(
+            &dummy_root(),
+            "origin",
+            "refs/test",
+            "newsha",
+            Some("abc123"),
+        )
+        .unwrap();
         assert_eq!(
             mock.calls.borrow()[0],
             "push_ref_with_lease:origin:refs/test:new_sha=newsha:expected_old=Some(\"abc123\")"

--- a/src/engine/git_ref.rs
+++ b/src/engine/git_ref.rs
@@ -36,6 +36,7 @@ pub trait GitRefOps {
         root: &Path,
         remote: &str,
         refname: &str,
+        new_sha: &str,
         expected_old: Option<&str>,
     ) -> Result<()>;
     fn read_commit_timestamp(&self, root: &Path, sha: &str) -> Result<DateTime<Utc>>;
@@ -252,13 +253,17 @@ impl GitRefOps for GitCli {
         root: &Path,
         remote: &str,
         refname: &str,
+        new_sha: &str,
         expected_old: Option<&str>,
     ) -> Result<()> {
         let lease_arg = match expected_old {
             Some(sha) => format!("--force-with-lease={}:{}", refname, sha),
             None => format!("--force-with-lease={}", refname),
         };
-        let output = self.run_git(root, &["push", &lease_arg, remote, refname])?;
+        // Push by SHA so dangling commit objects without a local ref can be pushed.
+        // Local ref advances only after this returns Ok (see LeaseEngine::acquire/heartbeat).
+        let refspec = format!("{}:{}", new_sha, refname);
+        let output = self.run_git(root, &["push", &lease_arg, remote, &refspec])?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!("git push --force-with-lease failed: {}", stderr.trim());
@@ -509,11 +514,12 @@ pub mod test_support {
             _root: &Path,
             remote: &str,
             refname: &str,
+            new_sha: &str,
             expected_old: Option<&str>,
         ) -> Result<()> {
             self.calls.borrow_mut().push(format!(
-                "push_ref_with_lease:{}:{}:expected_old={:?}",
-                remote, refname, expected_old
+                "push_ref_with_lease:{}:{}:new_sha={}:expected_old={:?}",
+                remote, refname, new_sha, expected_old
             ));
             Self::pop_or_default(&self.push_with_lease_results)
         }
@@ -658,22 +664,22 @@ mod tests {
     #[test]
     fn mock_push_ref_with_lease_records_call_with_expected_old() {
         let mock = MockGitRefClient::new().with_push_with_lease_result(Ok(()));
-        mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", Some("abc123"))
+        mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", "newsha", Some("abc123"))
             .unwrap();
         assert_eq!(
             mock.calls.borrow()[0],
-            "push_ref_with_lease:origin:refs/test:expected_old=Some(\"abc123\")"
+            "push_ref_with_lease:origin:refs/test:new_sha=newsha:expected_old=Some(\"abc123\")"
         );
     }
 
     #[test]
     fn mock_push_ref_with_lease_records_call_with_none() {
         let mock = MockGitRefClient::new().with_push_with_lease_result(Ok(()));
-        mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", None)
+        mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", "newsha", None)
             .unwrap();
         assert_eq!(
             mock.calls.borrow()[0],
-            "push_ref_with_lease:origin:refs/test:expected_old=None"
+            "push_ref_with_lease:origin:refs/test:new_sha=newsha:expected_old=None"
         );
     }
 
@@ -681,7 +687,8 @@ mod tests {
     fn mock_push_ref_with_lease_returns_configured_error() {
         let mock = MockGitRefClient::new()
             .with_push_with_lease_result(Err(anyhow::anyhow!("lease mismatch")));
-        let result = mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", Some("old"));
+        let result =
+            mock.push_ref_with_lease(&dummy_root(), "origin", "refs/test", "newsha", Some("old"));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("lease mismatch"));
     }

--- a/src/engine/git_ref.rs
+++ b/src/engine/git_ref.rs
@@ -24,7 +24,13 @@ pub trait GitRefOps {
     fn delete_ref(&self, root: &Path, refname: &str) -> Result<()>;
     fn fetch_refs(&self, root: &Path, remote: &str, pattern: &str) -> Result<()>;
     fn push_ref(&self, root: &Path, remote: &str, refname: &str) -> Result<()>;
-    fn delete_remote_ref(&self, root: &Path, remote: &str, refname: &str) -> Result<()>;
+    fn delete_remote_ref(
+        &self,
+        root: &Path,
+        remote: &str,
+        refname: &str,
+        expected_old: Option<&str>,
+    ) -> Result<()>;
     fn push_ref_with_lease(
         &self,
         root: &Path,
@@ -219,9 +225,21 @@ impl GitRefOps for GitCli {
         Ok(())
     }
 
-    fn delete_remote_ref(&self, root: &Path, remote: &str, refname: &str) -> Result<()> {
+    fn delete_remote_ref(
+        &self,
+        root: &Path,
+        remote: &str,
+        refname: &str,
+        expected_old: Option<&str>,
+    ) -> Result<()> {
         let delete_spec = format!(":{}", refname);
-        let output = self.run_git(root, &["push", remote, &delete_spec])?;
+        let output = match expected_old {
+            Some(sha) => {
+                let lease_arg = format!("--force-with-lease={}:{}", refname, sha);
+                self.run_git(root, &["push", &lease_arg, remote, &delete_spec])?
+            }
+            None => self.run_git(root, &["push", remote, &delete_spec])?,
+        };
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!("git push --delete failed: {}", stderr.trim());
@@ -472,10 +490,17 @@ pub mod test_support {
             Self::pop_or_default(&self.push_results)
         }
 
-        fn delete_remote_ref(&self, _root: &Path, remote: &str, refname: &str) -> Result<()> {
-            self.calls
-                .borrow_mut()
-                .push(format!("delete_remote_ref:{}:{}", remote, refname));
+        fn delete_remote_ref(
+            &self,
+            _root: &Path,
+            remote: &str,
+            refname: &str,
+            expected_old: Option<&str>,
+        ) -> Result<()> {
+            self.calls.borrow_mut().push(format!(
+                "delete_remote_ref:{}:{}:expected_old={:?}",
+                remote, refname, expected_old
+            ));
             Self::pop_or_default(&self.delete_remote_results)
         }
 

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -315,7 +315,7 @@ impl<R: GitRefOps> DocumentStore for GitRefStore<R> {
         let refname = Self::refname(&type_def.name, doc_id);
         if let Some(coord) = &self.config.coordination {
             self.git
-                .delete_remote_ref(&self.root, &coord.remote, &refname)?;
+                .delete_remote_ref(&self.root, &coord.remote, &refname, None)?;
         }
         self.git.delete_ref(&self.root, &refname)?;
 
@@ -716,6 +716,7 @@ mod tests {
             lease_duration: "60m".to_string(),
             grace_period: "2m".to_string(),
             max_push_retries: 5,
+            max_clock_skew: "5m".to_string(),
         });
         config
     }
@@ -837,7 +838,7 @@ mod tests {
         assert!(
             calls
                 .iter()
-                .any(|c| c == "delete_remote_ref:origin:refs/lazyspec/iteration/ITERATION-042"),
+                .any(|c| c == "delete_remote_ref:origin:refs/lazyspec/iteration/ITERATION-042:expected_old=None"),
             "should delete remote ref, got: {:?}",
             *calls
         );
@@ -1158,7 +1159,7 @@ mod tests {
         assert!(
             calls
                 .iter()
-                .any(|c| c == "delete_remote_ref:origin:refs/lazyspec/iteration/ITERATION-042"),
+                .any(|c| c == "delete_remote_ref:origin:refs/lazyspec/iteration/ITERATION-042:expected_old=None"),
             "should have attempted remote delete, got: {:?}",
             *calls
         );

--- a/src/engine/lease.rs
+++ b/src/engine/lease.rs
@@ -99,6 +99,7 @@ impl<R: GitRefOps> LeaseEngine<R> {
             root,
             &self.config.remote,
             &refname,
+            &new_sha,
             Some(ZERO_SHA),
         )?;
         self.git.update_ref(root, &refname, &new_sha, ZERO_SHA)?;
@@ -192,6 +193,7 @@ impl<R: GitRefOps> LeaseEngine<R> {
             root,
             &self.config.remote,
             &refname,
+            &new_sha,
             Some(&old_sha),
         )?;
         self.git.update_ref(root, &refname, &new_sha, &old_sha)?;
@@ -244,7 +246,7 @@ impl<R: GitRefOps> LeaseEngine<R> {
             self.git
                 .create_commit(root, &refname, &[("lease.json", &json)], Some(&sha))?;
         self.git
-            .push_ref_with_lease(root, &self.config.remote, &refname, Some(&sha))?;
+            .push_ref_with_lease(root, &self.config.remote, &refname, &new_sha, Some(&sha))?;
         self.git.update_ref(root, &refname, &new_sha, &sha)?;
         Ok(new_lease)
     }
@@ -361,7 +363,7 @@ mod tests {
         assert_eq!(
             calls[3],
             format!(
-                "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"{}\")",
+                "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:new_sha=sha1:expected_old=Some(\"{}\")",
                 ZERO_SHA
             )
         );
@@ -604,7 +606,7 @@ mod tests {
             .expect("expected push_ref_with_lease call");
         assert_eq!(
             push_call,
-            "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"old-sha\")"
+            "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:new_sha=new-sha:expected_old=Some(\"old-sha\")"
         );
     }
 
@@ -880,7 +882,7 @@ mod tests {
             .expect("expected push_ref_with_lease call");
         assert_eq!(
             push_lease_call,
-            "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"old-sha\")"
+            "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:new_sha=new-sha:expected_old=Some(\"old-sha\")"
         );
 
         let update_call = calls

--- a/src/engine/lease.rs
+++ b/src/engine/lease.rs
@@ -35,6 +35,12 @@ fn lease_ref(type_name: &str, id: &str) -> String {
     format!("refs/lazyspec/leases/{}/{}", type_name, id)
 }
 
+fn lease_glob(type_name: &str) -> String {
+    format!("refs/lazyspec/leases/{}/*", type_name)
+}
+
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
 pub fn fetch_ref_optional(
     git: &impl GitRefOps,
     root: &Path,
@@ -69,9 +75,8 @@ impl<R: GitRefOps> LeaseEngine<R> {
     ) -> Result<Lease> {
         let refname = lease_ref(type_name, id);
 
-        // Glob fetch so --prune removes all stale local lease refs for this type.
-        let lease_glob = format!("refs/lazyspec/leases/{}/*", type_name);
-        fetch_ref_optional(&self.git, root, &self.config.remote, &lease_glob)?;
+        // Glob fetch so --prune removes stale local lease refs whose remote counterparts are gone.
+        fetch_ref_optional(&self.git, root, &self.config.remote, &lease_glob(type_name))?;
         let existing = self.git.resolve_ref(root, &refname)?;
         if existing.is_some() {
             bail!("lease held");
@@ -84,9 +89,19 @@ impl<R: GitRefOps> LeaseEngine<R> {
             expires: now + duration,
         };
         let json = serde_json::to_string_pretty(&lease)?;
-        self.git
-            .create_ref_commit(root, &refname, &[("lease.json", &json)])?;
-        self.git.push_ref(root, &self.config.remote, &refname)?;
+        // Create commit object only (no local ref update yet). Remote CAS via
+        // --force-with-lease=ref:0000...0000 is the linearization point; local ref
+        // advances only on push success to avoid acquire/crash phantom-create windows.
+        let new_sha = self
+            .git
+            .create_commit(root, &refname, &[("lease.json", &json)], None)?;
+        self.git.push_ref_with_lease(
+            root,
+            &self.config.remote,
+            &refname,
+            Some(ZERO_SHA),
+        )?;
+        self.git.update_ref(root, &refname, &new_sha, ZERO_SHA)?;
         Ok(lease)
     }
 
@@ -120,7 +135,9 @@ impl<R: GitRefOps> LeaseEngine<R> {
         mismatch_msg: impl FnOnce(&str, &str) -> String,
     ) -> Result<()> {
         let refname = lease_ref(type_name, id);
-        fetch_ref_optional(&self.git, root, &self.config.remote, &refname)?;
+        // Glob fetch with prune so a remote-absent ref clears the stale local ref;
+        // otherwise a single-ref fetch leaves the local view authoritative.
+        fetch_ref_optional(&self.git, root, &self.config.remote, &lease_glob(type_name))?;
         let sha = self
             .git
             .resolve_ref(root, &refname)?
@@ -130,8 +147,9 @@ impl<R: GitRefOps> LeaseEngine<R> {
         if lease.agent != expected_agent {
             bail!("{}", mismatch_msg(&lease.agent, expected_agent));
         }
+        // CAS delete: refuse to delete if the remote ref no longer matches the sha we verified.
         self.git
-            .delete_remote_ref(root, &self.config.remote, &refname)?;
+            .delete_remote_ref(root, &self.config.remote, &refname, Some(&sha))?;
         self.git.delete_ref(root, &refname)?;
         Ok(())
     }
@@ -145,6 +163,9 @@ impl<R: GitRefOps> LeaseEngine<R> {
         now: DateTime<Utc>,
     ) -> Result<Lease> {
         let refname = lease_ref(type_name, id);
+        // Fetch-before-check: without this, a release+force-acquire by another agent is
+        // invisible and the subsequent plain push would resurrect a deleted lease.
+        fetch_ref_optional(&self.git, root, &self.config.remote, &lease_glob(type_name))?;
         let old_sha = self
             .git
             .resolve_ref(root, &refname)?
@@ -165,8 +186,15 @@ impl<R: GitRefOps> LeaseEngine<R> {
         let new_sha =
             self.git
                 .create_commit(root, &refname, &[("lease.json", &json)], Some(&old_sha))?;
+        // Remote CAS before local mutation: --force-with-lease=ref:old_sha rejects pushes
+        // when the remote has moved or the ref is absent (no phantom resurrection).
+        self.git.push_ref_with_lease(
+            root,
+            &self.config.remote,
+            &refname,
+            Some(&old_sha),
+        )?;
         self.git.update_ref(root, &refname, &new_sha, &old_sha)?;
-        self.git.push_ref(root, &self.config.remote, &refname)?;
         Ok(updated)
     }
 
@@ -188,6 +216,17 @@ impl<R: GitRefOps> LeaseEngine<R> {
         let _lease: Lease = serde_json::from_str(&blob)?;
 
         let last_touched = self.git.read_commit_timestamp(root, &sha)?;
+        // Reject leases whose commit timestamp is implausibly far in the future. Defends
+        // against GIT_COMMITTER_DATE forgery that would otherwise make a lease un-stealable.
+        let max_skew = parse_duration(&self.config.max_clock_skew)?;
+        if last_touched > now + max_skew {
+            bail!(
+                "lease commit timestamp {} is more than {} ahead of local clock {}",
+                last_touched,
+                self.config.max_clock_skew,
+                now
+            );
+        }
         let duration = parse_duration(&self.config.lease_duration)?;
         let grace = parse_duration(&self.config.grace_period)?;
         let effective_expiry = last_touched + duration + grace;
@@ -244,6 +283,7 @@ mod tests {
             lease_duration: "60m".to_string(),
             grace_period: "2m".to_string(),
             max_push_retries: 5,
+            max_clock_skew: "5m".to_string(),
         }
     }
 
@@ -300,8 +340,9 @@ mod tests {
         let mock = MockGitRefClient::new()
             .with_fetch_result(Ok(()))
             .with_resolve_result(Ok(None))
-            .with_create_ref_commit_result(Ok("sha1".to_string()))
-            .with_push_result(Ok(()));
+            .with_create_commit_result(Ok("sha1".to_string()))
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
 
         let engine = LeaseEngine::new(mock, test_config());
         let lease = engine
@@ -313,10 +354,74 @@ mod tests {
         assert_eq!(lease.expires, now + Duration::minutes(60));
 
         let calls = engine.git.calls.borrow();
-        assert!(calls[0].contains("fetch_refs"));
-        assert!(calls[1].contains("resolve_ref"));
-        assert!(calls[2].contains("create_ref_commit:refs/lazyspec/leases/story/STORY-001"));
-        assert!(calls[3].contains("push_ref"));
+        assert!(calls[0].starts_with("fetch_refs:"));
+        assert!(calls[0].contains("refs/lazyspec/leases/story/*"));
+        assert!(calls[1].starts_with("resolve_ref:"));
+        assert!(calls[2].starts_with("create_commit:refs/lazyspec/leases/story/STORY-001"));
+        assert_eq!(
+            calls[3],
+            format!(
+                "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"{}\")",
+                ZERO_SHA
+            )
+        );
+        assert_eq!(
+            calls[4],
+            format!(
+                "update_ref:refs/lazyspec/leases/story/STORY-001:sha1:{}",
+                ZERO_SHA
+            )
+        );
+    }
+
+    #[test]
+    fn acquire_uses_force_with_lease_zero_sha() {
+        let now = fixed_now();
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(None))
+            .with_create_commit_result(Ok("sha1".to_string()))
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        engine
+            .acquire(&dummy_root(), "story", "STORY-001", "agent-a", now)
+            .unwrap();
+
+        let calls = engine.git.calls.borrow();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("create_ref_commit")),
+            "acquire must not use create_ref_commit (would advance local ref before remote CAS)"
+        );
+        assert!(
+            !calls.iter().any(|c| c.starts_with("push_ref:")),
+            "acquire must not use plain push_ref"
+        );
+    }
+
+    #[test]
+    fn acquire_does_not_advance_local_ref_when_push_fails() {
+        let now = fixed_now();
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(None))
+            .with_create_commit_result(Ok("sha1".to_string()))
+            .with_push_with_lease_result(Err(anyhow::anyhow!(
+                "stale info: ref exists on remote"
+            )));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        let err = engine
+            .acquire(&dummy_root(), "story", "STORY-001", "agent-a", now)
+            .unwrap_err();
+        assert!(err.to_string().contains("stale info"));
+
+        let calls = engine.git.calls.borrow();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("update_ref:")),
+            "local update_ref must not run if remote push fails"
+        );
     }
 
     #[test]
@@ -352,8 +457,40 @@ mod tests {
             .unwrap();
 
         let calls = engine.git.calls.borrow();
-        assert!(calls.iter().any(|c| c.contains("delete_remote_ref")));
-        assert!(calls.iter().any(|c| c.contains("delete_ref")));
+        let delete_remote = calls
+            .iter()
+            .find(|c| c.starts_with("delete_remote_ref:"))
+            .expect("expected delete_remote_ref call");
+        assert_eq!(
+            delete_remote,
+            "delete_remote_ref:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"sha1\")"
+        );
+        assert!(calls.iter().any(|c| c.starts_with("delete_ref:")));
+    }
+
+    #[test]
+    fn release_fetches_glob_with_prune() {
+        let now = fixed_now();
+        let lease_json = make_lease_json("agent-a", now, now + Duration::minutes(60));
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("sha1".to_string())))
+            .with_read_blob_result(Ok(lease_json))
+            .with_delete_remote_result(Ok(()))
+            .with_delete_ref_result(Ok(()));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        engine
+            .release(&dummy_root(), "story", "STORY-001", "agent-a")
+            .unwrap();
+
+        let calls = engine.git.calls.borrow();
+        assert!(
+            calls[0].starts_with("fetch_refs:")
+                && calls[0].contains("refs/lazyspec/leases/story/*"),
+            "release must glob-fetch (not single-ref fetch) so absent remote refs prune local: got {}",
+            calls[0]
+        );
     }
 
     #[test]
@@ -421,11 +558,12 @@ mod tests {
         let lease_json = make_lease_json("agent-a", acquired, old_expires);
 
         let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
             .with_resolve_result(Ok(Some("old-sha".to_string())))
             .with_read_blob_result(Ok(lease_json))
             .with_create_commit_result(Ok("new-sha".to_string()))
-            .with_update_ref_result(Ok(()))
-            .with_push_result(Ok(()));
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
 
         let engine = LeaseEngine::new(mock, test_config());
         let updated = engine
@@ -456,22 +594,85 @@ mod tests {
             update_call,
             "update_ref:refs/lazyspec/leases/story/STORY-001:new-sha:old-sha"
         );
-        assert!(calls.iter().any(|c| c.contains("push_ref")));
+        assert!(
+            !calls.iter().any(|c| c.starts_with("push_ref:")),
+            "heartbeat must not use plain push_ref"
+        );
+        let push_call = calls
+            .iter()
+            .find(|c| c.starts_with("push_ref_with_lease:"))
+            .expect("expected push_ref_with_lease call");
+        assert_eq!(
+            push_call,
+            "push_ref_with_lease:origin:refs/lazyspec/leases/story/STORY-001:expected_old=Some(\"old-sha\")"
+        );
     }
 
     #[test]
-    fn heartbeat_uses_create_commit_then_cas() {
+    fn heartbeat_fetches_before_resolve() {
+        let acquired = fixed_now();
+        let lease_json = make_lease_json("agent-a", acquired, acquired + Duration::minutes(60));
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("old-sha".to_string())))
+            .with_read_blob_result(Ok(lease_json))
+            .with_create_commit_result(Ok("new-sha".to_string()))
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        engine
+            .heartbeat(&dummy_root(), "story", "STORY-001", "agent-a", acquired)
+            .unwrap();
+
+        let calls = engine.git.calls.borrow();
+        assert!(calls[0].starts_with("fetch_refs:"));
+        assert!(calls[0].contains("refs/lazyspec/leases/story/*"));
+        assert!(calls[1].starts_with("resolve_ref:"));
+    }
+
+    #[test]
+    fn heartbeat_does_not_advance_local_ref_when_push_fails() {
+        // Phantom-resurrection guard: if remote was deleted (e.g. force-acquire-then-release
+        // by another agent), --force-with-lease=ref:old_sha must fail and local must not advance.
+        let acquired = fixed_now();
+        let lease_json = make_lease_json("agent-a", acquired, acquired + Duration::minutes(60));
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("old-sha".to_string())))
+            .with_read_blob_result(Ok(lease_json))
+            .with_create_commit_result(Ok("new-sha".to_string()))
+            .with_push_with_lease_result(Err(anyhow::anyhow!("stale info")));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        let err = engine
+            .heartbeat(&dummy_root(), "story", "STORY-001", "agent-a", acquired)
+            .unwrap_err();
+        assert!(err.to_string().contains("stale info"));
+
+        let calls = engine.git.calls.borrow();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("update_ref:")),
+            "local update_ref must not run if remote push fails"
+        );
+    }
+
+    #[test]
+    fn heartbeat_uses_create_commit_then_push_then_cas() {
+        // Remote CAS via --force-with-lease must precede the local update_ref so that local
+        // never advances past what the remote accepts.
         let acquired = fixed_now();
         let old_expires = acquired + Duration::minutes(60);
         let heartbeat_time = acquired + Duration::minutes(30);
         let lease_json = make_lease_json("agent-a", acquired, old_expires);
 
         let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
             .with_resolve_result(Ok(Some("old-sha".to_string())))
             .with_read_blob_result(Ok(lease_json))
             .with_create_commit_result(Ok("new-sha".to_string()))
-            .with_update_ref_result(Ok(()))
-            .with_push_result(Ok(()));
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
 
         let engine = LeaseEngine::new(mock, test_config());
         engine
@@ -485,13 +686,14 @@ mod tests {
             .unwrap();
 
         let calls = engine.git.calls.borrow();
-        assert_eq!(calls.len(), 5);
-        assert!(calls[0].starts_with("resolve_ref:"));
-        assert!(calls[1].starts_with("read_ref_blob:"));
-        assert!(calls[2].starts_with("create_commit:"));
-        assert!(calls[2].contains("parent=Some(\"old-sha\")"));
-        assert!(calls[3].starts_with("update_ref:"));
-        assert!(calls[4].starts_with("push_ref:"));
+        assert_eq!(calls.len(), 6);
+        assert!(calls[0].starts_with("fetch_refs:"));
+        assert!(calls[1].starts_with("resolve_ref:"));
+        assert!(calls[2].starts_with("read_ref_blob:"));
+        assert!(calls[3].starts_with("create_commit:"));
+        assert!(calls[3].contains("parent=Some(\"old-sha\")"));
+        assert!(calls[4].starts_with("push_ref_with_lease:"));
+        assert!(calls[5].starts_with("update_ref:"));
     }
 
     #[test]
@@ -499,6 +701,7 @@ mod tests {
         let now = fixed_now();
         let lease_json = make_lease_json("agent-a", now, now + Duration::minutes(60));
         let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
             .with_resolve_result(Ok(Some("sha1".to_string())))
             .with_read_blob_result(Ok(lease_json));
 
@@ -864,5 +1067,53 @@ mod tests {
 
         let calls = engine.git.calls.borrow();
         assert!(calls.iter().any(|c| c == "read_commit_timestamp:old-sha"));
+    }
+
+    #[test]
+    fn force_acquire_rejects_commit_timestamp_beyond_skew_bound() {
+        // Defends against GIT_COMMITTER_DATE forgery: if a holder stamps the lease commit
+        // far in the future, force_acquire must reject the lease as untrusted rather than
+        // honour the future timestamp (which would otherwise make the lease un-stealable).
+        let now = fixed_now();
+        let future_commit_timestamp = now + Duration::hours(2);
+        let lease_json = make_lease_json("agent-a", now, now + Duration::minutes(60));
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("old-sha".to_string())))
+            .with_read_blob_result(Ok(lease_json))
+            .with_read_commit_timestamp_result(Ok(future_commit_timestamp));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        let err = engine
+            .force_acquire(&dummy_root(), "story", "STORY-001", "agent-b", now)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("ahead of local clock"),
+            "expected skew error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn force_acquire_accepts_commit_timestamp_within_skew_bound() {
+        // Trusted clock skew (NTP drift) is tolerated up to max_clock_skew.
+        let acquired = fixed_now();
+        let slightly_future_commit_ts = acquired + Duration::minutes(2);
+        let now = slightly_future_commit_ts + Duration::hours(2);
+        let lease_json = make_lease_json("agent-a", acquired, acquired + Duration::minutes(60));
+        let mock = MockGitRefClient::new()
+            .with_fetch_result(Ok(()))
+            .with_resolve_result(Ok(Some("old-sha".to_string())))
+            .with_read_blob_result(Ok(lease_json))
+            .with_read_commit_timestamp_result(Ok(slightly_future_commit_ts))
+            .with_create_commit_result(Ok("new-sha".to_string()))
+            .with_push_with_lease_result(Ok(()))
+            .with_update_ref_result(Ok(()));
+
+        let engine = LeaseEngine::new(mock, test_config());
+        engine
+            .force_acquire(&dummy_root(), "story", "STORY-001", "agent-b", now)
+            .unwrap();
     }
 }

--- a/src/engine/lease.rs
+++ b/src/engine/lease.rs
@@ -409,9 +409,7 @@ mod tests {
             .with_fetch_result(Ok(()))
             .with_resolve_result(Ok(None))
             .with_create_commit_result(Ok("sha1".to_string()))
-            .with_push_with_lease_result(Err(anyhow::anyhow!(
-                "stale info: ref exists on remote"
-            )));
+            .with_push_with_lease_result(Err(anyhow::anyhow!("stale info: ref exists on remote")));
 
         let engine = LeaseEngine::new(mock, test_config());
         let err = engine

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,6 +443,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Heartbeat {
             doc_id,
             agent_id,
+            min_interval,
             json,
         }) => {
             if let Err(e) = lazyspec::cli::lease::run_heartbeat(
@@ -450,6 +451,7 @@ fn main() -> anyhow::Result<()> {
                 &config,
                 &doc_id,
                 agent_id.as_deref(),
+                min_interval.as_deref(),
                 json,
             ) {
                 if json {

--- a/tests/fetch_prune_test.rs
+++ b/tests/fetch_prune_test.rs
@@ -40,6 +40,7 @@ fn config_with_git_ref_iteration() -> Config {
         lease_duration: "60m".to_string(),
         grace_period: "2m".to_string(),
         max_push_retries: 5,
+        max_clock_skew: "5m".to_string(),
     });
     config
 }

--- a/tests/git_ref_test.rs
+++ b/tests/git_ref_test.rs
@@ -196,7 +196,7 @@ fn delete_remote_ref_removes_from_remote() {
         .unwrap();
     git.push_ref(fixture.root(), "origin", refname).unwrap();
 
-    git.delete_remote_ref(fixture.root(), "origin", refname)
+    git.delete_remote_ref(fixture.root(), "origin", refname, None)
         .unwrap();
 
     // Verify ref is gone from remote via ls-remote on the bare repo
@@ -276,7 +276,7 @@ fn push_ref_with_lease_succeeds_when_remote_matches() {
         .unwrap();
 
     // Push with lease using the correct expected old SHA
-    git.push_ref_with_lease(fixture.root(), "origin", refname, Some(&sha))
+    git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(&sha))
         .unwrap();
 
     // Verify remote has the new SHA by fetching
@@ -284,6 +284,80 @@ fn push_ref_with_lease_succeeds_when_remote_matches() {
     git.fetch_refs(fixture.root(), "origin", refname).unwrap();
     let fetched = git.resolve_ref(fixture.root(), refname).unwrap();
     assert_eq!(fetched, Some(new_sha));
+}
+
+#[test]
+fn push_ref_with_lease_pushes_dangling_commit_without_local_ref() {
+    // Regression: LeaseEngine::acquire and ::heartbeat mint a dangling commit
+    // (no local ref) and push it. Earlier impl pushed by refname, which failed
+    // with "src refspec ... does not match any" for acquire and silently no-op'd
+    // for heartbeat (local ref still at old sha). Push must use <sha>:<refname>.
+    let (fixture, _bare) = TestFixture::with_git_remote();
+    let git = GitCli;
+    let refname = "refs/lazyspec/leases/iteration/ITERATION-REG";
+
+    let new_sha = git
+        .create_commit(fixture.root(), refname, &[("lease.json", "{}")], None)
+        .unwrap();
+
+    // Local ref must NOT exist at this point -- this is the precondition of acquire.
+    assert_eq!(
+        git.resolve_ref(fixture.root(), refname).unwrap(),
+        None,
+        "test precondition: local ref must be absent"
+    );
+
+    let zero = "0000000000000000000000000000000000000000";
+    git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(zero))
+        .unwrap();
+
+    // Verify the dangling commit landed on the remote.
+    git.fetch_refs(fixture.root(), "origin", refname).unwrap();
+    assert_eq!(
+        git.resolve_ref(fixture.root(), refname).unwrap(),
+        Some(new_sha)
+    );
+}
+
+#[test]
+fn push_ref_with_lease_pushes_new_sha_not_local_ref() {
+    // Regression for heartbeat: local ref still points at old sha when push fires.
+    // Earlier impl pushed by refname (i.e. old sha), so remote stayed stale even
+    // though local later advanced via update_ref. Push must carry new_sha.
+    let (fixture, _bare) = TestFixture::with_git_remote();
+    let git = GitCli;
+    let refname = "refs/lazyspec/leases/iteration/ITERATION-HB";
+
+    let old_sha = git
+        .create_ref_commit(fixture.root(), refname, &[("lease.json", "{\"v\":1}")])
+        .unwrap();
+    git.push_ref(fixture.root(), "origin", refname).unwrap();
+
+    // Mint a dangling new commit. Local ref still at old_sha.
+    let new_sha = git
+        .create_commit(
+            fixture.root(),
+            refname,
+            &[("lease.json", "{\"v\":2}")],
+            Some(&old_sha),
+        )
+        .unwrap();
+    assert_eq!(
+        git.resolve_ref(fixture.root(), refname).unwrap(),
+        Some(old_sha.clone()),
+        "test precondition: local ref must still be at old_sha"
+    );
+
+    git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(&old_sha))
+        .unwrap();
+
+    // Remote must now hold new_sha (not old_sha).
+    git.delete_ref(fixture.root(), refname).unwrap();
+    git.fetch_refs(fixture.root(), "origin", refname).unwrap();
+    assert_eq!(
+        git.resolve_ref(fixture.root(), refname).unwrap(),
+        Some(new_sha)
+    );
 }
 
 #[test]
@@ -321,7 +395,8 @@ fn push_ref_with_lease_fails_when_remote_changed() {
 
     // Push with lease using the stale expected old SHA -- should fail because
     // remote is at interloper_sha, not sha
-    let result = git.push_ref_with_lease(fixture.root(), "origin", refname, Some(&sha));
+    let result =
+        git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(&sha));
     assert!(
         result.is_err(),
         "push_ref_with_lease should fail when remote ref was changed by another agent"
@@ -382,6 +457,7 @@ fn heartbeat_succeeds_and_extends_expiry() {
         lease_duration: "60m".to_string(),
         grace_period: "2m".to_string(),
         max_push_retries: 5,
+        max_clock_skew: "5m".to_string(),
     };
 
     let engine = LeaseEngine::new(git, config.clone());

--- a/tests/git_ref_test.rs
+++ b/tests/git_ref_test.rs
@@ -395,8 +395,7 @@ fn push_ref_with_lease_fails_when_remote_changed() {
 
     // Push with lease using the stale expected old SHA -- should fail because
     // remote is at interloper_sha, not sha
-    let result =
-        git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(&sha));
+    let result = git.push_ref_with_lease(fixture.root(), "origin", refname, &new_sha, Some(&sha));
     assert!(
         result.is_err(),
         "push_ref_with_lease should fail when remote ref was changed by another agent"


### PR DESCRIPTION
## Summary

- **Lease remote-first push (b53c771):** `acquire` was creating the lease commit as a dangling object and pushing the ref symbolically, so the commit never made it to the remote and other agents couldn't resolve the lease. Push the ref by SHA so dangling commits land on the remote.
- **Heartbeat min-interval throttle (8ee2619, ITERATION-169):** `lazyspec heartbeat` now accepts `--min-interval`. Returns a no-op result when the last heartbeat is more recent than the interval. Lets hooks fire on every PostToolUse without hammering the remote.
- **Claude Code hooks + setup docs (c632506, STORY/ITERATION-170):** ships `hooks/claude-code-settings.json` with `SessionStart` claim, `PostToolUse` heartbeat (`--min-interval 15m`), `SessionEnd` release. README documents the `$ASSIGNED_TASK` contract, the `|| true` error-tolerance, and the throttle rationale.
- **AUDIT-016:** distributed safety review of the lease engine post RFC-035. Six findings (3 critical) covering heartbeat phantom resurrection, committer-date squat, asymmetric-partition release, clock-skew split-brain, force-acquire crash window, and orphan-ref divergence. Recommendations not yet applied; tracked for follow-up.

## Test plan

- [ ] `cargo test --all`
- [ ] Two-agent claim race against a shared remote: both run `lazyspec claim STORY-X --agent-id A|B`, exactly one wins, loser sees "lease held".
- [ ] Heartbeat throttle: run heartbeat twice within `--min-interval`, second call returns `{"action":"skipped"}` and does not push.
- [ ] Drop `hooks/claude-code-settings.json` into a project's `.claude/settings.json`, start a session with `ASSIGNED_TASK=ITERATION-170` exported, confirm claim on start / heartbeat on tool use / release on end.
- [ ] Same hook config with `ASSIGNED_TASK` unset: no `lazyspec` invocation, session start/end silent.