### PR TITLE
feat: classify github-issues types by native issue type and custom tag

### DIFF
--- a/.lazyspec.toml
+++ b/.lazyspec.toml
@@ -88,6 +88,7 @@ icon = "🎫"
 store = "github-issues"
 subdirectory = true
 intent = "A GitHub issue authored as structured markdown"
+github_label = "Ticket"
 
 [[types.attributes]]
 name = "priority"

--- a/README.md
+++ b/README.md
@@ -548,6 +548,41 @@ gh auth refresh -s project
 Without it, schema-snapshot refreshes degrade gracefully -- they emit a warning
 and keep serving the last cached snapshot, so offline validation still works.
 
+A `[[types]]` entry may also declare `github_issue_tag` and/or
+`github_issue_type` to control which issues classify as that type,
+independent of (or instead of) the default `lazyspec:{type}` label:
+
+```toml
+[[types]]
+name = "feature"
+prefix = "FEAT"
+store = "github-issues"
+github_issue_tag = "customer-facing"
+github_issue_type = "Feature"
+```
+
+- Neither set: unchanged default -- an issue matches when it carries the
+  `lazyspec:{type}` label.
+- Only `github_issue_tag` set: matches every issue carrying that tag; the
+  `lazyspec:{type}` label is not checked.
+- Only `github_issue_type` set: matches every issue whose native GitHub
+  Issue Type equals that value; the label is not checked.
+- Both set: an issue must carry the tag **and** have the native issue type --
+  AND, not OR.
+
+Because these are independent per-type rules, two types may legitimately
+match the same issue (e.g. both set `github_issue_type = "Feature"`). `fetch`
+then materializes one document per matching type from that single issue --
+same issue number, separate cache entries under each type's own prefix and
+numbering. Both documents stay independently `update`-able; each write goes
+to the same issue, so whichever update runs last wins on any field the two
+types share.
+
+`create` on a type with `github_issue_type` set also pushes that value onto
+the new issue's native issue type field (needs the `project` scope described
+above); `create` with `github_issue_tag` set applies that value as a label
+the same way the default `lazyspec:{type}` label is applied today.
+
 By default, a `github-issues`-backed type's issues are created, filtered, and
 tagged with the label `lazyspec:{name}`. A type's `github_label` field
 replaces that label with a literal string of your choosing:

--- a/README.md
+++ b/README.md
@@ -548,6 +548,25 @@ gh auth refresh -s project
 Without it, schema-snapshot refreshes degrade gracefully -- they emit a warning
 and keep serving the last cached snapshot, so offline validation still works.
 
+By default, a `github-issues`-backed type's issues are created, filtered, and
+tagged with the label `lazyspec:{name}`. A type's `github_label` field
+replaces that label with a literal string of your choosing:
+
+```toml
+[[types]]
+name = "ticket"
+plural = "tickets"
+dir = "docs/tickets"
+prefix = "TICKET"
+store = "github-issues"
+github_label = "Ticket"
+```
+
+With this set, `ticket` issues use the label `Ticket` instead of the default
+`lazyspec:ticket`. Omitting `github_label` leaves existing configs and their
+default labels unchanged. It only affects `github-issues`-backed types; setting
+it on any other `store` is inert.
+
 #### `github-milestones` store
 
 Types stored as `--store github-milestones` map each document to a GitHub

--- a/docs/iterations/ITERATION-261-custom-github-label-field-per-document-type.md
+++ b/docs/iterations/ITERATION-261-custom-github-label-field-per-document-type.md
@@ -1,0 +1,51 @@
+---
+title: Custom github_label field per document type
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-190
+---
+
+## Objective
+
+`github_label` field on `TypeDef` -- custom label per type, default `lazyspec:{type}` unchanged.
+
+## Context
+
+- Story: STORY-190
+- Touch: src/engine/config.rs:239-266 (`TypeDef` + resolver), src/engine/gh.rs:218-220 (`type_label`), src/engine/issue_body.rs:169-190 (`extract_type_and_tags`), src/engine/issue_cache.rs (:161,:201,:313,:352,:553,:599), src/cli/init.rs:85, src/engine/store_dispatch.rs (:268-282,:495,:897,:955-969,:1092-1106,:1131), README.md:536+
+- Design detail (resolver name clash, plumbing shape, validation stance): STORY-190 body verbatim -- don't re-derive, follow as written.
+
+## Satisfies
+
+STORY-190 AC1-AC4 (all -- single plumbing pass, not separable: write-side swap and read-side exact-match fix share one `label` field threaded through the same call chain).
+
+## Tasks
+
+1. `TypeDef`: add `label_override: Option<String>` (`#[serde(default)]`), add `github_label()` resolver (falls back `gh::type_label(&self.name)`).
+2. Write side: swap all 6 `gh::type_label(&type_def.name)` call sites (init.rs:85, store_dispatch.rs:495/897/1131, issue_cache.rs:161/313) for `type_def.github_label()`.
+3. Read side: introduce per-type label data threaded through `parse_issue` -> `IssueContext` -> `deserialize` -> `extract_type_and_tags` (replace bare `known_types: &[String]`/`&[&str]` with resolved label per type). Fix exact-match against resolved label, not `lazyspec:` prefix strip. Also fix fallback path issue_cache.rs:599 (`.starts_with("lazyspec:")`).
+4. Validation: no new rule -- `github_label` on non-`github-issues` type stays silently unused (confirm, don't add a check).
+5. README.md:536+: document `github_label` field, same style as sibling `[[types]]` fields in that section.
+6. Update existing unit tests touching `known_types` construction at listed call sites for the new shape.
+
+## Out of scope
+
+- `github_issue_tag`/`github_issue_type` fields -- STORY-191/192, separate mechanism.
+- Custom label colors/descriptions -- unchanged (`deterministic_color`, fixed description string).
+- `github-milestones` store -- no label scheme there, untouched.
+- Reconciling `github_label` vs STORY-191's `github_issue_tag` overlap -- open RFC-055 decision, not this slice.
+
+## Principles/conventions
+
+Engine change only where read/write call sites live (layering per CONVENTION.md L3) -- CLI/TUI untouched, no surface change beyond config field + README.
+
+## Verification
+
+- `[[types]] github_label = "Ticket"` type: create/fetch/delete issue -> label is literally `Ticket`, never `lazyspec:ticket`.
+- Type with `github_label` unset: byte-for-byte same label as before this change.
+- Round-trip: issue carrying custom label only (no `lazyspec:` prefix at all) -> `extract_type_and_tags` still resolves correct type on fetch.
+

--- a/docs/iterations/ITERATION-262-github-issue-type-tag-classification-config-schema.md
+++ b/docs/iterations/ITERATION-262-github-issue-type-tag-classification-config-schema.md
@@ -1,0 +1,50 @@
+---
+title: GitHub issue-type/tag classification config schema
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-191
+---
+
+## Objective
+
+Add `github_issue_tag`/`github_issue_type` fields to `TypeDef` -- schema only, no consumer.
+
+## Context
+
+- Story: STORY-191
+- Touch: src/engine/config.rs:239-266 (`TypeDef`)
+- No resolver, no read/write logic -- STORY-192 is first consumer.
+
+## Satisfies
+
+STORY-191 AC1-AC5 (all -- schema-only story, single field addition, not separable).
+
+## Tasks
+
+1. `TypeDef`: add `github_issue_tag: Option<String>` and `github_issue_type: Option<String>`, both `#[serde(default)]`, matching existing `parent_type`/`intent` pattern in the same struct.
+2. Confirm `config --json` surfaces both fields as `null` when absent, configured values when set (should fall out of `#[derive(Serialize)]` on `TypeDef` -- verify, don't assume).
+3. Confirm `validate` emits no finding for either field on a non-`github-issues`-store type (no new rule to add -- absence of a check is correct per story's Validation section).
+
+## Out of scope
+
+- Classification/matching logic -- STORY-192.
+- Discovery query changes -- STORY-193.
+- Dual materialization -- STORY-194.
+- Write-side `create` push -- STORY-195.
+- README documentation -- STORY-196.
+- Reconciling with STORY-190's `github_label`/`label_override` -- open RFC-055 decision.
+
+## Principles/conventions
+
+Config schema addition only (CONVENTION.md L3 engine layer, no I/O) -- no CLI/TUI surface change.
+
+## Verification
+
+- `[[types]]` entry with both fields set parses on any `store` value, `config --json` echoes both.
+- `[[types]]` entry with neither field: `config --json` shows both as `null`, existing config parsing byte-for-byte unchanged.
+- `validate --json` on a fixture with `github_issue_tag` set on a `store = "filesystem"` type: zero findings mentioning either field.
+

--- a/docs/iterations/ITERATION-263-per-type-match-rule-plumbing-for-issue-classification.md
+++ b/docs/iterations/ITERATION-263-per-type-match-rule-plumbing-for-issue-classification.md
@@ -1,7 +1,7 @@
 ---
 title: Per-type match-rule plumbing for issue classification
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-03
 tags: []

--- a/docs/iterations/ITERATION-263-per-type-match-rule-plumbing-for-issue-classification.md
+++ b/docs/iterations/ITERATION-263-per-type-match-rule-plumbing-for-issue-classification.md
@@ -1,0 +1,56 @@
+---
+title: Per-type match-rule plumbing for issue classification
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-192
+---
+
+## Objective
+
+`extract_type_and_tags` answers "does issue satisfy type T's rule" per-type, independent of others -- no first-hit short circuit. Thread each type's full match rule (not bare name) through the fetch/read chain.
+
+## Context
+
+- Story: STORY-192 (blocked by STORY-191, landed as ITERATION-262 -- `github_issue_tag`/`github_issue_type` now on `TypeDef`)
+- Prior: ITERATION-261 (STORY-190) already threads a narrower per-type label through the same chain. Per STORY-192 body "Relation to STORY-190": reconcile into ONE `TypeMatchRule`-shaped pass -- extend/replace 261's plumbing, don't build a second one. `TypeMatchRule.label` is exactly what 261's plumbing resolves; if 261's `github_label()` resolver exists, reuse it for `label`'s default.
+- Design (struct shape, match semantics, exact call sites/line numbers, all signature changes): STORY-192 body verbatim -- don't re-derive.
+- Touch: src/engine/issue_body.rs (`TypeMatchRule` new, `IssueContext`:13-22, `deserialize`:83-119, `extract_type_and_tags`:169-190, `default_known_types()`:255 test fixture), src/engine/issue_cache.rs (`IssueContext.issue_type` source, `parse_issue`:553-568, `refresh_stale`:131-142/200-208, `fetch_all`:302-311/351-359, `insert_issue_type`:641-646 -- native type already read here, source `issue.issue_type`, test fixtures building `known_types`), src/engine/store_dispatch.rs (three `IssueContext` builders: `merge_relation_to_remote`:268-282, `update`:955-969, `set_provenance`:1092-1106), src/cli/setup.rs:47-52, src/cli/fetch.rs:117-122.
+
+## Satisfies
+
+STORY-192 AC1-AC6 (all -- single `TypeMatchRule` plumbing pass; independent-check semantics and the multi-match no-short-circuit guarantee are two facets of the same call-chain change, not separable slices).
+
+## Tasks
+
+1. Define `TypeMatchRule { name: String, label: String, tag: Option<String>, issue_type: Option<String> }` in issue_body.rs, plus a constructor from `&TypeDef` (reuse `github_label()` from ITERATION-261 if present; else `gh::type_label(&name)`).
+2. Add `issue_type: Option<String>` to `IssueContext`, sourced from `GhIssue.issue_type` at the point `parse_issue` builds context.
+3. Rewrite `extract_type_and_tags`: `known_types: &[TypeMatchRule]` + `issue_native_type: Option<&str>` param. Per-type independent check: neither tag/issue_type set -> label exact-match (case-insensitive); only tag -> tag match, skip label; only issue_type -> native-type match, skip label; both -> AND. No break on first match -- every candidate checked.
+4. Update `deserialize`, `parse_issue`, both `IssueContext` builders in issue_cache.rs (`refresh_stale`, `fetch_all`), the three in store_dispatch.rs, and the two `all_type_names` builders (cli/setup.rs, cli/fetch.rs) to build/pass `Vec<TypeMatchRule>` instead of `Vec<String>`/`&[&str]`.
+5. Populate `issue_type` on the three store_dispatch.rs `IssueContext` literals from `remote_issue.issue_type`.
+6. Update existing `known_types` test fixtures (issue_body.rs `default_known_types()`, issue_cache.rs `vec!["story".to_string()]`-style literals) to `TypeMatchRule` construction.
+7. New unit test directly on `extract_type_and_tags`: two types both matching one issue -> both checks run, neither short-circuits (per AC5).
+
+## Out of scope
+
+- Discovery/GraphQL query construction -- STORY-193.
+- Writing >1 cache doc on multi-match -- STORY-194.
+- `create` pushing `github_issue_type` -- STORY-195.
+- README -- STORY-196.
+
+## Principles/conventions
+
+Engine-only change (CONVENTION.md L3) -- no CLI/TUI surface change. Reuses ITERATION-261's plumbing shape rather than duplicating it, per story's explicit "one pass, not two" instruction.
+
+## Verification
+
+- Unconfigured type (no tag/issue_type): issue with matching label classifies exactly as before -- regression-free.
+- Tag-only type: issue with that label but no `lazyspec:{name}` label at all still matches.
+- Issue-type-only type: issue with matching native type but no label at all still matches.
+- Both set: issue satisfying only one of the two does NOT match (AND, not OR).
+- Two types both matching one issue: unit test on `extract_type_and_tags` shows both checks execute (no short-circuit).
+- All listed call sites compile against `Vec<TypeMatchRule>`; existing fetch/update/set_provenance/merge_relation_to_remote tests for unconfigured types pass unchanged.
+

--- a/docs/iterations/ITERATION-264-issue-type-graphql-discovery-for-github-issues-fetch.md
+++ b/docs/iterations/ITERATION-264-issue-type-graphql-discovery-for-github-issues-fetch.md
@@ -1,0 +1,54 @@
+---
+title: Issue-type GraphQL discovery for github-issues fetch
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-193
+---
+
+## Objective
+
+GraphQL search discovery for `github_issue_type`-configured types; both-signals case intersects REST label results with GraphQL search results by issue number (AND, not union).
+
+## Context
+
+- Story: STORY-193 (assumes STORY-191 schema + STORY-192 `TypeMatchRule` plumbing landed -- ITERATION-262, ITERATION-263)
+- Design (exact query, `parse_search_issue_numbers`, `search_issue_numbers_by_type` signature, `discover_issues` helper shape, cost profile): STORY-193 body verbatim -- don't re-derive.
+- Touch: src/engine/gh.rs (new `ISSUE_TYPE_SEARCH_QUERY`, `parse_search_issue_numbers`, `search_issue_numbers_by_type`, next to `ISSUE_TYPE_QUERY`/`parse_issue_type_name` at gh.rs:770-782), src/engine/issue_cache.rs (`refresh_stale`:131-193, `fetch_all`:302-317 -- shared `discover_issues` helper).
+
+## Satisfies
+
+STORY-193 AC1-AC6 (all -- one discovery-branch change shared by both fetch entry points, not separable).
+
+## Tasks
+
+1. gh.rs: add `ISSUE_TYPE_SEARCH_QUERY` const, `parse_search_issue_numbers` (defensive parse, empty on malformed), `search_issue_numbers_by_type` (free fn, reuses existing `GhGraphql::graphql` + `build_graphql_args`, `$searchQuery` variable per `ISSUE_TYPE_QUERY` pattern).
+2. issue_cache.rs: extract shared `discover_issues(gh, gh_graphql, repo, rule: &TypeMatchRule, fields, limit) -> Result<Vec<GhIssue>>` covering the three branches: label/tag-only (unchanged REST `issue_list`), issue-type-only (search + resolve each number via `issue_view`, no `issue_list` call), both-set (REST + search, intersect by issue number, drop non-intersecting).
+3. Wire `refresh_stale` and `fetch_all` to call `discover_issues` instead of their current inline `let label = ...; let labels = vec![label];` block.
+4. Truncation warning: when GraphQL search returns exactly 100 numbers, surface a `RefreshWarning`/`FetchResult` warning mirroring the existing `FETCH_LIMIT`-hit warning (issue_cache.rs:320-327).
+5. Unit tests via `MockGhClient`'s existing `graphql_responses`/`graphql_calls` seam (gh.rs:1167-1168,:1676-1691): `parse_search_issue_numbers` on well-formed and malformed responses; both-signals intersection drops an issue present in only one result set; issue-type-only path makes zero `issue_list` calls.
+
+## Out of scope
+
+- Config fields, classification logic -- STORY-191/192.
+- Dual materialization -- STORY-194.
+- `create` write-side push -- STORY-195.
+- README -- STORY-196.
+- Pagination past 100 (search) / 500 (REST `FETCH_LIMIT`) -- warn only, no further pages.
+- Escaping `"` in issue-type names for the search qualifier -- known edge case, not solved here.
+
+## Principles/conventions
+
+Engine-only (CONVENTION.md L3) -- no new `GhGraphql` trait method, reuses existing `graphql()`/`build_graphql_args`, matching `issue_view`'s existing ad hoc query pattern.
+
+## Verification
+
+- Only `github_issue_type` set: zero `gh issue list --label` calls; candidate set is exactly the search result, each resolved via `issue_view`.
+- Only `github_issue_tag` set (or neither): discovery byte-for-byte unchanged from today -- one REST call, no GraphQL search.
+- Both set: both calls made, result is issue-number intersection, not union.
+- `parse_search_issue_numbers` on `{"data":{"search":{"nodes":[{"number":42},{"number":7}]}}}` -> `[42, 7]`; malformed/missing nodes -> `[]`.
+- Search returning exactly 100 numbers -> truncation warning surfaced.
+

--- a/docs/iterations/ITERATION-264-issue-type-graphql-discovery-for-github-issues-fetch.md
+++ b/docs/iterations/ITERATION-264-issue-type-graphql-discovery-for-github-issues-fetch.md
@@ -1,7 +1,7 @@
 ---
 title: Issue-type GraphQL discovery for github-issues fetch
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-03
 tags: []

--- a/docs/iterations/ITERATION-265-dual-materialization-for-overlapping-type-matches.md
+++ b/docs/iterations/ITERATION-265-dual-materialization-for-overlapping-type-matches.md
@@ -1,7 +1,7 @@
 ---
 title: Dual materialization for overlapping type matches
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-03
 tags: []

--- a/docs/iterations/ITERATION-265-dual-materialization-for-overlapping-type-matches.md
+++ b/docs/iterations/ITERATION-265-dual-materialization-for-overlapping-type-matches.md
@@ -1,0 +1,51 @@
+---
+title: Dual materialization for overlapping type matches
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-194
+---
+
+## Objective
+
+Lock in, with a test, that `fetch_all`/`refresh_stale` already write independent per-type cache docs when two types both match one issue -- no production code change expected.
+
+## Context
+
+- Story: STORY-194 (assumes STORY-192/193 landed -- ITERATION-263, ITERATION-264 -- for real match-rule evaluation; this story's test mocks the multi-match outcome directly, doesn't need real classification)
+- Design (why this already works, exact test shape, accepted last-write-wins risk): STORY-194 body verbatim -- don't re-derive.
+- Touch: src/engine/issue_cache.rs test module only. Closest existing shape: `test_fetch_all_populates_cache_with_frontmatter` (issue_cache.rs:1126), `test_fetch_all_cleans_up_removed_issues` (:1246), `test_refresh_stale_fetches_all_via_issue_list` (:941).
+
+## Satisfies
+
+STORY-194 AC1-AC4 (all -- one test scenario exercised across fetch + refresh, not separable).
+
+## Tasks
+
+1. Two `TypeDef` fixtures, distinct `prefix`/`name`/`dir`, both `store = GithubIssues`.
+2. `MockReader` returning the same issue `number` (e.g. `42`) for both types' `issue_list` calls (existing `MockReader::issue_list` already ignores `_labels`, issue_cache.rs:832-845).
+3. Call `fetch_all` once per `TypeDef` against the same temp root + `IssueMap`. Assert two cache files exist under each type's own `.lazyspec/cache/<type>/` dir, correctly named/prefixed, each parses with `type:` matching its own type, each `IssueMap` entry resolves `issue_number: 42` under its own doc id.
+4. Backdate both docs' lock entries; call `refresh_stale` for type A then type B. Assert both refresh independently -- refreshing A doesn't touch B's cache dir/lock entry/issue-map row, and vice versa.
+5. If any assertion fails: that is the finding to report, not something to route around with a production change (per story's explicit no-change expectation).
+
+## Out of scope
+
+- Match-rule evaluation/discovery deciding which issues match which type -- STORY-192/193 (mocked directly here).
+- Any conflict detection, optimistic locking, ownership, or precedence mechanism -- explicitly out of scope per RFC-055 Non-goals; last-write-wins accepted (RFC-050 precedent).
+- Any change to `fetch_all`, `refresh_stale`, `write_cache_file`/`write_cache_parent`/`write_cache_child`, or `update`.
+- A `validate`/`fetch` overlap diagnostic -- flagged as a possible follow-up, not required here.
+- `create` native issue type push -- STORY-195. README -- STORY-196.
+
+## Principles/conventions
+
+Test-only addition to existing issue_cache.rs test module (CONVENTION.md L4 -- real implementations by default, fakes only at trait seams; `MockReader` is the existing seam, no new fake introduced).
+
+## Verification
+
+- Two independent cache files exist after the two `fetch_all` calls, correctly attributed and indexed.
+- Independent `refresh_stale` per type: no cross-contamination of cache dir, lock entry, or issue-map row.
+- `update` on either doc still goes through the existing single-issue update flow unmodified; no assertion that the two docs stay in sync post-update (divergence via last-write-wins is the expected outcome).
+

--- a/docs/iterations/ITERATION-266-push-native-issue-type-on-lazyspec-created-github-issues.md
+++ b/docs/iterations/ITERATION-266-push-native-issue-type-on-lazyspec-created-github-issues.md
@@ -1,0 +1,52 @@
+---
+title: Push native issue type on lazyspec-created GitHub issues
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-195
+---
+
+## Objective
+
+`GithubIssuesStore::create` resolves `type_def.github_issue_type` before issue creation, pushes it via `push_issue_type` right after -- no follow-up `update --issue_type` needed.
+
+## Context
+
+- Story: STORY-195 (assumes STORY-191 schema landed -- ITERATION-262)
+- Design (exact resolve-before-create ordering, error message reuse, `create_child_subissue` free-ride): STORY-195 body verbatim -- don't re-derive.
+- Touch: src/engine/store_dispatch.rs `create` (868-940, `issue_create` call at 904; resolve+push added around it), reusing `push_issue_type` (373-410) and `update`'s existing resolve pattern (1023-1043) and error branches (1030-1040) verbatim.
+- `materialize_one` (479-520) NOT touched -- separate call site, out of scope.
+
+## Satisfies
+
+STORY-195 AC1-AC4 (all -- one call-site change: resolve-then-create-then-push, tested across configured/unconfigured/unresolvable/child-subissue cases).
+
+## Tasks
+
+1. In `create`, after existing `label_ensure` call (899-901) and before `issue_create` (904): when `type_def.github_issue_type` is `Some(name)`, load `GhSchemaSnapshot::load(&self.root)` + `.issue_type_id(name)`; on empty `snapshot.issue_types` or unresolved name, fail with the same two error strings `update` uses (1030-1040) -- before any remote write.
+2. After `issue_create` returns and `issue.number` is known: if resolved, call `self.push_issue_type(issue.number, Some(&resolved_id))?`. When `github_issue_type` unset: no call at all (no "clear" case needed -- new issue has no prior state).
+3. Confirm `create_child_subissue` (728-772, delegates to `create` at line 748) inherits this behavior with no code change -- add a test proving it, not new logic.
+
+## Out of scope
+
+- `github_issue_tag` label resolution at creation -- STORY-190/191/192; this story assumes `create`'s existing `label_ensure`/`issue_create` call already resolves the right label.
+- Read-side classification/discovery -- STORY-192/193.
+- Dual materialization -- STORY-194.
+- README -- STORY-196.
+- `materialize_one`'s `issue_create` call site (502) -- plausible follow-up, not required here.
+- Clearing a previously-pushed type on `create` -- not applicable, no prior state.
+
+## Principles/conventions
+
+Engine-only (CONVENTION.md L3) -- reuses `push_issue_type` and `update`'s error branches verbatim rather than inventing new error strings.
+
+## Verification
+
+- `github_issue_type` set to a name present in org schema: new issue has that native type set, via `push_issue_type` called right after `issue_create` succeeds.
+- `github_issue_type` unset: no `push_issue_type` call, issue creation byte-for-byte unchanged.
+- `github_issue_type` set to an unresolvable name (empty org schema, or name absent): same error `update --issue_type` produces, and no issue is created at all (fails before `issue_create`).
+- `create_child_subissue` with `github_issue_type` configured on its type: child issue gets the type pushed too, with zero new code exercised beyond the delegation to `create`.
+

--- a/docs/iterations/ITERATION-267-document-github-issue-tag-and-github-issue-type-in-readme.md
+++ b/docs/iterations/ITERATION-267-document-github-issue-tag-and-github-issue-type-in-readme.md
@@ -1,0 +1,46 @@
+---
+title: Document github_issue_tag and github_issue_type in README
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-03
+tags: []
+related:
+- implements: STORY-196
+---
+
+## Objective
+
+Document `github_issue_tag`/`github_issue_type` in README's `github-issues` store auth section -- doc-only, no code.
+
+## Context
+
+- Story: STORY-196 (assumes STORY-191/192/193/194/195 shipped -- ITERATION-262 through 266 -- so documented behavior matches reality)
+- Exact proposed text (four matching cases, dual-materialization/last-write-wins callout, `create` behavior, placement rationale): STORY-196 body verbatim -- copy the proposed addition as written, don't re-derive.
+- Touch: README.md, existing `#### \`github-issues\` store auth` section (README.md:537-549) only -- insert after `GH_TOKEN` paragraph, before `#### \`github-milestones\` store`.
+
+## Satisfies
+
+STORY-196 AC1-AC4 (all -- single README insertion).
+
+## Tasks
+
+1. Insert STORY-196's proposed addition (prose + `toml` example + four-case bullet list + dual-materialization/last-write-wins paragraph + `create` behavior paragraph) verbatim into README.md at the specified location.
+2. Confirm no other README section is touched.
+3. Confirm the added text matches the section's existing prose-plus-`toml`-example convention (Custom Types, Numbering, Validation Rules sections) -- same heading level, same code-fence style.
+
+## Out of scope
+
+- Editing config schema, matching logic, discovery, materialization, or write-side behavior -- STORY-191/192/193/194/195.
+- Documenting `github_label`/`label_override` (STORY-190) or its overlap with `github_issue_tag` -- open RFC-055 decision, not documented until resolved.
+
+## Principles/conventions
+
+Documentation-only (CONVENTION.md L1 -- codebase produces/serves structured markdown, this is the README instance of that).
+
+## Verification
+
+- README's `github-issues` auth section documents both fields, the four matching cases (neither/tag-only/type-only/both, AND semantics), dual materialization, and last-write-wins.
+- `git diff README.md` touches only the one section -- no other section changed.
+- Documented semantics match RFC-055's Design section exactly -- no drift from the four cases as specified.
+

--- a/docs/rfcs/RFC-055-github-issue-type-as-a-classification-signal-for-the-github-issues-store.md
+++ b/docs/rfcs/RFC-055-github-issue-type-as-a-classification-signal-for-the-github-issues-store.md
@@ -1,0 +1,134 @@
+---
+title: GitHub issue-type as a classification signal for the github-issues store
+type: rfc
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- related-to: RFC-050
+- related-to: RFC-037
+---## Summary
+
+Let a `github-issues`-store type declare its native GitHub Issue Type (`github_issue_type`) and/or an arbitrary tag (`github_issue_tag`) as classification signals, alongside or instead of the existing `lazyspec:{type}` label. When set, these fields opt a type out of the default label check entirely; when both are set they combine with AND. Two lazyspec types are allowed to both match the same underlying GitHub issue — `fetch` then materializes one independent doc per matching type, all pointing at the same issue, kept in sync last-write-wins.
+
+## Motivation
+
+Type classification for `github-issues`-store types is label-only today: `lazyspec:{type}` by default (RFC-037), or a custom string via `github_label` (STORY-190, accepted but unbuilt). RFC-050 added the native GitHub Issue Type field to the document model, but deliberately kept it out of classification — its Goals section states plainly: "Native issue-type readable and writable as an orthogonal document attribute (lazyspec type stays the `lazyspec:{type}` label)." Issue type today is metadata you can read and set on a doc; it plays no part in deciding what doc a GitHub issue becomes.
+
+That leaves a gap for teams who already classify their GitHub issues with native Issue Types instead of (or in addition to) labels: "all issues in GitHub with issue type = Feature become stories in lazyspec" is not expressible today. This RFC reverses RFC-050's specific stance and makes native issue type a first-class classification signal.
+
+## Goals
+
+- `github_issue_type: Option<String>` on `TypeDef` — the native GitHub Issue Type name this lazyspec type matches.
+- `github_issue_tag: Option<String>` on `TypeDef` — an arbitrary GitHub label this lazyspec type matches, independent of the `lazyspec:` prefix scheme. Absorbs the field STORY-190 proposed as `github_label`.
+- Matching semantics per type, evaluated at fetch/classify time:
+  - Neither field set: today's behavior, unchanged (`lazyspec:{type}` label match).
+  - Only `github_issue_type` set: matches every issue with that native issue type; no label/tag check at all.
+  - Only `github_issue_tag` set: matches every issue carrying that tag; no native-type check at all.
+  - Both set: AND — an issue must carry both signals to match.
+- Setting either field opts a type fully out of the default `lazyspec:{type}` fallback — no dual-checking against the old default once either is configured.
+- Cross-type overlap is a supported outcome: two types may both be configured to match the same issue (e.g. both set `github_issue_type = "Feature"`, or one via tag and the other via type). No precedence or ownership mechanism arbitrates this.
+- `fetch` materializes one independent cache doc per matching type from a single GitHub issue (dual materialization) — same issue number, different type dir/prefix/numbering, N docs when N types match.
+- `create` for a type with `github_issue_type` configured also pushes that native issue type onto the newly created GitHub issue, reusing the existing `push_issue_type` mutation (built for manual `update --issue_type` under RFC-050).
+- Discovery: label/tag-based matching keeps using the existing server-side `gh issue list --label` filter; issue-type-based matching adds a GraphQL search query (no REST filter exists for native issue type), reusing the GraphQL plumbing RFC-050 already established for issue-type resolution. For a type with only one signal configured, that signal's result set is used directly; for a type with both `github_issue_tag` and `github_issue_type` set, the two result sets intersect (AND semantics, matching the Goals above) rather than merge — a union would wrongly surface issues satisfying only one of the two configured signals.
+
+## Non-goals
+
+- **No precedence or ownership mechanism across overlapping type matches.** Overlap is an accepted, intended outcome, not an error state to arbitrate.
+- **No conflict detection or optimistic locking on dual-materialized writes.** Two docs backed by the same issue both remain independently `update`-able; whichever writes last to the issue's single `<!-- lazyspec ... -->` frontmatter comment block wins. This matches RFC-050's existing house policy ("last-write-wins + refresh; optimistic locking for native fields is out of scope") — not a new risk class introduced here.
+- **No change to `filesystem` or `github-milestones` store classification.** Scoped to `github-issues` only.
+- **No resolution of STORY-190's fate here.** STORY-190 (accepted, unbuilt) proposed `github_label: Option<String>` for the same purpose `github_issue_tag` now serves. This RFC does not retire or rewrite that story; it flags the overlap as a follow-up decision once this RFC is accepted (see Decisions).
+
+## Design
+
+### Config schema
+
+Two new optional `TypeDef` fields, both `#[serde(default)]`:
+
+```rust
+pub struct TypeDef {
+    // ...
+    pub github_issue_tag: Option<String>,
+    pub github_issue_type: Option<String>,
+}
+```
+
+Both are inert on non-`github-issues` types (unused by any store), following the same silent-ignore precedent STORY-190 set for `github_label` on non-`github-issues` types.
+
+### Classification (read side)
+
+`extract_type_and_tags` (issue_body.rs) currently walks an issue's labels once, matching the first `lazyspec:`-prefixed suffix against `known_types`, falling back to a `default_type`. That function's contract changes from "which label matches" to "does this issue satisfy this type's configured match rule", evaluated independently per candidate type rather than short-circuiting on the first hit:
+
+- Type has neither field set → existing label-prefix check (or custom `github_label` per STORY-190, pending its reconciliation).
+- Type has `github_issue_type` and/or `github_issue_tag` set → check only those signals (AND if both), skip the label-prefix check entirely.
+
+Because a type boundary is no longer "first match wins" but "does this type's rule hold", an issue can satisfy zero, one, or several types. Zero → existing `default_type` fallback (per the type currently being fetched, since fetch is invoked per-type). Several → dual materialization (below).
+
+The plumbing gap flagged in STORY-190 — that only bare type-name strings reach `extract_type_and_tags`, not each type's resolved label/tag/issue-type rule — applies here too and in the same call chain (`issue_cache.rs` `parse_issue`/`refresh_stale`/`fetch_all`, `store_dispatch.rs`'s three `IssueContext` builders). Threading the full per-type match rule (not just a name list) through this chain is shared groundwork for both STORY-190 and this RFC.
+
+### Dual materialization
+
+`fetch` is invoked per lazyspec type today and already writes into that type's own `.lazyspec/cache/<type>/` directory with its own numbering. Dual materialization requires no new storage concept: when type A's fetch and type B's fetch each independently determine a given issue matches their own rule, each writes its own doc (`TICKET-42`, `STORY-17`) into its own cache directory, unaware of the other. No cross-type coordination is introduced; the "duplication" is simply that fetch no longer assumes each issue belongs to exactly one type's cache.
+
+Both docs remain live: subsequent `fetch` runs for either type continue reclassifying and refreshing their own copy, and `update` on either writes through to the same underlying issue.
+
+### Discovery: label vs. issue-type search
+
+Label/tag discovery is unchanged: `gh issue list --label <value>`, server-side filtered (gh.rs:719, 796).
+
+Issue-type discovery has no REST filter equivalent. It uses a GraphQL search query scoped to the repo, e.g.:
+
+```graphql
+search(query: "repo:OWNER/REPO is:issue type:\"Feature\"", type: ISSUE, first: 100) {
+  nodes { ... on Issue { number } }
+}
+```
+
+reusing the `GhGraphql` trait RFC-050 introduced. When a type's config implies checking both label and issue-type (i.e. `github_issue_tag` and `github_issue_type` both set), both queries run and their issue-number results intersect (AND semantics — Goals); when only `github_issue_type` is set, only the GraphQL search result set is used.
+
+### Write side: create
+
+`create` for a type with `github_issue_type` configured pushes that value via the existing `push_issue_type` mutation (store_dispatch.rs) immediately after issue creation, the same call `update --issue_type` already uses. `github_issue_tag`, if also configured, is applied as a label at creation the same way the default `lazyspec:{type}` / custom `github_label` is today.
+
+### Write side: dual-materialized updates
+
+No new write path. Each materialized doc's `update` goes through the store's existing single-issue update flow unmodified. The shared-frontmatter last-write-wins behavior is a consequence of that flow being unaware another type's doc also targets the same issue — not a new code path requiring its own conflict handling.
+
+## Relation to prior RFCs
+
+- **Amends RFC-050.** RFC-050's Goals section states native issue-type stays "orthogonal" and that "lazyspec type stays the `lazyspec:{type}` label." This RFC replaces that stance for types that opt in via `github_issue_type`/`github_issue_tag`; types that set neither are unaffected and keep RFC-050's original orthogonal behavior.
+- **Revises RFC-037.** RFC-037 states the store "uses a single `lazyspec:{type}` label per issue for type filtering" and that there is "one [label] per issue" (RFC-037:34, 78), implicitly one doc per issue. This RFC changes that invariant to "one doc per matching type" — one issue may back zero, one, or several lazyspec docs depending on how many types' rules it satisfies.
+- **Overlaps STORY-190.** STORY-190 (accepted, unbuilt) proposes `github_label: Option<String>` to override the label string a type filters/creates/tags with. `github_issue_tag` in this RFC serves the same purpose (a type-configurable tag independent of the `lazyspec:` prefix). Reconciling the two — folding STORY-190 into this RFC's field, or keeping both — is an open decision for after this RFC lands (see Decisions).
+
+## Interfaces
+
+- `TypeDef.github_issue_tag: Option<String>` @draft, `#[serde(default)]`.
+- `TypeDef.github_issue_type: Option<String>` @draft, `#[serde(default)]`.
+- `extract_type_and_tags` (issue_body.rs) signature changes from "known type names + label list" to "per-type match rule (label-or-tag-or-issue-type, AND/fallback semantics) + label list" @draft.
+- Fetch call chain (`issue_cache.rs` `parse_issue`, `refresh_stale`, `fetch_all`; `store_dispatch.rs`'s three `IssueContext` builders) threads full per-type match rules instead of bare `known_types: &[String]` @draft — shared with STORY-190's plumbing gap.
+- New GraphQL search call for issue-type discovery, via the existing `GhGraphql` trait (RFC-050) @draft.
+- `push_issue_type` (store_dispatch.rs) gains a call site from `create`, not just `update` @draft.
+
+## Decisions (ADRs to emit)
+
+- **Native issue type becomes a classification signal, reversing RFC-050's orthogonality stance for opted-in types.** Records why the "type stays the label" invariant no longer holds universally.
+- **Overlap across types is accepted, not arbitrated.** No precedence/ownership mechanism; two types may legitimately both match one issue.
+- **One doc per matching type, not one doc per issue.** Revises RFC-037's original per-issue invariant.
+- **Last-write-wins extends to dual-materialized docs sharing one issue.** Consistent with RFC-050's existing native-write policy, applied to a new case (two *different* doc identities, not just concurrent edits to one).
+
+## Stories
+
+1. **Config schema** — `github_issue_tag` / `github_issue_type` fields on `TypeDef`, validation (inert on non-`github-issues` types, per STORY-190 precedent).
+2. **Per-type match-rule plumbing** — thread label/tag/issue-type rules through the fetch call chain in place of bare `known_types`, replacing `extract_type_and_tags`'s first-match logic with independent per-type evaluation. Shares groundwork with STORY-190.
+3. **Issue-type GraphQL discovery** — search-based fetch path, combined with existing label-filtered `gh issue list` results per type's configured signals (intersected when both are set, per Design).
+4. **Dual materialization** — fetch writes independent cache docs per matching type from one issue; round-trip test (issue matching two types produces two docs, both refresh correctly).
+5. **`create` pushes native issue type** — bidirectional write-side symmetry with `github_issue_type`.
+6. **README documentation** — new fields under the `github-issues` store auth section, matching sibling field documentation conventions.
+
+## Risks and tradeoffs
+
+- **Silent data loss on dual-materialized writes.** Two docs, one issue, one frontmatter comment block: updating one can silently drop the other's attributes. Accepted per RFC-050 precedent; revisit if this proves surprising in practice.
+- **Overlap has no guardrail against misconfiguration.** Two types both targeting `github_issue_type = "Feature"` is indistinguishable, from lazyspec's view, between "intentional dual classification" and "accidental typo/copy-paste." No validation catches the latter, by design (Non-goals) — a `validate`/`fetch` diagnostic surfacing detected overlaps (informational only, not blocking) is worth considering as follow-up, not required here.
+- **GraphQL search adds a second discovery query per fetch for issue-type-enabled types**, beyond the existing label-filtered REST call. Cost scales with the number of types configuring `github_issue_type`, not with total repo issue count (search is itself server-side filtered).
+- **STORY-190 overlap left unresolved.** Shipping this RFC without reconciling STORY-190's `github_label` field risks two near-identical mechanisms coexisting in config. Flagged as a Decision, not resolved here.

--- a/docs/stories/STORY-190-custom-github-label-per-document-type.md
+++ b/docs/stories/STORY-190-custom-github-label-per-document-type.md
@@ -1,0 +1,69 @@
+---
+title: Custom GitHub label per document type
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-037
+---## Problem
+
+RFC-037 fixes the github-issues type filter label as `lazyspec:{type}`, hardcoded in `type_label()` (src/engine/gh.rs:218-220). Every `github-issues` type gets this exact label. A type named `ticket` always shows `lazyspec:ticket` on its issues — no way to use a plainer label like `Ticket`.
+
+## Goal
+
+Let a `github-issues` type declare its own label in config. Default stays `lazyspec:{type}` when unset, so existing configs need no change.
+
+## Design
+
+Add `github_label: Option<String>` to `TypeDef` (src/engine/config.rs:239-266), `#[serde(default)]`. Add a resolver method:
+
+```rust
+impl TypeDef {
+    pub fn github_label(&self) -> String {
+        self.github_label.clone().unwrap_or_else(|| gh::type_label(&self.name))
+    }
+}
+```
+
+(name clash: rename the field or the method — pick one, `github_label()` reads better than the field, so consider `label_override: Option<String>` for the field.)
+
+### Write side — swap every `gh::type_label(&type_def.name)` call for `type_def.github_label()`
+
+- src/cli/init.rs:85 (`ensure_github_labels`, label creation on `init`)
+- src/engine/store_dispatch.rs:495 (`materialize_one`)
+- src/engine/store_dispatch.rs:897 (issue create on new doc)
+- src/engine/store_dispatch.rs:1131 (`delete`, tags deleted issue)
+- src/engine/issue_cache.rs:161 (`refresh_stale`, fetch filter)
+- src/engine/issue_cache.rs:313 (`fetch_all`, fetch filter)
+
+### Read side — label-to-type matching can't stay a `"lazyspec:"` prefix strip
+
+`extract_type_and_tags` (src/engine/issue_body.rs:169-190) currently strips the `lazyspec:` prefix and matches the suffix against `known_types` (plain name strings). Once labels are arbitrary strings, prefix-stripping can't identify the type label among an issue's other labels — needs an exact match against each known type's resolved label instead.
+
+Plumbing: `Config` (full `TypeDef` list, so full label set) is in scope one level above every call site (`issue_cache.rs` `refresh_stale`/`fetch_all` take `config: &Config`; the three `store_dispatch.rs` sites hold `self.config`) but only bare name strings get extracted before passing down to `parse_issue` / `IssueContext` / `deserialize` / `extract_type_and_tags`. Thread a name+label pair (or a `label -> name` map) through this chain instead of `known_types: &[String]`:
+
+- src/engine/issue_cache.rs:553 (`parse_issue` signature)
+- src/engine/issue_cache.rs:201, :352 (its two call sites, `known_types` currently built as bare names)
+- src/engine/issue_body.rs:95-96 (`deserialize`, builds `known_type_refs` from `ctx.known_types`)
+- src/engine/store_dispatch.rs:268-282, :955-969, :1092-1106 (three direct `IssueContext` builders, `known_types` built via `self.config.documents.types.iter().map(|t| t.name.clone())`)
+
+Also fix the fallback path: src/engine/issue_cache.rs:599 filters tags with `.starts_with("lazyspec:")` when `deserialize` fails — same exact-match-against-resolved-labels fix applies here.
+
+### Validation
+
+A `github_label` override on a non-`github-issues` type is inert (unused by any store) — decide whether `validate` should warn on it or silently ignore. Recommend silently ignore; it's a config directive not a data-integrity concern (consistent with how e.g. `agents` is unused for non-iteration types today).
+
+## Non-goals
+
+- Custom labels for tags (already unprefixed, direct pass-through — untouched).
+- Custom colors/descriptions for the label (still `deterministic_color`/`"lazyspec document type: {name}"`).
+- `github-milestones` store — no label scheme there at all (native milestone entity), out of scope.
+
+## Acceptance criteria
+
+- `[[types]]` entry with `github_label = "Ticket"` creates/filters/tags issues using `Ticket`, not `lazyspec:ticket`.
+- Omitting `github_label` keeps current `lazyspec:{type}` behavior (regression-free default).
+- Reading back an issue tagged with a custom label correctly resolves its lazyspec type (round-trip through `extract_type_and_tags`).
+- `README.md` documents `github_label` under the `github-issues` store auth section (README.md:536+), matching how other `[[types]]` fields are documented there.

--- a/docs/stories/STORY-190-custom-github-label-per-document-type.md
+++ b/docs/stories/STORY-190-custom-github-label-per-document-type.md
@@ -1,7 +1,7 @@
 ---
 title: Custom GitHub label per document type
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-190-custom-github-label-per-document-type.md
+++ b/docs/stories/STORY-190-custom-github-label-per-document-type.md
@@ -1,7 +1,7 @@
 ---
 title: Custom GitHub label per document type
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
+++ b/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
@@ -1,0 +1,55 @@
+---
+title: GitHub issue-type/tag classification config schema
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+- blocks: STORY-192
+---## Problem
+
+RFC-055 makes native GitHub Issue Type a classification signal for `github-issues`-store types, and folds STORY-190's proposed `github_label` field into a renamed `github_issue_tag`. Neither field exists on `TypeDef` yet (src/engine/config.rs:239-266): today a `[[types]]` entry has no way to declare a native issue-type match or a tag-based match independent of the `lazyspec:{type}` prefix scheme.
+
+## Goal
+
+Add the two config fields RFC-055's Design section specifies, parseable and round-tripping through `config --json`, with no behavior change — no classification, discovery, or write-side logic consumes them yet. That is stories 2-5 (below); this story is the schema foundation they all build on.
+
+## Design
+
+Add to `TypeDef` (src/engine/config.rs:239-266):
+
+```rust
+pub struct TypeDef {
+    // ...existing fields...
+    #[serde(default)]
+    pub github_issue_tag: Option<String>,
+    #[serde(default)]
+    pub github_issue_type: Option<String>,
+}
+```
+
+Both default to `None` when absent from TOML, matching the `#[serde(default)]` pattern already used for `parent_type` and `intent` (also `Option<String>`) in the same struct, and per STORY-190's identical treatment of `github_label`.
+
+### Validation — inert on non-`github-issues` types
+
+Per STORY-190's precedent (docs/stories/STORY-190-custom-github-label-per-document-type.md, "Validation" section) for its `github_label` field: a `github_issue_tag` or `github_issue_type` set on a type whose `store` is not `github-issues` is unused by any store and should be silently ignored by `validate`, not flagged as an error or warning. Same reasoning applies here — this is a config directive with no data-integrity implication, consistent with how `agents` is unused for non-iteration types today. No new validation rule is added; the absence of a check is the intended behavior.
+
+No resolver method (cf. STORY-190's `github_label()`) is needed yet — nothing reads these fields in this story. STORY-192 (per-type match-rule plumbing) is where a consuming type first reads `github_issue_tag`/`github_issue_type` off `TypeDef`.
+
+## Non-goals
+
+- Classification/matching logic (read side) — STORY-192 and STORY-193.
+- Dual materialization when a type's rule matches more than one type — STORY-194.
+- Write-side behavior (`create` pushing native issue type, tagging with `github_issue_tag`) — STORY-195.
+- README documentation of the new fields — STORY-196.
+- Reconciling `github_issue_tag` with STORY-190's `github_label` field (RFC-055 flags this as an open Decision, not resolved by this story).
+
+## Acceptance criteria
+
+- A `[[types]]` entry with `github_issue_tag = "some-tag"` and/or `github_issue_type = "Feature"` parses without error, on any `store` backend.
+- `config --json` output for that type includes `github_issue_tag` and `github_issue_type` with the configured values.
+- Omitting both fields keeps existing config parsing behavior unchanged (regression-free default; both surface as `null` in `config --json`).
+- `validate` does not report any finding — error or warning — for either field set on a non-`github-issues`-store type.
+- Setting either field has no effect on fetch, create, update, or delete behavior (no consumer exists yet).

--- a/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
+++ b/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub issue-type/tag classification config schema
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
+++ b/docs/stories/STORY-191-github-issue-type-tag-classification-config-schema.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub issue-type/tag classification config schema
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-192-per-type-match-rule-plumbing-for-issue-classification.md
+++ b/docs/stories/STORY-192-per-type-match-rule-plumbing-for-issue-classification.md
@@ -1,7 +1,7 @@
 ---
 title: Per-type match-rule plumbing for issue classification
 type: story
-status: accepted
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-192-per-type-match-rule-plumbing-for-issue-classification.md
+++ b/docs/stories/STORY-192-per-type-match-rule-plumbing-for-issue-classification.md
@@ -1,0 +1,84 @@
+---
+title: Per-type match-rule plumbing for issue classification
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+---## Problem
+
+`extract_type_and_tags` (src/engine/issue_body.rs:169-190) decides a fetched GitHub issue's lazyspec type by walking its labels once and matching the first `lazyspec:`-prefixed suffix against `known_types: &[&str]` — bare type names, first hit wins, loop then breaks in spirit (`doc_type.is_none()` guard). That contract cannot express RFC-055's per-type match rules: a type may instead (or additionally) match on an arbitrary `github_issue_tag` label or a native `github_issue_type`, AND-combined when both are set on one type, with the label-prefix check skipped entirely once either is configured (RFC-055 Design/Goals). "First match in label order" and "does type T's own rule hold" are different questions, and the current call chain cannot ask the second one because only bare type-name strings — not each type's full label/tag/issue-type rule — ever reach `extract_type_and_tags`.
+
+This is the same plumbing gap STORY-190 identified for its own purpose (custom `github_label` per type): `Config` (the full `TypeDef` list) is available one level above every call site, but only bare names get extracted before being passed down through `parse_issue` → `IssueContext` → `deserialize` → `extract_type_and_tags`. STORY-190 and this story need the identical fix — thread each type's resolved match data through this chain instead of `Vec<String>`/`&[&str]` of names — and should be built as one plumbing pass, not two competing ones. See "Relation to STORY-190" below.
+
+## Goal
+
+Change `extract_type_and_tags`'s contract from "which label matches first" to "does this issue satisfy type T's configured match rule", evaluated independently for every candidate type (no short-circuit on first hit). Thread each type's full match rule — not just its name — through the fetch/read call chain so this evaluation is possible.
+
+This story is plumbing only. It does not change what `fetch` requests from GitHub (STORY-193, not yet built), and it does not implement writing more than one cache doc when an issue satisfies more than one type's rule (STORY-194, not yet built). Within this story, an issue that satisfies zero or one types behaves as today (falls back to `default_type` on zero); the multi-match case is made *classifiable* here so STORY-194 has something to consume, but *consuming* it (dual materialization) is explicitly out of scope.
+
+## Depends on
+
+Blocked by STORY-191 (config schema): this story consumes `TypeDef.github_issue_tag: Option<String>` and `TypeDef.github_issue_type: Option<String>`, which do not exist yet. No match rule can be built from a `TypeDef` until STORY-191 lands.
+
+## Design
+
+### Match rule shape
+
+Introduce a small struct in src/engine/issue_body.rs, alongside `IssueContext`, capturing one type's resolved classification rule:
+
+- `name: String` — the lazyspec type name (`DocType` value on match).
+- `label: String` — the label checked when neither of the below is set. Defaults to `gh::type_label(&type_def.name)` (today's `lazyspec:{name}`) until/unless STORY-190's `github_label()` resolver exists, at which point only this one line of the constructor changes — see "Relation to STORY-190".
+- `tag: Option<String>` — from `TypeDef.github_issue_tag` (STORY-191).
+- `issue_type: Option<String>` — from `TypeDef.github_issue_type` (STORY-191).
+
+Built once per type from its `TypeDef`, e.g. a `From<&TypeDef>`/constructor function callers use wherever `known_types` is assembled today.
+
+### Match semantics (independent per type, per RFC-055 Design/Goals)
+
+For a given type's rule and a given issue (its labels + native issue type):
+
+- `tag` and `issue_type` both `None` → default: issue carries the `lazyspec:{label}`-style label (today's exact-prefix check, case-insensitive).
+- Only `tag` set → issue carries that label; label-prefix check skipped entirely.
+- Only `issue_type` set → issue's native issue type equals it; label-prefix check skipped entirely.
+- Both set → AND: issue must satisfy both.
+
+Every candidate type's rule is checked against the issue — no `break`/first-hit short circuit. Zero types satisfied → `default_type` fallback (the type currently being fetched/parsed), unchanged from today. One type satisfied → that type. More than one satisfied → out of this story's scope to *act* on (STORY-194); this story's job is only that the check does not silently stop at the first match and mask a second one, since STORY-194's dual materialization has nothing to build on otherwise.
+
+### Native issue type must reach the check
+
+`IssueContext` (src/engine/issue_body.rs:13-22) currently carries `labels: Vec<String>` but nothing about the issue's native GitHub issue type — that's only read later, by `insert_issue_type` (src/engine/issue_cache.rs:641-646), *after* `deserialize`/`extract_type_and_tags` have already run. A `github_issue_type` rule cannot be evaluated without it. Add `issue_type: Option<String>` to `IssueContext`, sourced from `GhIssue.issue_type` (src/engine/gh.rs:51) at the same point `parse_issue` builds the rest of the context.
+
+### Signature changes (all verified against current source)
+
+- `IssueContext` (src/engine/issue_body.rs:13-22): `known_types: Vec<String>` → `known_types: Vec<TypeMatchRule>`; add `issue_type: Option<String>`.
+- `deserialize` (src/engine/issue_body.rs:83-119, specifically the `known_type_refs`/`extract_type_and_tags` call at lines 95-96): drop the `&str`-collecting intermediate, pass `&ctx.known_types` and `ctx.issue_type.as_deref()` straight through.
+- `extract_type_and_tags` (src/engine/issue_body.rs:169-190): `known_types: &[&str]` → `known_types: &[TypeMatchRule]`; add an `issue_native_type: Option<&str>` parameter; replace the label loop's first-match logic with the independent per-type check above.
+- `parse_issue` (src/engine/issue_cache.rs:553-568): `known_types: &[String]` → `known_types: &[TypeMatchRule]`; populate the new `IssueContext.issue_type` from `issue.issue_type.clone()`.
+- Its two call sites: `refresh_stale` (src/engine/issue_cache.rs:131-142 signature, call at 200-208) and `fetch_all` (src/engine/issue_cache.rs:302-311 signature, call at 351-359) both take `known_types: &[String]` as a parameter and pass it straight through — change both signatures to `&[TypeMatchRule]`.
+- Two upstream builders that currently construct the bare `Vec<String>` fed into `fetch_all`'s `known_types` parameter: src/cli/setup.rs:47-52 (`all_type_names`) and src/cli/fetch.rs:117-122 (`all_type_names`) — both build `config.documents.types.iter().map(|t| t.name.clone()).collect()` and must build `Vec<TypeMatchRule>` instead.
+- Three direct `IssueContext` builders in src/engine/store_dispatch.rs — `merge_relation_to_remote` (268-282), `update` (955-969), `set_provenance` (1092-1106) — all build `known_types` as `self.config.documents.types.iter().map(|t| t.name.clone()).collect()` today; all three switch to building `Vec<TypeMatchRule>` the same way, and all three also need an `issue_type` field added to the `IssueContext` literal, sourced from the remote issue already in scope (`remote_issue.issue_type` — same field `parse_issue` reads).
+- Existing unit tests in src/engine/issue_body.rs and src/engine/issue_cache.rs that construct `known_types` as `Vec<String>`/`&[&str]` literals (e.g. `default_known_types()` at issue_body.rs:255, and the many `let known_types = vec!["story".to_string()]` fixtures in issue_cache.rs) need mechanical updates to the new type; not enumerated individually here.
+
+### Relation to STORY-190
+
+STORY-190 needs the exact same plumbing change (bare type names → richer per-type data reaching `extract_type_and_tags`) to resolve custom `github_label` values instead of assuming `lazyspec:{name}`. This is not a coincidence: both stories hit the identical call chain (`parse_issue` → the three `IssueContext` builders → `deserialize` → `extract_type_and_tags`) for the same reason — only names cross that boundary today. The `TypeMatchRule.label` field this story introduces is exactly the field STORY-190 needs to populate from `github_label`; if STORY-190 is implemented after this story, its change is confined to how `label` is computed (swap the `gh::type_label(&type_def.name)` default for `type_def.github_label()`), not the plumbing shape. If STORY-190 lands first, this story's `TypeMatchRule` should reuse its resolver rather than reintroducing a second one. Either order, one `TypeMatchRule`-shaped plumbing pass should satisfy both stories — implementers should not build this twice.
+
+## Non-goals
+
+- Discovery changes (server-side `gh issue list --label`/GraphQL search query construction per type's configured signals) — STORY-193.
+- Writing more than one cache doc per issue when several types' rules match — STORY-194.
+- Pushing `github_issue_type` to GitHub on `create` — STORY-195.
+- README documentation of the new fields — STORY-196.
+- Resolving STORY-190's `github_label` vs. this RFC's `github_issue_tag` overlap — RFC-055 flags that as an open decision (RFC-055 Decisions), not this story's concern beyond sharing plumbing cleanly.
+
+## Acceptance criteria
+
+- **Given** a type with neither `github_issue_tag` nor `github_issue_type` set, **when** an issue carrying its `lazyspec:{name}` (or STORY-190 custom) label is classified, **then** it matches exactly as before (regression-free default).
+- **Given** a type with only `github_issue_tag` set, **when** an issue carries that tag as a plain label but has no `lazyspec:{name}` label at all, **then** it still matches that type (label-prefix check is skipped, not required in addition).
+- **Given** a type with only `github_issue_type` set, **when** an issue's native issue type equals it but the issue carries no matching label of any kind, **then** it still matches that type.
+- **Given** a type with both `github_issue_tag` and `github_issue_type` set, **when** an issue satisfies only one of the two, **then** it does not match that type (AND, not OR).
+- **Given** two types whose rules both independently match one issue, **when** classification runs, **then** the check for the second type is still performed and not skipped because the first already matched (no first-hit short circuit) — verified by a unit test on `extract_type_and_tags` directly, independent of how a caller currently chooses to act on more than one match.
+- **Given** the existing `known_types: &[&str]`/`Vec<String>`-based call chain, **when** this story lands, **then** every call site listed in Design (issue_body.rs, issue_cache.rs, store_dispatch.rs, cli/setup.rs, cli/fetch.rs) compiles against `Vec<TypeMatchRule>` and existing fetch/update/set_provenance/merge_relation_to_remote behavior for unconfigured types (STORY-191 fields absent) is unchanged.

--- a/docs/stories/STORY-193-issue-type-graphql-discovery-for-github-issues-fetch.md
+++ b/docs/stories/STORY-193-issue-type-graphql-discovery-for-github-issues-fetch.md
@@ -1,0 +1,106 @@
+---
+title: Issue-type GraphQL discovery for github-issues fetch
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+---## Problem
+
+`github-issues` fetch discovers candidate issues for a type with exactly one mechanism today: a server-side label filter. `IssueCache::refresh_stale` and `IssueCache::fetch_all` (src/engine/issue_cache.rs:131-245 and :302-448) each build `let label = type_label(&type_def.name); let labels = vec![label];` (issue_cache.rs:161-162 and :313-314) and pass it straight to `gh.issue_list(repo, &labels, ...)` (issue_cache.rs:179 and :317), which forwards to `gh issue list --label <value>` (src/engine/gh.rs:706, :718-720 in `GhIssueReader::issue_list`). That REST filter only understands labels.
+
+RFC-055 (Story 1/STORY-191) adds `TypeDef.github_issue_tag`/`github_issue_type` (today's `TypeDef` has no such fields — src/engine/config.rs:240-266) as classification signals, and native GitHub Issue Type has no REST list filter at all. A type configured with `github_issue_type` needs a different discovery mechanism, and a type configured with *both* `github_issue_tag` and `github_issue_type` needs the two mechanisms' results combined by intersection, not union — per RFC-055's Design ("Discovery: label vs. issue-type search"), a union would wrongly surface issues that satisfy only one of the two configured signals.
+
+## Goal
+
+Add a GraphQL search-based discovery path for the native-issue-type signal, and wire it into both existing fetch entry points (`refresh_stale`, `fetch_all`) so each type's candidate issue set is resolved according to which signals it has configured:
+
+- Neither signal set (today's default): unchanged, label-filtered `gh issue list --label lazyspec:{type}`.
+- Only `github_issue_tag` set: unchanged mechanism, just a different label string (STORY-191/192's concern, not this story's).
+- Only `github_issue_type` set: GraphQL search result set only, no REST label call.
+- Both set: REST label-filtered result intersected with the GraphQL search result set, by issue number.
+
+This story assumes STORY-191 (schema) has landed and STORY-192 (per-type match-rule plumbing) has threaded each type's resolved signal(s) down to `refresh_stale`/`fetch_all` in place of (or alongside) today's `known_types: &[String]`. This story does not itself add config fields or change classification (`extract_type_and_tags`/`parse_issue`'s label-matching logic) — it only adds the missing discovery mechanism and its intersection/union-avoidance behavior at the two `gh.issue_list` call sites.
+
+## Design
+
+### New GraphQL search query (gh.rs)
+
+Add a query and parser next to the existing `ISSUE_TYPE_QUERY` / `parse_issue_type_name` pair (gh.rs:770-782), which already resolves one issue's native type over GraphQL and is the closest precedent in the file:
+
+```rust
+const ISSUE_TYPE_SEARCH_QUERY: &str =
+    "query($searchQuery: String!) { search(query: $searchQuery, type: ISSUE, first: 100) { nodes { ... on Issue { number } } } }";
+
+fn parse_search_issue_numbers(resp: &serde_json::Value) -> Vec<u64> {
+    resp.pointer("/data/search/nodes")
+        .and_then(|v| v.as_array())
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|n| n.pointer("/number").and_then(|v| v.as_u64()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn search_issue_numbers_by_type(
+    gh_graphql: &dyn GhGraphql,
+    repo: &str,
+    issue_type: &str,
+) -> Result<Vec<u64>> {
+    let search_query = format!("repo:{} is:issue type:\"{}\"", repo, issue_type);
+    let resp = gh_graphql.graphql(
+        ISSUE_TYPE_SEARCH_QUERY,
+        &[("searchQuery", GqlVar::Str(search_query))],
+    )?;
+    Ok(parse_search_issue_numbers(&resp))
+}
+```
+
+Notes on this design:
+
+- The search string is passed as a GraphQL variable (`$searchQuery`), not interpolated into the query literal — the same pattern `ISSUE_TYPE_QUERY` already uses for `$owner`/`$name`/`$number` (gh.rs:753-756), and it sidesteps needing to escape the query body itself.
+- No new trait method is needed on `GhGraphql` (gh.rs:425-452): the existing generic `graphql()` method and `build_graphql_args` (gh.rs:634-656) are reused as-is, the same way `issue_view` already builds an ad hoc query through them (gh.rs:750-757). `search_issue_numbers_by_type` is a free function, matching `parse_issue_type_name`'s shape, not a trait addition.
+- `parse_search_issue_numbers` follows `parse_project_item_fields`'s (gh.rs:554-621) defensive style: missing/malformed nodes are skipped rather than erroring the whole parse.
+- `first: 100` is a flat, unpaginated cap, matching the existing `FETCH_LIMIT = 500` flat cap already accepted for `fetch_all`'s REST call (issue_cache.rs:315, with an existing "there may be more" warning at :320-327 when the cap is hit). Pagination beyond one page is out of scope here (see Non-goals) — this story should emit an equivalent warning when a search returns exactly 100 numbers.
+- The `type:"..."` GitHub search qualifier does not itself escape an embedded `"` in the configured issue-type name; a type name containing a double quote will produce a malformed search query. Flagged as a known edge case, not solved by this story (native GitHub Issue Type names are short controlled-vocabulary strings in practice; STORY-191 is the right place to decide whether to validate this at config time).
+
+### Wiring into the two discovery call sites (issue_cache.rs)
+
+Both `refresh_stale` (src/engine/issue_cache.rs:131-193) and `fetch_all` (:302-317) already receive `gh_graphql: &dyn GhGraphql` as a parameter (:136 and :307 respectively) — it is already threaded through for the native-field schema-snapshot refresh (`refresh_schema_snapshot`, :250-271), so this story needs no new plumbing to reach a GraphQL client from either call site; it only needs the per-type signal values that STORY-192 threads in.
+
+Each site's `let label = type_label(&type_def.name); let labels = vec![label];` block (issue_cache.rs:161-162, :313-314) becomes a branch on the type's resolved discovery signal(s):
+
+- **Label/tag only** (today's default, or `github_issue_tag` alone): unchanged — `gh.issue_list(repo, &labels, &fields, ...)` as today, just resolving the label string from whatever STORY-191/192 hand down instead of always `type_label(&type_def.name)`.
+- **`github_issue_type` only**: call `search_issue_numbers_by_type(gh_graphql, repo, issue_type)`, then resolve each returned number to a full `GhIssue` via the existing `GhIssueReader::issue_view` (gh.rs:240, implemented :732-761) — `issue_view` already fetches full REST fields *and* resolves native `issue_type` over GraphQL in one call, so no new "fetch full issue by number" path is needed. `gh.issue_list` is not called at all for this type.
+- **Both set**: call the existing REST `gh.issue_list(repo, &[tag], &fields, ...)` (full `GhIssue` objects, unchanged) *and* `search_issue_numbers_by_type` (issue numbers only), then filter the REST result down to issues whose `number` is in the search result set. This reuses the REST call's already-fetched full issue data instead of also calling `issue_view` per number, and is a true set intersection — an issue returned by only one of the two calls is dropped, matching RFC-055's Design explicitly (AND semantics, not union).
+
+Both call sites should share one resolution helper (e.g. `fn discover_issues(gh, gh_graphql, repo, rule, fields, limit) -> Result<Vec<GhIssue>>` in issue_cache.rs) rather than duplicating the three-way branch independently in `refresh_stale` and `fetch_all`, since today those two functions already duplicate the `let label = ...; let labels = ...;` two-liner and diverge only in `fields`/`limit`.
+
+### Cost profile
+
+- Label-only and tag-only types: no change in call count (one REST call, as today).
+- Both-signals types: one REST call plus one GraphQL search call, per fetch — the cost RFC-055's Risks section already anticipates ("cost scales with the number of types configuring `github_issue_type`, not with total repo issue count").
+- Issue-type-only types: one GraphQL search call plus one `issue_view` GraphQL+REST round trip *per matched issue*. This N+1 cost is not called out in RFC-055's Risks section (which focused on the both-signals case) and is worth flagging here: it is proportional to the number of matched issues, not just the number of issue-type-configured types. Accepted for this story since no bulk "fetch full issues by number list" GraphQL query exists yet in this codebase; revisit if it proves too slow in practice.
+
+## Non-goals
+
+- Adding `github_issue_tag`/`github_issue_type` to `TypeDef` or any config validation — STORY-191.
+- Changing `extract_type_and_tags`/`parse_issue`'s classification logic, or threading per-type match rules through `IssueContext` builders — STORY-192. This story consumes whatever signal values STORY-192's plumbing supplies; it does not itself decide how a type's rule is resolved from config.
+- Dual materialization (two docs from one issue matching two types) — STORY-194.
+- `create` pushing `github_issue_type` onto newly created issues via `push_issue_type` — STORY-195.
+- README documentation of the new fields — STORY-196.
+- Pagination past the first 100 GraphQL search results (or past the existing 500 REST `FETCH_LIMIT`) — a warning on truncation is in scope; fetching further pages is not.
+- Any change to the write side (`push_issue_type`, `issue_create`'s label loop at gh.rs:795-798) — this story is discovery/read-side only.
+
+## Acceptance criteria
+
+- **Given** a type with only `github_issue_type` configured, **when** fetch runs (`refresh_stale` or `fetch_all`), **then** no `gh issue list --label` call is made for that type, and the candidate issue set is exactly the numbers returned by `search_issue_numbers_by_type`, each resolved to a full issue via `issue_view`.
+- **Given** a type with only `github_issue_tag` set (or neither field set, today's default), **when** fetch runs, **then** discovery behavior is byte-for-byte unchanged from today: a single REST `gh.issue_list` call with that type's resolved label, no GraphQL search call.
+- **Given** a type with both `github_issue_tag` and `github_issue_type` configured, **when** fetch runs, **then** both the REST label call and the GraphQL search call are made, and the resulting candidate set is their intersection by issue number — an issue present in only one of the two result sets is excluded, never included via a union.
+- **Given** a GraphQL search response shaped like `{"data":{"search":{"nodes":[{"number":42},{"number":7}]}}}`, **when** `parse_search_issue_numbers` parses it, **then** it returns `[42, 7]`; given malformed or missing nodes, it returns an empty list rather than erroring.
+- **Given** a GraphQL search returns exactly 100 issue numbers, **when** fetch runs for that type, **then** a `RefreshWarning`/`FetchResult` warning is surfaced noting the result may be truncated, mirroring the existing `FETCH_LIMIT`-hit warning (issue_cache.rs:320-327).
+- **Given** `MockGhClient`'s existing `graphql_responses`/`graphql_calls` test seam (gh.rs:1167-1168, :1676-1691) which already records calls and returns queued canned responses with no mock changes needed, **when** unit tests exercise `search_issue_numbers_by_type` and the both-signals intersection path, **then** they can do so entirely through that existing seam.

--- a/docs/stories/STORY-193-issue-type-graphql-discovery-for-github-issues-fetch.md
+++ b/docs/stories/STORY-193-issue-type-graphql-discovery-for-github-issues-fetch.md
@@ -1,7 +1,7 @@
 ---
 title: Issue-type GraphQL discovery for github-issues fetch
 type: story
-status: accepted
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-194-dual-materialization-for-overlapping-type-matches.md
+++ b/docs/stories/STORY-194-dual-materialization-for-overlapping-type-matches.md
@@ -1,7 +1,7 @@
 ---
 title: Dual materialization for overlapping type matches
 type: story
-status: accepted
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-194-dual-materialization-for-overlapping-type-matches.md
+++ b/docs/stories/STORY-194-dual-materialization-for-overlapping-type-matches.md
@@ -1,0 +1,61 @@
+---
+title: Dual materialization for overlapping type matches
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+---## Problem
+
+RFC-055 lets two `github-issues` types both match the same GitHub issue (e.g. both set `github_issue_type = "Feature"`, or one via `github_issue_tag` and the other via type). Once STORY-192 (per-type match-rule plumbing) and STORY-193 (issue-type GraphQL discovery) let each type's own fetch independently decide an issue satisfies its rule, nothing in `fetch`'s write path currently assumes — or guards against — the same issue being written into two different types' caches. This story confirms that write path already does the right thing with no changes, and locks that behavior in with a test.
+
+## Goal
+
+Prove `fetch` produces two independent cache docs when two types both match one issue, and that both docs individually refresh correctly afterward. Per RFC-055's Design ("Dual materialization" subsection), this requires **no new storage concept** — it is an emergent property of `fetch_all`/`refresh_stale` already being invoked once per type, into that type's own cache directory, with its own id prefix.
+
+## Design
+
+### Why this already works
+
+`IssueCache::fetch_all` (src/engine/issue_cache.rs:302-448) and `IssueCache::refresh_stale` (src/engine/issue_cache.rs:131-245) are both called once per lazyspec type — see the per-type `label`/`labels` filter built at the top of each (issue_cache.rs:313-317 for `fetch_all`, issue_cache.rs:161-179 for `refresh_stale`) and passed to `gh.issue_list`. Each call:
+
+- Resolves the doc id from that type's own prefix: `type_def.make_id(issue.number)` (issue_cache.rs:360, :209), which is `format!("{}-{}", self.prefix, suffix)` (src/engine/config.rs:989-991). Two types with different `prefix` values produce two different ids from the same `issue.number` (e.g. issue #42 → `STORY-42` for one type, `TICKET-42` for another).
+- Writes into that type's own cache directory: `root.join(".lazyspec/cache").join(&type_def.name)` (issue_cache.rs:332; mirrored in `write_cache_file`/`write_cache_parent`/`write_cache_child`, src/engine/store_dispatch.rs:1649-1790, which join `.lazyspec/cache/<type_def.name>` before writing).
+- Reads and writes its own `cache.lock` entries and `IssueMap` rows keyed by its own id (issue_cache.rs:403-424, :198-233).
+
+None of this reads or touches any other type's cache directory, lock entries, or issue-map rows. So once STORY-192/193 land and two types' independent discovery queries both surface the same issue number, calling `fetch_all` (or `refresh_stale`) for type A and then for type B — the same two calls that already run today, one per configured type — naturally writes two docs, one per type's cache directory, each with its own id. Dual materialization is fetch no longer assuming each issue belongs to exactly one type's cache, per RFC-055's Design section; it is not a code change in this story.
+
+### What this story actually adds
+
+A round-trip test in `src/engine/issue_cache.rs`'s test module, alongside the existing `fetch_all`/`refresh_stale` tests (e.g. `test_fetch_all_populates_cache_with_frontmatter`, issue_cache.rs:1126, and the two-fetch `test_fetch_all_cleans_up_removed_issues`, issue_cache.rs:1246, are the closest existing shape to follow):
+
+- Two `TypeDef`s with distinct `prefix`/`name`/`dir` (e.g. a `story_type_def()`-style helper and a second `ticket_type_def()`-style helper), both store `GithubIssues`.
+- A `MockReader` returning an issue with the same `number` (e.g. `42`) for both types' `issue_list` calls — this simulates "both types' discovery independently matched issue #42" without needing STORY-192/193's real match-rule evaluation, since `MockReader::issue_list` already ignores its `_labels` argument and returns a fixed issue set (see issue_cache.rs:832-845).
+- Call `cache.fetch_all(...)` once for each `TypeDef` against the same temp root and `IssueMap`.
+- Assert both cache files exist under their own type directories (`.lazyspec/cache/<type-a>/<PREFIX-A>-42.md` and `.lazyspec/cache/<type-b>/<PREFIX-B>-42.md`), both parse with correct frontmatter (`type:` matching their own type name), and both `IssueMap` entries resolve to `issue_number: 42` under their own doc id.
+- Call `cache.refresh_stale(...)` for each type after backdating both docs' lock entries, and assert both refresh independently (mirroring `test_refresh_stale_fetches_all_via_issue_list`, issue_cache.rs:941) — refreshing type A's doc does not touch type B's cache directory or lock entry, and vice versa.
+
+No production code in `issue_cache.rs` or `store_dispatch.rs` is expected to change for this story; if the test above fails, that is itself the finding (see Risks below), not an assumption to route around silently.
+
+### Accepted risk: last-write-wins across the two docs
+
+Both materialized docs remain independently `update`-able. `GithubIssuesStore::update` (src/engine/store_dispatch.rs:952) reads the issue's *current* remote body fresh via `check_lock` (store_dispatch.rs:953), deserializes it through `issue_body::deserialize` under its own type's `IssueContext` (store_dispatch.rs:955-969), mutates, and writes back through `issue_body::serialize`'s single `<!-- lazyspec ... -->` comment block (src/engine/issue_body.rs:24,32). There is exactly one such comment block per GitHub issue. When type A's doc and type B's doc both point at issue #42, an `update` on one reads and rewrites that one shared block with no awareness the other type's doc also targets it — whichever `update` runs last wins, and the other doc's most recent locally-known state can silently diverge from what's now on GitHub until its own next `fetch`/`refresh`.
+
+This is a **stated, accepted risk**, not a defect for this story to fix. RFC-055's Non-goals section is explicit: "No conflict detection or optimistic locking on dual-materialized writes... This matches RFC-050's existing house policy (\"last-write-wins + refresh; optimistic locking for native fields is out of scope\") — not a new risk class introduced here." This story must not introduce any ownership, precedence, or locking mechanism to arbitrate between the two docs — that is explicitly out of scope per RFC-055's Non-goals ("No precedence or ownership mechanism across overlapping type matches").
+
+## Non-goals
+
+- Per-type match-rule evaluation and discovery that decides *which* issues match which type's rule — STORY-192, STORY-193. This story assumes that decision has already been made (or, for its test, mocks the outcome directly).
+- Any conflict detection, optimistic locking, ownership, or precedence mechanism across the two materialized docs. Explicitly out of scope per RFC-055's Non-goals; last-write-wins on the shared `<!-- lazyspec ... -->` comment block is accepted, matching RFC-050 precedent.
+- Any change to `fetch_all`, `refresh_stale`, `write_cache_file`/`write_cache_parent`/`write_cache_child`, or `update`. This story is a test confirming existing per-type-scoped behavior already supports dual materialization, not a refactor.
+- A `validate`/`fetch` diagnostic surfacing detected overlaps — flagged in RFC-055's Risks as a possible follow-up, not required here.
+- `create` pushing native issue type — STORY-195. README documentation — STORY-196.
+
+## Acceptance criteria
+
+- **Given** two configured types with different `prefix` values (e.g. `story_type_def()` and a second type def), **when** each type's `fetch_all` is called against a `MockReader` that returns the same underlying issue number (e.g. `42`) for both, **then** two independent cache files exist afterward — one under each type's own `.lazyspec/cache/<type>/` directory, each named from its own type's prefix and the shared issue number (e.g. `STORY-42.md` and `TICKET-42.md`).
+- **Given** those two materialized docs, **when** their frontmatter is parsed, **then** each correctly attributes `type:` to its own lazyspec type name (not the other's), and each type's `IssueMap` entry resolves the shared issue number under its own doc id.
+- **Given** both docs' cache-lock entries backdated stale, **when** `refresh_stale` is called for type A and then for type B, **then** both refresh independently to fresh content, and refreshing one does not modify the other type's cache directory, cache-lock entry, or issue-map row.
+- **Given** the above, **when** `update` is called on either doc, **then** it writes through the store's existing single-issue update flow unmodified (no new write path is introduced), and no test in this story asserts the two docs stay in sync — divergence via last-write-wins is the expected, accepted outcome per RFC-055's Non-goals.

--- a/docs/stories/STORY-195-push-native-issue-type-on-lazyspec-created-github-issues.md
+++ b/docs/stories/STORY-195-push-native-issue-type-on-lazyspec-created-github-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Push native issue type on lazyspec-created GitHub issues
 type: story
-status: accepted
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-195-push-native-issue-type-on-lazyspec-created-github-issues.md
+++ b/docs/stories/STORY-195-push-native-issue-type-on-lazyspec-created-github-issues.md
@@ -1,0 +1,50 @@
+---
+title: Push native issue type on lazyspec-created GitHub issues
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+---## Problem
+
+RFC-055 lets a `github-issues`-store type declare a native GitHub Issue Type via `github_issue_type` (STORY-191's config schema). Today that field, once it exists, is read on `update --issue_type` only: `GithubIssuesStore::update`'s issue-type handling (src/engine/store_dispatch.rs:952-1070) resolves a `--issue_type` CLI value to a native type-id and pushes it via `push_issue_type` (src/engine/store_dispatch.rs:373-410). `create` (src/engine/store_dispatch.rs:868-940) has no equivalent: a brand-new issue for a type with `github_issue_type` configured is created with no native issue type set at all, leaving the config directive silently unhonored until someone runs a manual `update --issue_type` afterward. RFC-055's Design ("Write side: create") calls this out explicitly as required write-side symmetry.
+
+## Goal
+
+`lazyspec create <type> ...`, for a type with `github_issue_type` configured, pushes that native issue type onto the newly created GitHub issue in the same `create` call — no follow-up `update --issue_type` required. Reuse `push_issue_type` (store_dispatch.rs:373-410) exactly as `update` already does; add no new mutation.
+
+## Design
+
+### Call site: `GithubIssuesStore::create`, not `materialize_one`
+
+Two places in store_dispatch.rs call `.issue_create(...)`: `create` (the `DocumentStore` entry point behind `lazyspec create`, store_dispatch.rs:868-940, `issue_create` at line 904) and `materialize_one` (store_dispatch.rs:479-520, `issue_create` at line 502, used by `materialize_subdir` to push pre-existing filesystem docs onto GitHub). `create_child_subissue` (store_dispatch.rs:728-772) delegates to `create` internally (line 748), so it inherits this story's behavior for free. This story touches only `create`'s call site (line 904); `materialize_one` is explicitly out of scope (see Non-goals).
+
+### Resolve the type id before creating the issue, not after
+
+`update`'s existing pattern (store_dispatch.rs:1023-1043) resolves and validates the native issue-type id from `type_def`'s configured name *before* any remote write, so an invalid value rejects without a wasted mutation. `create` should follow the same discipline, one step earlier: resolve `type_def.github_issue_type` (when `Some`) to a type-id via `GhSchemaSnapshot::load(&self.root)` + `.issue_type_id(name)` (gh_schema.rs:57, :75) *before* calling `issue_create` (store_dispatch.rs:904) — right after the existing `label_ensure` call (store_dispatch.rs:899-901) that resolves the type's label. This way an unresolvable `github_issue_type` (no org-owned repo, or a name absent from the org's schema) fails before a stray issue is created, rather than creating the issue and then failing to tag it. Reuse `update`'s two error branches verbatim (store_dispatch.rs:1030-1040): "native issue types require an organization-owned repository" when `snapshot.issue_types` is empty, "invalid issue_type '{name}': not a known GitHub issue type" otherwise.
+
+### Push the id immediately after issue creation
+
+Immediately after `issue_create` returns (store_dispatch.rs:904-905), with `issue.number` now known, call `self.push_issue_type(issue.number, Some(&resolved_id))?` when `type_def.github_issue_type` was configured and resolved. When it is unset, make no call at all — unlike `update`, which has an explicit "clear" case (`Some(None)` when `--issue_type ""`, store_dispatch.rs:1024), `create` has no prior state to clear: an issue with no configured `github_issue_type` is simply created with GitHub's default (no issue type), exactly as today.
+
+### `github_issue_tag` is not this story's work
+
+RFC-055's Design notes `github_issue_tag`, if also configured, is applied as a label at creation "the same way the default `lazyspec:{type}` / custom `github_label` is today" — i.e. through the *same* existing `label_ensure`/`issue_create` call this story touches (store_dispatch.rs:899-904), not a new one. Once STORY-192's per-type match-rule plumbing resolves a type's effective creation label (falling back through `github_issue_tag` / STORY-190's `github_label` / the default `lazyspec:{type}`), `create`'s existing label call site applies whatever that resolution yields automatically. This story does not implement that label resolution; it only adds the issue-type push alongside it.
+
+## Non-goals
+
+- `github_issue_tag` label resolution at creation time — STORY-190, STORY-191, STORY-192. This story assumes whatever label `create`'s existing `label_ensure`/`issue_create` call resolves to is already correct.
+- Read-side classification and discovery (which issues match which type's rule) — STORY-192, STORY-193.
+- Dual materialization — STORY-194.
+- README documentation of `github_issue_type`/`github_issue_tag` — STORY-196.
+- `materialize_one` / `materialize_subdir`'s `issue_create` call site (store_dispatch.rs:502). Pushing native issue type there for subdir-materialized docs is a plausible follow-up but is not required by RFC-055's Story 5 and is left untouched here.
+- Clearing a previously-pushed issue type on `create` — not applicable; a newly created issue has no prior native-type state to clear.
+
+## Acceptance criteria
+
+- **Given** a `github-issues`-store type with `github_issue_type` set to a name present in the repo's org issue-type schema, **when** `lazyspec create <type> ...` runs, **then** the newly created GitHub issue has that native issue type set, via a `push_issue_type(issue.number, Some(id))` call made immediately after `issue_create` succeeds.
+- **Given** a type with `github_issue_type` unset, **when** `create` runs, **then** no `push_issue_type` call is made and issue creation is byte-for-byte unchanged from today (regression-free default).
+- **Given** a type with `github_issue_type` set to a name that does not resolve (empty org issue-type schema, or a name absent from it), **when** `create` runs, **then** it fails with the same error the equivalent `update --issue_type` failure already produces, and no GitHub issue is created (the id resolves, and fails, before `issue_create` is called).
+- **Given** `create_child_subissue`, **when** its underlying type has `github_issue_type` configured, **then** the created child issue gets the native issue type pushed too, with no additional code — it delegates to `create`.

--- a/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
+++ b/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
@@ -1,0 +1,114 @@
+---
+title: Document github_issue_tag and github_issue_type in README
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-02
+tags: []
+related:
+- implements: RFC-055
+---## Problem
+
+RFC-055 adds two new `[[types]]` fields for `github-issues`-store types --
+`github_issue_tag` and `github_issue_type` -- as classification signals
+alongside the existing `lazyspec:{type}` label. STORY-191 lands the schema for
+both fields; STORY-192/193/194/195 land the matching, discovery,
+materialization, and write-side behavior. None of that is discoverable from
+the README: the `github-issues` store auth section (README.md:537-549)
+documents `gh` auth setup only, with no mention of either field once they
+ship.
+
+## Goal
+
+Document `github_issue_tag` and `github_issue_type` in README.md's
+`github-issues` store auth section, in the same prose-plus-`toml`-example
+style already used by sibling config-field sections (Custom Types, Numbering,
+Validation Rules).
+
+## Design
+
+This is a documentation-only story: no code changes. The proposed addition
+sits in the existing `#### \`github-issues\` store auth` section
+(README.md:537-549), appended after the current `GH_TOKEN` paragraph and
+before `#### \`github-milestones\` store`. Field semantics and names are as
+specified by RFC-055's Design and Goals sections and STORY-191's schema; this
+story does not redefine them, only documents them.
+
+Proposed README addition:
+
+> A `[[types]]` entry may also declare `github_issue_tag` and/or
+> `github_issue_type` to control which issues classify as that type,
+> independent of (or instead of) the default `lazyspec:{type}` label:
+>
+> ```toml
+> [[types]]
+> name = "feature"
+> prefix = "FEAT"
+> store = "github-issues"
+> github_issue_tag = "customer-facing"
+> github_issue_type = "Feature"
+> ```
+>
+> - Neither set: unchanged default -- an issue matches when it carries the
+>   `lazyspec:{type}` label.
+> - Only `github_issue_tag` set: matches every issue carrying that tag; the
+>   `lazyspec:{type}` label is not checked.
+> - Only `github_issue_type` set: matches every issue whose native GitHub
+>   Issue Type equals that value; the label is not checked.
+> - Both set: an issue must carry the tag **and** have the native issue type --
+>   AND, not OR.
+>
+> Because these are independent per-type rules, two types may legitimately
+> match the same issue (e.g. both set `github_issue_type = "Feature"`). `fetch`
+> then materializes one document per matching type from that single issue --
+> same issue number, separate cache entries under each type's own prefix and
+> numbering. Both documents stay independently `update`-able; each write goes
+> to the same issue, so whichever update runs last wins on any field the two
+> types share.
+>
+> `create` on a type with `github_issue_type` set also pushes that value onto
+> the new issue's native issue type field (needs the `project` scope described
+> above); `create` with `github_issue_tag` set applies that value as a label
+> the same way the default `lazyspec:{type}` label is applied today.
+
+Rationale for placement and framing:
+
+- Sits under "auth" because issue-type discovery is GraphQL-based and needs
+  the same `project` scope already documented there -- the callout to that
+  scope in the last paragraph ties the new fields back to the auth
+  requirement instead of repeating it.
+- The bullet list mirrors RFC-055's four matching cases (neither / tag-only /
+  type-only / both) verbatim, so a reader can map config directly to
+  behavior without re-deriving it.
+- Dual materialization and last-write-wins are called out briefly, in prose,
+  because they are surprising consequences a reader needs before opting in --
+  not because this story re-specifies STORY-194's or RFC-055's design (it
+  doesn't; it summarizes the user-visible outcome only).
+- `github_label` (STORY-190's proposed field, unbuilt, and its overlap with
+  `github_issue_tag`) is deliberately not mentioned -- RFC-055 leaves that
+  reconciliation as an open decision, so documenting it here would describe
+  behavior that doesn't exist yet.
+
+## Non-goals
+
+- Editing README.md itself -- that happens when this story is executed, not
+  when it's authored.
+- Config schema, matching logic, discovery, materialization, or write-side
+  behavior -- STORY-191, STORY-192, STORY-193, STORY-194, and STORY-195
+  respectively. This story only documents their combined user-visible
+  contract once shipped.
+- Resolving `github_label` / `github_issue_tag` overlap -- an open RFC-055
+  decision, out of scope here.
+
+## Acceptance criteria
+
+- README.md's `github-issues` store auth section documents `github_issue_tag`
+  and `github_issue_type`, including the four matching cases (neither / tag
+  only / type only / both, AND semantics) and the dual-materialization /
+  last-write-wins consequence of overlap.
+- The added text follows the section's existing prose-plus-`toml`-example
+  convention (as used by Custom Types, Numbering, and Validation Rules), not a
+  new format.
+- No other README section is touched.
+- The documented semantics match RFC-055's Design section exactly (matching
+  rules, dual materialization, `create` write-side behavior) -- no drift.

--- a/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
+++ b/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
@@ -1,7 +1,7 @@
 ---
 title: Document github_issue_tag and github_issue_type in README
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
+++ b/docs/stories/STORY-196-document-github-issue-tag-and-github-issue-type-in-readme.md
@@ -1,7 +1,7 @@
 ---
 title: Document github_issue_tag and github_issue_type in README
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-02
 tags: []

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -118,6 +118,7 @@ pub fn run_add_type(
             .unwrap_or_default(),
         lifecycle: Lifecycle::default(),
         attributes: Vec::new(),
+        label_override: None,
     });
 
     let out = write_config_in_place(&src, &config)?;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -119,6 +119,8 @@ pub fn run_add_type(
         lifecycle: Lifecycle::default(),
         attributes: Vec::new(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     });
 
     let out = write_config_in_place(&src, &config)?;

--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -373,6 +373,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         // A realistic cache file: no `id:` in frontmatter (mirrors what

--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -3,6 +3,7 @@ use crate::engine::config::{Config, StoreBackend, TypeDef};
 use crate::engine::gh::{GhGraphql, GhIssueReader, GhIssueWriter, GhMilestoneApi};
 use crate::engine::git_ref::GitRefOps;
 use crate::engine::github::resolve_repo;
+use crate::engine::issue_body::TypeMatchRule;
 use crate::engine::issue_cache::IssueCache;
 use crate::engine::issue_map::IssueMap;
 use crate::engine::store_dispatch::GithubIssuesStore;
@@ -114,11 +115,11 @@ pub fn run(
         let mut issue_map = IssueMap::load(root)?;
         let cache = IssueCache::new(root);
 
-        let all_type_names: Vec<String> = config
+        let all_type_rules: Vec<TypeMatchRule> = config
             .documents
             .types
             .iter()
-            .map(|t| t.name.clone())
+            .map(TypeMatchRule::from)
             .collect();
 
         for type_name in &gh_to_fetch {
@@ -133,7 +134,7 @@ pub fn run(
                 gh,
                 &repo,
                 &mut issue_map,
-                &all_type_names,
+                &all_type_rules,
                 config,
             )?;
 

--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -374,6 +374,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         // A realistic cache file: no `id:` in frontmatter (mirrors what

--- a/src/cli/fix/relations.rs
+++ b/src/cli/fix/relations.rs
@@ -161,6 +161,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![

--- a/src/cli/fix/relations.rs
+++ b/src/cli/fix/relations.rs
@@ -160,6 +160,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -3,7 +3,7 @@ use crate::engine::config::{
     DocumentConfig, FilesystemConfig, Naming, Templates, UiConfig,
 };
 use crate::engine::fs_ops::default_template;
-use crate::engine::gh::{deterministic_color, type_label, GhCli, GhError, GhIssueWriter};
+use crate::engine::gh::{deterministic_color, GhCli, GhError, GhIssueWriter};
 use crate::engine::github::resolve_repo;
 use anyhow::{bail, Result};
 use std::fs;
@@ -82,7 +82,10 @@ fn ensure_github_labels(config: &Config, root: &Path) {
 
     let client = GhCli::new();
     for type_name in &gh_types {
-        let label = type_label(type_name);
+        let label = match config.type_by_name(type_name) {
+            Some(type_def) => type_def.github_label(),
+            None => continue,
+        };
         let color = deterministic_color(type_name);
         let description = format!("lazyspec document type: {}", type_name);
         match client.label_ensure(&repo, &label, &description, &color) {

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -376,6 +376,7 @@ mod tests {
                         authorship: Default::default(),
                         lifecycle: Default::default(),
                         attributes: Default::default(),
+                        label_override: None,
                     },
                     TypeDef {
                         name: "story".to_string(),
@@ -393,6 +394,7 @@ mod tests {
                         authorship: Default::default(),
                         lifecycle: Default::default(),
                         attributes: Default::default(),
+                        label_override: None,
                     },
                     TypeDef {
                         name: "bug".to_string(),
@@ -410,6 +412,7 @@ mod tests {
                         authorship: Default::default(),
                         lifecycle: Default::default(),
                         attributes: Default::default(),
+                        label_override: None,
                     },
                 ],
                 naming: Naming {

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -377,6 +377,8 @@ mod tests {
                         lifecycle: Default::default(),
                         attributes: Default::default(),
                         label_override: None,
+                        github_issue_tag: None,
+                        github_issue_type: None,
                     },
                     TypeDef {
                         name: "story".to_string(),
@@ -395,6 +397,8 @@ mod tests {
                         lifecycle: Default::default(),
                         attributes: Default::default(),
                         label_override: None,
+                        github_issue_tag: None,
+                        github_issue_type: None,
                     },
                     TypeDef {
                         name: "bug".to_string(),
@@ -413,6 +417,8 @@ mod tests {
                         lifecycle: Default::default(),
                         attributes: Default::default(),
                         label_override: None,
+                        github_issue_tag: None,
+                        github_issue_type: None,
                     },
                 ],
                 naming: Naming {

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -629,6 +629,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![
@@ -1254,6 +1255,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![
@@ -1612,6 +1614,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
         let story_type = TypeDef {
             name: "story".to_string(),
@@ -1629,6 +1632,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         let mut config = Config::default();
@@ -2130,6 +2134,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
         let story_type = TypeDef {
             name: "story".to_string(),
@@ -2147,6 +2152,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         let mut config = Config::default();

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -630,6 +630,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![
@@ -1256,6 +1258,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
         let mut config = Config::default();
         config.documents.types = vec![
@@ -1615,6 +1619,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
         let story_type = TypeDef {
             name: "story".to_string(),
@@ -1633,6 +1639,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         let mut config = Config::default();
@@ -2135,6 +2143,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
         let story_type = TypeDef {
             name: "story".to_string(),
@@ -2153,6 +2163,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         let mut config = Config::default();

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,6 +1,7 @@
 use crate::engine::config::Config;
 use crate::engine::gh::{AuthStatus, GhAuth, GhGraphql, GhIssueReader};
 use crate::engine::github::resolve_repo;
+use crate::engine::issue_body::TypeMatchRule;
 use crate::engine::issue_cache::IssueCache;
 use crate::engine::issue_map::IssueMap;
 use anyhow::{bail, Context, Result};
@@ -44,11 +45,11 @@ pub fn run(
             .type_by_name(type_name)
             .ok_or_else(|| anyhow::anyhow!("type '{}' not found in config", type_name))?;
 
-        let all_type_names: Vec<String> = config
+        let all_type_rules: Vec<TypeMatchRule> = config
             .documents
             .types
             .iter()
-            .map(|t| t.name.clone())
+            .map(TypeMatchRule::from)
             .collect();
         let result = cache.fetch_all(
             root,
@@ -57,7 +58,7 @@ pub fn run(
             gh,
             &repo,
             &mut issue_map,
-            &all_type_names,
+            &all_type_rules,
             config,
         )?;
 

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -263,6 +263,11 @@ pub struct TypeDef {
     pub lifecycle: Lifecycle,
     #[serde(default)]
     pub attributes: Vec<AttrDef>,
+    /// Overrides the default `lazyspec:{name}` GitHub label used to identify
+    /// this type's issues, for `github-issues`-backed types. Unused by other
+    /// stores.
+    #[serde(default, rename = "github_label")]
+    pub label_override: Option<String>,
 }
 
 /// One entry in the `[[relationships]]` block: a relationship name and its
@@ -642,6 +647,7 @@ pub fn starter_types() -> Vec<TypeDef> {
         authorship: Authorship::default(),
         lifecycle: default_lifecycle(),
         attributes: Vec::new(),
+        label_override: None,
     };
     vec![
         simple("rfc", "rfcs", "docs/rfcs", "RFC", "●"),
@@ -671,6 +677,7 @@ pub fn starter_types() -> Vec<TypeDef> {
             authorship: Authorship::default(),
             lifecycle: default_lifecycle(),
             attributes: Vec::new(),
+            label_override: None,
         },
         TypeDef {
             name: "dictum".to_string(),
@@ -688,6 +695,7 @@ pub fn starter_types() -> Vec<TypeDef> {
             authorship: Authorship::default(),
             lifecycle: default_lifecycle(),
             attributes: Vec::new(),
+            label_override: None,
         },
     ]
 }
@@ -994,6 +1002,14 @@ impl TypeDef {
     pub fn accepts_status(&self, status: &Status) -> bool {
         self.lifecycle.states.iter().any(|s| s == status.as_str())
     }
+
+    /// The GitHub label identifying this type's issues: the configured
+    /// `label_override` if set, else the default `lazyspec:{name}`.
+    pub fn github_label(&self) -> String {
+        self.label_override
+            .clone()
+            .unwrap_or_else(|| crate::engine::gh::type_label(&self.name))
+    }
 }
 
 #[cfg(test)]
@@ -1015,6 +1031,7 @@ impl TypeDef {
             authorship: Authorship::default(),
             lifecycle: Lifecycle::default(),
             attributes: Vec::new(),
+            label_override: None,
         }
     }
 }
@@ -2090,5 +2107,45 @@ name = "mentions"
             2,
             "skip_serializing_if must omit absent traversal: {emitted}"
         );
+    }
+
+    #[test]
+    fn github_label_returns_override_verbatim_when_set() {
+        let mut td = TypeDef::test_fixture("story", StoreBackend::GithubIssues);
+        td.label_override = Some("Ticket".to_string());
+
+        assert_eq!(td.github_label(), "Ticket");
+    }
+
+    #[test]
+    fn github_label_falls_back_to_type_label_when_unset() {
+        let td = TypeDef::test_fixture("story", StoreBackend::GithubIssues);
+
+        assert_eq!(td.github_label(), "lazyspec:story");
+    }
+
+    #[test]
+    fn toml_github_label_key_parses_into_label_override() {
+        let toml_str = format!(
+            "{TYPES}{}",
+            r#"
+[[types]]
+name = "ticket"
+plural = "tickets"
+dir = "docs/tickets"
+prefix = "TICKET"
+github_label = "Ticket"
+"#
+        );
+        let config = Config::parse(&toml_str).unwrap();
+        let td = config.type_by_name("ticket").unwrap();
+        assert_eq!(td.label_override, Some("Ticket".to_string()));
+    }
+
+    #[test]
+    fn toml_without_github_label_key_leaves_label_override_none() {
+        let config = Config::parse(TYPES).unwrap();
+        let td = config.type_by_name("rfc").unwrap();
+        assert_eq!(td.label_override, None);
     }
 }

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -268,6 +268,16 @@ pub struct TypeDef {
     /// stores.
     #[serde(default, rename = "github_label")]
     pub label_override: Option<String>,
+    /// A GitHub label naming this type as a classification signal, distinct
+    /// from `label_override`'s identity label. Schema only for now -- no
+    /// resolver or matching logic reads this field yet.
+    #[serde(default)]
+    pub github_issue_tag: Option<String>,
+    /// A GitHub native issue type naming this type as a classification
+    /// signal. Schema only for now -- no resolver, discovery, or write logic
+    /// reads this field yet.
+    #[serde(default)]
+    pub github_issue_type: Option<String>,
 }
 
 /// One entry in the `[[relationships]]` block: a relationship name and its
@@ -648,6 +658,8 @@ pub fn starter_types() -> Vec<TypeDef> {
         lifecycle: default_lifecycle(),
         attributes: Vec::new(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     };
     vec![
         simple("rfc", "rfcs", "docs/rfcs", "RFC", "●"),
@@ -678,6 +690,8 @@ pub fn starter_types() -> Vec<TypeDef> {
             lifecycle: default_lifecycle(),
             attributes: Vec::new(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         },
         TypeDef {
             name: "dictum".to_string(),
@@ -696,6 +710,8 @@ pub fn starter_types() -> Vec<TypeDef> {
             lifecycle: default_lifecycle(),
             attributes: Vec::new(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         },
     ]
 }
@@ -1032,6 +1048,8 @@ impl TypeDef {
             lifecycle: Lifecycle::default(),
             attributes: Vec::new(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 }
@@ -2147,5 +2165,69 @@ github_label = "Ticket"
         let config = Config::parse(TYPES).unwrap();
         let td = config.type_by_name("rfc").unwrap();
         assert_eq!(td.label_override, None);
+    }
+
+    #[test]
+    fn toml_github_issue_tag_and_type_keys_parse_into_type_def() {
+        let toml_str = format!(
+            "{TYPES}{}",
+            r#"
+[[types]]
+name = "ticket"
+plural = "tickets"
+dir = "docs/tickets"
+prefix = "TICKET"
+github_issue_tag = "Bug"
+github_issue_type = "Bug"
+"#
+        );
+        let config = Config::parse(&toml_str).unwrap();
+        let td = config.type_by_name("ticket").unwrap();
+        assert_eq!(td.github_issue_tag, Some("Bug".to_string()));
+        assert_eq!(td.github_issue_type, Some("Bug".to_string()));
+    }
+
+    #[test]
+    fn toml_without_github_issue_tag_and_type_keys_leaves_both_none() {
+        let config = Config::parse(TYPES).unwrap();
+        let td = config.type_by_name("rfc").unwrap();
+        assert_eq!(td.github_issue_tag, None);
+        assert_eq!(td.github_issue_type, None);
+    }
+
+    #[test]
+    fn type_def_json_surfaces_github_issue_tag_and_type_as_null_when_absent() {
+        let config = Config::parse(TYPES).unwrap();
+        let td = config.type_by_name("rfc").unwrap();
+        let json = serde_json::to_value(td).unwrap();
+        assert_eq!(json["github_issue_tag"], serde_json::Value::Null);
+        assert_eq!(json["github_issue_type"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn type_def_json_surfaces_github_issue_tag_and_type_when_set() {
+        let toml_str = format!(
+            "{TYPES}{}",
+            r#"
+[[types]]
+name = "ticket"
+plural = "tickets"
+dir = "docs/tickets"
+prefix = "TICKET"
+github_issue_tag = "Bug"
+github_issue_type = "Bug"
+"#
+        );
+        let config = Config::parse(&toml_str).unwrap();
+        let td = config.type_by_name("ticket").unwrap();
+        let json = serde_json::to_value(td).unwrap();
+        assert_eq!(
+            json["github_issue_tag"],
+            serde_json::Value::String("Bug".to_string())
+        );
+        assert_eq!(
+            json["github_issue_type"],
+            serde_json::Value::String("Bug".to_string())
+        );
     }
 }

--- a/src/engine/config_write.rs
+++ b/src/engine/config_write.rs
@@ -980,6 +980,8 @@ require_parent_status = "accepted"
                 lifecycle: Default::default(),
                 attributes: Default::default(),
                 label_override: None,
+                github_issue_tag: None,
+                github_issue_type: None,
             });
             c
         };
@@ -1068,6 +1070,8 @@ name = "related-to"
                 lifecycle: Default::default(),
                 attributes: Default::default(),
                 label_override: None,
+                github_issue_tag: None,
+                github_issue_type: None,
             });
             c.rules.clear();
             c

--- a/src/engine/config_write.rs
+++ b/src/engine/config_write.rs
@@ -979,6 +979,7 @@ require_parent_status = "accepted"
                 authorship: Default::default(),
                 lifecycle: Default::default(),
                 attributes: Default::default(),
+                label_override: None,
             });
             c
         };
@@ -1066,6 +1067,7 @@ name = "related-to"
                 authorship: Default::default(),
                 lifecycle: Default::default(),
                 attributes: Default::default(),
+                label_override: None,
             });
             c.rules.clear();
             c

--- a/src/engine/document.rs
+++ b/src/engine/document.rs
@@ -845,6 +845,8 @@ Body.
             lifecycle: Default::default(),
             attributes: attrs,
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 

--- a/src/engine/document.rs
+++ b/src/engine/document.rs
@@ -844,6 +844,7 @@ Body.
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: attrs,
+            label_override: None,
         }
     }
 

--- a/src/engine/gh.rs
+++ b/src/engine/gh.rs
@@ -781,6 +781,46 @@ fn parse_issue_type_name(resp: &serde_json::Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Page size of [`ISSUE_TYPE_SEARCH_QUERY`] (`search(... first:)`). Kept in sync
+/// with the literal in that query by hand; used to detect a truncated result.
+pub const ISSUE_TYPE_SEARCH_PAGE_SIZE: usize = 100;
+
+const ISSUE_TYPE_SEARCH_QUERY: &str =
+    "query($searchQuery: String!) { search(query: $searchQuery, type: ISSUE, first: 100) { nodes { ... on Issue { number } } } }";
+
+/// Extract issue numbers from an [`ISSUE_TYPE_SEARCH_QUERY`] response. Defensive
+/// like [`parse_project_item_fields`]: a missing or malformed `nodes` array
+/// yields an empty vec rather than erroring.
+fn parse_search_issue_numbers(resp: &serde_json::Value) -> Vec<u64> {
+    resp.pointer("/data/search/nodes")
+        .and_then(|v| v.as_array())
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|n| n.pointer("/number").and_then(|v| v.as_u64()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Discover the issue numbers in `repo` classified under the native GitHub issue
+/// type `issue_type`, via the GraphQL `search` API (there is no REST list filter
+/// for issue type). Capped at [`ISSUE_TYPE_SEARCH_PAGE_SIZE`]; callers detect a
+/// full page as a truncated result. A free function over the generic
+/// [`GhGraphql::graphql`] seam, mirroring `issue_view`'s ad hoc GraphQL use.
+pub fn search_issue_numbers_by_type(
+    gh_graphql: &dyn GhGraphql,
+    repo: &str,
+    issue_type: &str,
+) -> Result<Vec<u64>> {
+    let search_query = format!("repo:{} is:issue type:\"{}\"", repo, issue_type);
+    let resp = gh_graphql.graphql(
+        ISSUE_TYPE_SEARCH_QUERY,
+        &[("searchQuery", GqlVar::Str(search_query))],
+    )?;
+    Ok(parse_search_issue_numbers(&resp))
+}
+
 impl GhIssueWriter for GhCli {
     fn issue_create(
         &self,
@@ -2370,6 +2410,39 @@ mod tests {
         assert_eq!(
             status.value,
             GhFieldValueRepr::OptionName("In Progress".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_search_issue_numbers_extracts_numbers_in_order() {
+        let resp = serde_json::json!({
+            "data": {"search": {"nodes": [{"number": 42}, {"number": 7}]}}
+        });
+        assert_eq!(parse_search_issue_numbers(&resp), vec![42, 7]);
+    }
+
+    #[test]
+    fn parse_search_issue_numbers_missing_or_malformed_nodes_is_empty() {
+        let missing = serde_json::json!({"data": {"search": {}}});
+        assert!(parse_search_issue_numbers(&missing).is_empty());
+        let malformed = serde_json::json!({"data": {"search": {"nodes": "nope"}}});
+        assert!(parse_search_issue_numbers(&malformed).is_empty());
+    }
+
+    #[test]
+    fn search_issue_numbers_by_type_sends_repo_and_type_qualified_query() {
+        let client = MockGhClient::new().with_graphql_responses(vec![serde_json::json!({
+            "data": {"search": {"nodes": [{"number": 1}, {"number": 2}]}}
+        })]);
+        let numbers = search_issue_numbers_by_type(&client, "owner/repo", "Bug").unwrap();
+        assert_eq!(numbers, vec![1, 2]);
+        let calls = client.graphql_calls.borrow();
+        assert_eq!(
+            calls[0].1,
+            vec![(
+                "searchQuery".to_string(),
+                GqlVar::Str("repo:owner/repo is:issue type:\"Bug\"".to_string())
+            )]
         );
     }
 

--- a/src/engine/gh.rs
+++ b/src/engine/gh.rs
@@ -1162,6 +1162,7 @@ pub mod test_support {
         pub last_edit_body: RefCell<Option<String>>,
         pub last_edit_labels_remove: RefCell<Vec<String>>,
         pub last_create_body: RefCell<Option<String>>,
+        pub last_create_labels: RefCell<Vec<String>>,
         pub create_titles: RefCell<Vec<String>>,
         pub next_issue_number: Cell<u64>,
         pub graphql_responses: RefCell<Vec<serde_json::Value>>,
@@ -1198,6 +1199,7 @@ pub mod test_support {
                 last_edit_body: RefCell::new(None),
                 last_edit_labels_remove: RefCell::new(vec![]),
                 last_create_body: RefCell::new(None),
+                last_create_labels: RefCell::new(vec![]),
                 create_titles: RefCell::new(vec![]),
                 next_issue_number: Cell::new(1),
                 graphql_responses: RefCell::new(vec![]),
@@ -1304,6 +1306,7 @@ pub mod test_support {
             labels: &[String],
         ) -> Result<GhIssue> {
             *self.last_create_body.borrow_mut() = Some(body.to_string());
+            *self.last_create_labels.borrow_mut() = labels.to_vec();
             self.create_titles.borrow_mut().push(title.to_string());
             if let Some(ref issue) = self.create_result {
                 return Ok(issue.clone());

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -360,6 +360,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         }
     }
 

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -361,6 +361,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 

--- a/src/engine/issue_body.rs
+++ b/src/engine/issue_body.rs
@@ -2,23 +2,56 @@ use anyhow::{anyhow, Result};
 use chrono::NaiveDate;
 use regex::Regex;
 
-use crate::engine::config::AttrDef;
+use crate::engine::config::{AttrDef, TypeDef};
 use crate::engine::document::{
     self, coerce_attr, deserialize_naive_date, AttrValue, DocMeta, DocType, Relation, Status,
 };
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+/// One document type's resolved classification rule against a GitHub issue.
+///
+/// - `name` is the lazyspec type name (the resulting `DocType` on a match).
+/// - `label` is the type's `github_label()` (its `label_override` or the default
+///   `lazyspec:{name}`), checked when neither `tag` nor `issue_type` is set.
+/// - `tag` is an arbitrary GitHub label naming this type; when set, the `label`
+///   check is skipped and this label is checked instead.
+/// - `issue_type` is a native GitHub issue type naming this type.
+///
+/// When both `tag` and `issue_type` are set they are AND-combined. See
+/// [`extract_type_and_tags`] for the full match semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeMatchRule {
+    pub name: String,
+    pub label: String,
+    pub tag: Option<String>,
+    pub issue_type: Option<String>,
+}
+
+impl From<&TypeDef> for TypeMatchRule {
+    fn from(type_def: &TypeDef) -> Self {
+        TypeMatchRule {
+            name: type_def.name.clone(),
+            label: type_def.github_label(),
+            tag: type_def.github_issue_tag.clone(),
+            issue_type: type_def.github_issue_type.clone(),
+        }
+    }
+}
+
 /// Fields that come from GitHub Issue primitives rather than the issue body.
 pub struct IssueContext {
     pub title: String,
     pub labels: Vec<String>,
     pub is_open: bool,
-    /// Known document types as `(type_name, resolved_label)` pairs, where the
-    /// resolved label is the type's `github_label()` (its `label_override` or the
-    /// default `lazyspec:{name}`). A GitHub label is recognized as a type when it
-    /// exactly matches (case-insensitive) one of these resolved labels.
-    pub known_types: Vec<(String, String)>,
+    /// Known document types as resolved [`TypeMatchRule`]s. Each type's rule is
+    /// evaluated independently against the issue's labels and native issue type
+    /// to decide whether the issue belongs to that type.
+    pub known_types: Vec<TypeMatchRule>,
+    /// The issue's own native GitHub issue type, distinct from a classification
+    /// rule's `issue_type`. Used to evaluate rules configured with a
+    /// `github_issue_type`.
+    pub issue_type: Option<String>,
     pub default_type: String,
     /// Declared attribute schema for the document's type, used to coerce the
     /// `attributes:` block in the HTML comment back into typed [`AttrValue`]s.
@@ -96,7 +129,12 @@ pub fn deserialize(issue_body: &str, ctx: &IssueContext) -> Result<(DocMeta, Str
         .map(parse_relation)
         .collect::<Result<Vec<_>>>()?;
 
-    let (doc_type, tags) = extract_type_and_tags(&ctx.labels, &ctx.known_types, &ctx.default_type);
+    let (doc_type, tags) = extract_type_and_tags(
+        &ctx.labels,
+        &ctx.known_types,
+        ctx.issue_type.as_deref(),
+        &ctx.default_type,
+    );
 
     let status = reconstruct_status(ctx.is_open, parsed.status.as_deref());
 
@@ -165,36 +203,71 @@ fn reconstruct_status(is_open: bool, frontmatter_status: Option<&str>) -> Status
     }
 }
 
-/// Extract doc_type and tags from GitHub labels.
+/// Extract doc_type and tags by evaluating each known type's [`TypeMatchRule`]
+/// against the issue's labels and native issue type.
 ///
-/// Each label is matched (case-insensitive) against the resolved GitHub label of
-/// every known type (`known_types` carries `(type_name, resolved_label)` pairs).
-/// The first label matching a known type's resolved label becomes the doc_type;
-/// any label matching a known type's resolved label is consumed (never carried
-/// as a tag). Every other label becomes a tag. With no match, `default_type` is
-/// used.
+/// Every rule is evaluated independently -- there is no first-hit short circuit.
+/// A rule is satisfied when:
+/// - neither `tag` nor `issue_type` is set: a label case-insensitively equals
+///   `rule.label`;
+/// - only `tag` is set: a label case-insensitively equals `rule.tag` (the
+///   `label` check is skipped);
+/// - only `issue_type` is set: `issue_native_type` equals `rule.issue_type`;
+/// - both are set: both the tag-label match and the issue-type match hold (AND).
+///
+/// The first satisfied rule (in `known_types` order) wins the returned
+/// `DocType`; with no satisfied rule, `default_type` is used. A label that any
+/// rule uses to classify (its `label` when unqualified, or its `tag` when set)
+/// is never carried as a tag, regardless of whether that rule's overall match
+/// succeeded. Every other label becomes a tag.
 pub(crate) fn extract_type_and_tags(
     labels: &[String],
-    known_types: &[(String, String)],
+    known_types: &[TypeMatchRule],
+    issue_native_type: Option<&str>,
     default_type: &str,
 ) -> (DocType, Vec<String>) {
-    let mut doc_type: Option<DocType> = None;
-    let mut tags = Vec::new();
+    let has_label = |value: &str| {
+        let lower = value.to_lowercase();
+        labels.iter().any(|l| l.to_lowercase() == lower)
+    };
 
-    for label in labels {
-        let lower = label.to_lowercase();
-        let matched = known_types
-            .iter()
-            .find(|(_, resolved_label)| resolved_label.to_lowercase() == lower);
-        match matched {
-            Some((type_name, _)) => {
-                if doc_type.is_none() {
-                    doc_type = Some(DocType::new(type_name));
-                }
-            }
-            None => tags.push(label.clone()),
+    // Single pass over the rules couples doc_type resolution with tag exclusion:
+    // both are derived here so a short-circuit that stopped once doc_type is found
+    // would also stop excluding later rules' classifying labels.
+    let mut doc_type: Option<DocType> = None;
+    let mut classifying_labels: Vec<String> = Vec::new();
+    for rule in known_types {
+        // The label value a rule classifies on: its `tag` when set, else its
+        // `label` (an `issue_type`-only rule classifies on no label). Such a
+        // label is never carried as a tag.
+        let classifying = match (&rule.tag, &rule.issue_type) {
+            (Some(tag), _) => Some(tag.to_lowercase()),
+            (None, None) => Some(rule.label.to_lowercase()),
+            (None, Some(_)) => None,
+        };
+        if let Some(ref classifying) = classifying {
+            classifying_labels.push(classifying.clone());
+        }
+
+        let satisfied = match (&rule.tag, &rule.issue_type) {
+            (None, None) => has_label(&rule.label),
+            (Some(tag), None) => has_label(tag),
+            (None, Some(it)) => issue_native_type == Some(it.as_str()),
+            (Some(tag), Some(it)) => has_label(tag) && issue_native_type == Some(it.as_str()),
+        };
+        if satisfied && doc_type.is_none() {
+            doc_type = Some(DocType::new(&rule.name));
         }
     }
+
+    let tags = labels
+        .iter()
+        .filter(|label| {
+            let lower = label.to_lowercase();
+            !classifying_labels.iter().any(|c| c == &lower)
+        })
+        .cloned()
+        .collect();
 
     (doc_type.unwrap_or_else(|| DocType::new(default_type)), tags)
 }
@@ -262,22 +335,29 @@ mod tests {
         }
     }
 
-    /// The default known types as `(name, resolved_label)` pairs, each using the
-    /// default `lazyspec:{name}` label (no override).
-    fn default_known_types() -> Vec<(String, String)> {
+    /// A label-only match rule using the default `lazyspec:{name}` label.
+    fn label_rule(name: &str) -> TypeMatchRule {
+        TypeMatchRule {
+            name: name.to_string(),
+            label: format!("lazyspec:{name}"),
+            tag: None,
+            issue_type: None,
+        }
+    }
+
+    /// The default known types as label-only rules, each using the default
+    /// `lazyspec:{name}` label (no override).
+    fn default_known_types() -> Vec<TypeMatchRule> {
         ["rfc", "story", "iteration", "adr", "spec"]
             .iter()
-            .map(|name| (name.to_string(), format!("lazyspec:{name}")))
+            .map(|name| label_rule(name))
             .collect()
     }
 
-    /// Build `(name, resolved_label)` pairs from bare names, each using the
-    /// default `lazyspec:{name}` label.
-    fn known_pairs(names: &[&str]) -> Vec<(String, String)> {
-        names
-            .iter()
-            .map(|name| (name.to_string(), format!("lazyspec:{name}")))
-            .collect()
+    /// Build label-only rules from bare names, each using the default
+    /// `lazyspec:{name}` label.
+    fn known_pairs(names: &[&str]) -> Vec<TypeMatchRule> {
+        names.iter().map(|name| label_rule(name)).collect()
     }
 
     fn sample_context() -> IssueContext {
@@ -286,6 +366,7 @@ mod tests {
             labels: vec!["lazyspec:rfc".to_string(), "performance".to_string()],
             is_open: true,
             known_types: default_known_types(),
+            issue_type: None,
             default_type: "spec".to_string(),
             attr_defs: vec![],
         }
@@ -395,7 +476,7 @@ mod tests {
     #[test]
     fn extract_type_and_tags_finds_type() {
         let labels = vec!["lazyspec:rfc".to_string(), "cache".to_string()];
-        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "spec");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), None, "spec");
         assert_eq!(dt.as_str(), "rfc");
         assert_eq!(tags, vec!["cache"]);
     }
@@ -403,7 +484,7 @@ mod tests {
     #[test]
     fn extract_type_and_tags_defaults_to_configured_type() {
         let labels = vec!["random-label".to_string()];
-        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "testgh");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), None, "testgh");
         assert_eq!(dt.as_str(), "testgh");
         assert_eq!(tags, vec!["random-label"]);
     }
@@ -413,8 +494,13 @@ mod tests {
     #[test]
     fn extract_type_and_tags_recognizes_custom_label() {
         let labels = vec!["Ticket".to_string(), "cache".to_string()];
-        let known = vec![("ticket".to_string(), "Ticket".to_string())];
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
+        let known = vec![TypeMatchRule {
+            name: "ticket".to_string(),
+            label: "Ticket".to_string(),
+            tag: None,
+            issue_type: None,
+        }];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "spec");
         assert_eq!(dt.as_str(), "ticket");
         assert_eq!(tags, vec!["cache"]);
     }
@@ -470,6 +556,7 @@ mod tests {
             labels: vec!["lazyspec:rfc".to_string(), "performance".to_string()],
             is_open: false,
             known_types: default_known_types(),
+            issue_type: None,
             default_type: "spec".to_string(),
             attr_defs: vec![],
         };
@@ -595,7 +682,7 @@ mod tests {
             "lazyspec:unknown".to_string(),
             "team-alpha".to_string(),
         ];
-        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "spec");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), None, "spec");
         assert_eq!(dt.as_str(), "iteration");
         // Matching is now exact against each known type's resolved label, not a
         // `lazyspec:` prefix strip. `lazyspec:unknown` matches no known type, so
@@ -685,7 +772,7 @@ mod tests {
     fn custom_type_recognized_when_in_known_types() {
         let labels = vec!["lazyspec:task".to_string(), "team-beta".to_string()];
         let known = known_pairs(&["task", "rfc", "story"]);
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "spec");
         assert_eq!(dt.as_str(), "task");
         assert_eq!(tags, vec!["team-beta"]);
     }
@@ -769,9 +856,109 @@ mod tests {
     fn custom_type_defaults_to_configured_type_when_not_in_known_types() {
         let labels = vec!["lazyspec:task".to_string(), "team-beta".to_string()];
         let known = known_pairs(&["rfc", "story"]);
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "testgh");
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "testgh");
         assert_eq!(dt.as_str(), "testgh");
         // `lazyspec:task` is not a recognized type here, so it survives as a tag.
         assert_eq!(tags, vec!["lazyspec:task", "team-beta"]);
+    }
+
+    // AC1: a rule with neither tag nor issue_type matches by its label, exactly
+    // as before ITERATION-261/263.
+    #[test]
+    fn extract_type_and_tags_label_only_rule_matches_by_label() {
+        let labels = vec!["lazyspec:bug".to_string(), "cache".to_string()];
+        let known = vec![label_rule("bug")];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "spec");
+        assert_eq!(dt.as_str(), "bug");
+        assert_eq!(tags, vec!["cache"]);
+    }
+
+    // AC2: a rule with only `tag` set matches on that plain label even when the
+    // issue carries no `lazyspec:{name}` label at all -- the label check is
+    // skipped, not additionally required.
+    #[test]
+    fn extract_type_and_tags_tag_only_rule_matches_without_lazyspec_label() {
+        let labels = vec!["needs-triage".to_string(), "cache".to_string()];
+        let known = vec![TypeMatchRule {
+            name: "bug".to_string(),
+            label: "lazyspec:bug".to_string(),
+            tag: Some("needs-triage".to_string()),
+            issue_type: None,
+        }];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "spec");
+        assert_eq!(dt.as_str(), "bug");
+        assert_eq!(tags, vec!["cache"]);
+    }
+
+    // AC3: a rule with only `issue_type` set matches on the issue's native type
+    // even when the issue carries no matching label of any kind.
+    #[test]
+    fn extract_type_and_tags_issue_type_only_rule_matches_without_any_label() {
+        let labels = vec!["cache".to_string()];
+        let known = vec![TypeMatchRule {
+            name: "bug".to_string(),
+            label: "lazyspec:bug".to_string(),
+            tag: None,
+            issue_type: Some("Bug".to_string()),
+        }];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, Some("Bug"), "spec");
+        assert_eq!(dt.as_str(), "bug");
+        assert_eq!(tags, vec!["cache"]);
+    }
+
+    // AC4: a rule with both `tag` and `issue_type` set is an AND, not an OR --
+    // satisfying only one half does not match; satisfying both does.
+    #[test]
+    fn extract_type_and_tags_tag_and_issue_type_both_required_and_not_or() {
+        let rule = TypeMatchRule {
+            name: "bug".to_string(),
+            label: "lazyspec:bug".to_string(),
+            tag: Some("hot".to_string()),
+            issue_type: Some("Bug".to_string()),
+        };
+        let known = vec![rule];
+
+        // Only the tag holds (native type differs) -> no match, falls back.
+        let (dt, _) = extract_type_and_tags(&["hot".to_string()], &known, Some("Task"), "spec");
+        assert_eq!(dt.as_str(), "spec", "tag alone must not match");
+
+        // Only the issue_type holds (tag label absent) -> no match, falls back.
+        let (dt, _) = extract_type_and_tags(&["cache".to_string()], &known, Some("Bug"), "spec");
+        assert_eq!(dt.as_str(), "spec", "issue_type alone must not match");
+
+        // Both hold -> match.
+        let (dt, _) = extract_type_and_tags(&["hot".to_string()], &known, Some("Bug"), "spec");
+        assert_eq!(dt.as_str(), "bug", "tag AND issue_type must match");
+    }
+
+    // AC5: every rule is evaluated independently with no first-hit short circuit.
+    // Two rules both match the issue; the first wins the doc_type, but the second
+    // rule's classification label ("hot") must still be consumed (never carried as
+    // a tag). doc_type resolution and classifying-label exclusion share a single
+    // loop, so a regression that short-circuited that loop once doc_type is found
+    // would leave "hot" in the returned tags and this assertion would fail.
+    #[test]
+    fn extract_type_and_tags_evaluates_every_rule_independently_no_short_circuit() {
+        let labels = vec![
+            "lazyspec:story".to_string(),
+            "hot".to_string(),
+            "other".to_string(),
+        ];
+        let known = vec![
+            label_rule("story"),
+            TypeMatchRule {
+                name: "urgent".to_string(),
+                label: "lazyspec:urgent".to_string(),
+                tag: Some("hot".to_string()),
+                issue_type: None,
+            },
+        ];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, None, "spec");
+        assert_eq!(dt.as_str(), "story", "first satisfied rule wins doc_type");
+        assert_eq!(
+            tags,
+            vec!["other"],
+            "second rule's tag label must be consumed, proving it was evaluated"
+        );
     }
 }

--- a/src/engine/issue_body.rs
+++ b/src/engine/issue_body.rs
@@ -14,7 +14,11 @@ pub struct IssueContext {
     pub title: String,
     pub labels: Vec<String>,
     pub is_open: bool,
-    pub known_types: Vec<String>,
+    /// Known document types as `(type_name, resolved_label)` pairs, where the
+    /// resolved label is the type's `github_label()` (its `label_override` or the
+    /// default `lazyspec:{name}`). A GitHub label is recognized as a type when it
+    /// exactly matches (case-insensitive) one of these resolved labels.
+    pub known_types: Vec<(String, String)>,
     pub default_type: String,
     /// Declared attribute schema for the document's type, used to coerce the
     /// `attributes:` block in the HTML comment back into typed [`AttrValue`]s.
@@ -92,8 +96,7 @@ pub fn deserialize(issue_body: &str, ctx: &IssueContext) -> Result<(DocMeta, Str
         .map(parse_relation)
         .collect::<Result<Vec<_>>>()?;
 
-    let known_type_refs: Vec<&str> = ctx.known_types.iter().map(|s| s.as_str()).collect();
-    let (doc_type, tags) = extract_type_and_tags(&ctx.labels, &known_type_refs, &ctx.default_type);
+    let (doc_type, tags) = extract_type_and_tags(&ctx.labels, &ctx.known_types, &ctx.default_type);
 
     let status = reconstruct_status(ctx.is_open, parsed.status.as_deref());
 
@@ -164,11 +167,15 @@ fn reconstruct_status(is_open: bool, frontmatter_status: Option<&str>) -> Status
 
 /// Extract doc_type and tags from GitHub labels.
 ///
-/// The first label matching a known doc type is used as the type; all remaining
-/// labels become tags.
-fn extract_type_and_tags(
+/// Each label is matched (case-insensitive) against the resolved GitHub label of
+/// every known type (`known_types` carries `(type_name, resolved_label)` pairs).
+/// The first label matching a known type's resolved label becomes the doc_type;
+/// any label matching a known type's resolved label is consumed (never carried
+/// as a tag). Every other label becomes a tag. With no match, `default_type` is
+/// used.
+pub(crate) fn extract_type_and_tags(
     labels: &[String],
-    known_types: &[&str],
+    known_types: &[(String, String)],
     default_type: &str,
 ) -> (DocType, Vec<String>) {
     let mut doc_type: Option<DocType> = None;
@@ -176,13 +183,16 @@ fn extract_type_and_tags(
 
     for label in labels {
         let lower = label.to_lowercase();
-        if let Some(suffix) = lower.strip_prefix("lazyspec:") {
-            if doc_type.is_none() && known_types.iter().any(|t| t.to_lowercase() == suffix) {
-                doc_type = Some(DocType::new(suffix));
+        let matched = known_types
+            .iter()
+            .find(|(_, resolved_label)| resolved_label.to_lowercase() == lower);
+        match matched {
+            Some((type_name, _)) => {
+                if doc_type.is_none() {
+                    doc_type = Some(DocType::new(type_name));
+                }
             }
-            // lazyspec:-prefixed labels are never added to tags
-        } else {
-            tags.push(label.clone());
+            None => tags.push(label.clone()),
         }
     }
 
@@ -252,14 +262,22 @@ mod tests {
         }
     }
 
-    fn default_known_types() -> Vec<String> {
-        vec![
-            "rfc".to_string(),
-            "story".to_string(),
-            "iteration".to_string(),
-            "adr".to_string(),
-            "spec".to_string(),
-        ]
+    /// The default known types as `(name, resolved_label)` pairs, each using the
+    /// default `lazyspec:{name}` label (no override).
+    fn default_known_types() -> Vec<(String, String)> {
+        ["rfc", "story", "iteration", "adr", "spec"]
+            .iter()
+            .map(|name| (name.to_string(), format!("lazyspec:{name}")))
+            .collect()
+    }
+
+    /// Build `(name, resolved_label)` pairs from bare names, each using the
+    /// default `lazyspec:{name}` label.
+    fn known_pairs(names: &[&str]) -> Vec<(String, String)> {
+        names
+            .iter()
+            .map(|name| (name.to_string(), format!("lazyspec:{name}")))
+            .collect()
     }
 
     fn sample_context() -> IssueContext {
@@ -377,9 +395,7 @@ mod tests {
     #[test]
     fn extract_type_and_tags_finds_type() {
         let labels = vec!["lazyspec:rfc".to_string(), "cache".to_string()];
-        let types = default_known_types();
-        let known: Vec<&str> = types.iter().map(|s| s.as_str()).collect();
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "spec");
         assert_eq!(dt.as_str(), "rfc");
         assert_eq!(tags, vec!["cache"]);
     }
@@ -387,11 +403,20 @@ mod tests {
     #[test]
     fn extract_type_and_tags_defaults_to_configured_type() {
         let labels = vec!["random-label".to_string()];
-        let types = default_known_types();
-        let known: Vec<&str> = types.iter().map(|s| s.as_str()).collect();
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "testgh");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "testgh");
         assert_eq!(dt.as_str(), "testgh");
         assert_eq!(tags, vec!["random-label"]);
+    }
+
+    // A type whose resolved label is a custom override (no `lazyspec:` prefix) is
+    // recognized on read by exact-matching that label.
+    #[test]
+    fn extract_type_and_tags_recognizes_custom_label() {
+        let labels = vec!["Ticket".to_string(), "cache".to_string()];
+        let known = vec![("ticket".to_string(), "Ticket".to_string())];
+        let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
+        assert_eq!(dt.as_str(), "ticket");
+        assert_eq!(tags, vec!["cache"]);
     }
 
     // AC3: typed attributes survive serialize -> deserialize through the HTML comment.
@@ -570,11 +595,12 @@ mod tests {
             "lazyspec:unknown".to_string(),
             "team-alpha".to_string(),
         ];
-        let types = default_known_types();
-        let known: Vec<&str> = types.iter().map(|s| s.as_str()).collect();
-        let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
+        let (dt, tags) = extract_type_and_tags(&labels, &default_known_types(), "spec");
         assert_eq!(dt.as_str(), "iteration");
-        assert_eq!(tags, vec!["team-alpha"]);
+        // Matching is now exact against each known type's resolved label, not a
+        // `lazyspec:` prefix strip. `lazyspec:unknown` matches no known type, so
+        // it becomes an ordinary tag (previously it was silently dropped).
+        assert_eq!(tags, vec!["lazyspec:unknown", "team-alpha"]);
     }
 
     // --- Round-trip fidelity tests ---
@@ -658,7 +684,7 @@ mod tests {
     #[test]
     fn custom_type_recognized_when_in_known_types() {
         let labels = vec!["lazyspec:task".to_string(), "team-beta".to_string()];
-        let known = vec!["task", "rfc", "story"];
+        let known = known_pairs(&["task", "rfc", "story"]);
         let (dt, tags) = extract_type_and_tags(&labels, &known, "spec");
         assert_eq!(dt.as_str(), "task");
         assert_eq!(tags, vec!["team-beta"]);
@@ -742,9 +768,10 @@ mod tests {
     #[test]
     fn custom_type_defaults_to_configured_type_when_not_in_known_types() {
         let labels = vec!["lazyspec:task".to_string(), "team-beta".to_string()];
-        let known = vec!["rfc", "story"];
+        let known = known_pairs(&["rfc", "story"]);
         let (dt, tags) = extract_type_and_tags(&labels, &known, "testgh");
         assert_eq!(dt.as_str(), "testgh");
-        assert_eq!(tags, vec!["team-beta"]);
+        // `lazyspec:task` is not a recognized type here, so it survives as a tag.
+        assert_eq!(tags, vec!["lazyspec:task", "team-beta"]);
     }
 }

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -506,7 +506,7 @@ fn discover_issues(
             })
         }
         (Some(tag), Some(issue_type)) => {
-            let rest = gh.issue_list(repo, &[tag.clone()], fields, limit)?;
+            let rest = gh.issue_list(repo, std::slice::from_ref(tag), fields, limit)?;
             let numbers = search_issue_numbers_by_type(gh_graphql, repo, issue_type)?;
             let search_truncated = numbers.len() == ISSUE_TYPE_SEARCH_PAGE_SIZE;
             let keep: std::collections::HashSet<u64> = numbers.into_iter().collect();

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -812,6 +812,32 @@ mod tests {
         }
     }
 
+    // A second github-issues TypeDef, distinct prefix/name/dir from
+    // story_type_def(), used to prove two types can independently match the
+    // same underlying GitHub issue number without colliding (RFC-055).
+    fn ticket_type_def() -> TypeDef {
+        TypeDef {
+            name: "ticket".to_string(),
+            plural: "tickets".to_string(),
+            dir: "docs/ticket".to_string(),
+            prefix: "TICKET".to_string(),
+            icon: None,
+            numbering: NumberingStrategy::default(),
+            subdirectory: false,
+            store: StoreBackend::GithubIssues,
+            singleton: false,
+            parent_type: None,
+            agents: Vec::new(),
+            intent: None,
+            authorship: Default::default(),
+            lifecycle: Default::default(),
+            attributes: Default::default(),
+            label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
+        }
+    }
+
     fn story_match_rule() -> TypeMatchRule {
         TypeMatchRule {
             name: "story".to_string(),
@@ -1521,6 +1547,202 @@ mod tests {
         };
         let docs = store.list(&filter);
         assert_eq!(docs.len(), 3);
+    }
+
+    // AC (STORY-194): two github-issues types with distinct prefix/name/dir can
+    // both independently match the same underlying GitHub issue number. Each
+    // fetch_all call is scoped entirely to its own TypeDef -- doc id via
+    // type_def.make_id, cache dir via type_def.name -- so both materialize
+    // side by side under the same root and shared IssueMap without colliding.
+    #[test]
+    fn test_fetch_all_dual_materializes_overlapping_issue_across_types() {
+        let (cache, tmp) = make_cache();
+        let story_type = story_type_def();
+        let ticket_type = ticket_type_def();
+
+        // MockReader::issue_list ignores the label filter and always returns
+        // this same issue #42 -- standing in for both types' discovery
+        // independently surfacing the same GitHub issue.
+        let gh = MockReader::new(vec![make_gh_issue(42, "Some Issue", "Body", &[])])
+            .with_graphql_responses(vec![
+                empty_issue_types_response(),
+                empty_issue_types_response(),
+            ]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+
+        cache
+            .fetch_all(
+                tmp.path(),
+                &story_type,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        cache
+            .fetch_all(
+                tmp.path(),
+                &ticket_type,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[ticket_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        let story_path = tmp.path().join(".lazyspec/cache/story/STORY-42.md");
+        let ticket_path = tmp.path().join(".lazyspec/cache/ticket/TICKET-42.md");
+        assert!(story_path.exists(), "story cache file should exist");
+        assert!(ticket_path.exists(), "ticket cache file should exist");
+
+        let story_content = std::fs::read_to_string(&story_path).unwrap();
+        let ticket_content = std::fs::read_to_string(&ticket_path).unwrap();
+        assert!(
+            story_content.contains("type: story"),
+            "story doc should carry its own type, not ticket's: {}",
+            story_content
+        );
+        assert!(
+            ticket_content.contains("type: ticket"),
+            "ticket doc should carry its own type, not story's: {}",
+            ticket_content
+        );
+
+        assert_eq!(issue_map.get("STORY-42").unwrap().issue_number, 42);
+        assert_eq!(issue_map.get("TICKET-42").unwrap().issue_number, 42);
+    }
+
+    // AC (STORY-194): refresh_stale for one type never touches another type's
+    // cache dir, cache.lock entry, or issue-map row, even when both types
+    // resolved the same GitHub issue number during their own fetch_all.
+    #[test]
+    fn test_refresh_stale_isolates_overlapping_issue_across_types() {
+        let (cache, tmp) = make_cache();
+        let story_type = story_type_def();
+        let ticket_type = ticket_type_def();
+        let ttl = Duration::seconds(60);
+
+        // Arrange: seed both types' caches for the same issue #42 via fetch_all,
+        // exactly as their independent discovery would.
+        let seed_gh = MockReader::new(vec![make_gh_issue(42, "Some Issue", "Body v1", &[])])
+            .with_graphql_responses(vec![
+                empty_issue_types_response(),
+                empty_issue_types_response(),
+            ]);
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        cache
+            .fetch_all(
+                tmp.path(),
+                &story_type,
+                &seed_gh,
+                &seed_gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+        cache
+            .fetch_all(
+                tmp.path(),
+                &ticket_type,
+                &seed_gh,
+                &seed_gh,
+                "owner/repo",
+                &mut issue_map,
+                &[ticket_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        backdate_all(&cache, &["STORY-42", "TICKET-42"]);
+
+        let ticket_path = tmp.path().join(".lazyspec/cache/ticket/TICKET-42.md");
+        let ticket_content_before = std::fs::read_to_string(&ticket_path).unwrap();
+        let ticket_lock_before = cache.load_lock().get("TICKET-42").unwrap().to_string();
+
+        // Act: refresh only the story type, with a changed upstream body so a
+        // real write happens (not a no-op "unchanged" skip).
+        let story_refresh_gh =
+            MockReader::new(vec![make_gh_issue(42, "Some Issue", "Body v2", &[])])
+                .with_graphql_responses(vec![empty_issue_types_response()]);
+        let story_result = cache.refresh_stale(
+            tmp.path(),
+            &story_type,
+            &story_refresh_gh,
+            &story_refresh_gh,
+            "owner/repo",
+            &mut issue_map,
+            ttl,
+            &[story_match_rule()],
+            &Config::default(),
+        );
+
+        assert_eq!(story_result.refreshed, 1);
+        assert!(
+            cache.is_fresh("STORY-42", ttl),
+            "story entry should be refreshed and fresh"
+        );
+
+        // Assert: the story-only refresh left ticket's cache file, lock entry,
+        // and issue-map row completely untouched.
+        let ticket_content_after = std::fs::read_to_string(&ticket_path).unwrap();
+        let ticket_lock_after = cache.load_lock().get("TICKET-42").unwrap().to_string();
+        assert_eq!(
+            ticket_content_before, ticket_content_after,
+            "ticket cache content must be untouched by a story-only refresh"
+        );
+        assert_eq!(
+            ticket_lock_before, ticket_lock_after,
+            "ticket lock entry must be untouched by a story-only refresh"
+        );
+        assert!(
+            !cache.is_fresh("TICKET-42", ttl),
+            "ticket entry remains stale since only story was refreshed"
+        );
+        assert_eq!(issue_map.get("TICKET-42").unwrap().issue_number, 42);
+
+        // Act again, the other way around: refresh only ticket now, and
+        // confirm story (already refreshed above) is left alone this time.
+        let story_path = tmp.path().join(".lazyspec/cache/story/STORY-42.md");
+        let story_content_before = std::fs::read_to_string(&story_path).unwrap();
+        let story_lock_before = cache.load_lock().get("STORY-42").unwrap().to_string();
+
+        let ticket_refresh_gh =
+            MockReader::new(vec![make_gh_issue(42, "Some Issue", "Body v3", &[])])
+                .with_graphql_responses(vec![empty_issue_types_response()]);
+        let ticket_result = cache.refresh_stale(
+            tmp.path(),
+            &ticket_type,
+            &ticket_refresh_gh,
+            &ticket_refresh_gh,
+            "owner/repo",
+            &mut issue_map,
+            ttl,
+            &[ticket_match_rule()],
+            &Config::default(),
+        );
+
+        assert_eq!(ticket_result.refreshed, 1);
+        assert!(cache.is_fresh("TICKET-42", ttl));
+
+        let story_content_after = std::fs::read_to_string(&story_path).unwrap();
+        let story_lock_after = cache.load_lock().get("STORY-42").unwrap().to_string();
+        assert_eq!(
+            story_content_before, story_content_after,
+            "story cache content must be untouched by a ticket-only refresh"
+        );
+        assert_eq!(
+            story_lock_before, story_lock_after,
+            "story lock entry must be untouched by a ticket-only refresh"
+        );
     }
 
     #[test]

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use crate::engine::cache_lock::CacheLock;
 use crate::engine::config::{AttrDef, Config, TypeDef};
 use crate::engine::document::{AttrValue, DocMeta, Relation, RelationType, Status};
-use crate::engine::gh::{GhGraphql, GhIssue, GhIssueReader};
+use crate::engine::gh::{
+    search_issue_numbers_by_type, GhGraphql, GhIssue, GhIssueReader, ISSUE_TYPE_SEARCH_PAGE_SIZE,
+};
 use crate::engine::gh_schema;
 use crate::engine::gh_subissue;
 use crate::engine::issue_body::{self, IssueContext, TypeMatchRule};
@@ -158,8 +160,6 @@ impl IssueCache {
             };
         }
 
-        let label = type_def.github_label();
-        let labels = vec![label];
         let fields = vec![
             "id".into(),
             "number".into(),
@@ -176,8 +176,12 @@ impl IssueCache {
             .relationship_by_github_native("milestone")
             .map(|r| r.name.as_str());
 
-        let issues = match gh.issue_list(repo, &labels, &fields, None) {
-            Ok(issues) => issues,
+        let rule = TypeMatchRule::from(type_def);
+        let Discovery {
+            issues,
+            search_truncated,
+        } = match discover_issues(gh, gh_graphql, repo, &rule, &fields, None) {
+            Ok(d) => d,
             Err(e) => {
                 return RefreshResult {
                     refreshed: 0,
@@ -235,6 +239,9 @@ impl IssueCache {
         let _ = lock.save(&self.root);
 
         let mut warnings = write_warnings;
+        if search_truncated {
+            warnings.push(search_truncation_warning(&type_def.name));
+        }
         warnings.extend(self.refresh_schema_snapshot(gh_graphql, repo));
 
         RefreshResult {
@@ -310,11 +317,13 @@ impl IssueCache {
         known_types: &[TypeMatchRule],
         config: &Config,
     ) -> anyhow::Result<FetchResult> {
-        let label = type_def.github_label();
-        let labels = vec![label];
         const FETCH_LIMIT: u64 = 500;
 
-        let issues = gh.issue_list(repo, &labels, &[], Some(FETCH_LIMIT))?;
+        let rule = TypeMatchRule::from(type_def);
+        let Discovery {
+            issues,
+            search_truncated,
+        } = discover_issues(gh, gh_graphql, repo, &rule, &[], Some(FETCH_LIMIT))?;
 
         let mut warnings: Vec<RefreshWarning> = Vec::new();
         if issues.len() as u64 == FETCH_LIMIT {
@@ -324,6 +333,9 @@ impl IssueCache {
                     FETCH_LIMIT, type_def.name
                 ),
             });
+        }
+        if search_truncated {
+            warnings.push(search_truncation_warning(&type_def.name));
         }
 
         let previously_cached: std::collections::HashSet<String> =
@@ -445,6 +457,80 @@ impl IssueCache {
             removed: removed.len(),
             warnings,
         })
+    }
+}
+
+/// Outcome of a type's discovery step. `search_truncated` is true when the
+/// GraphQL issue-type search returned a full page, signalling that candidates
+/// beyond the first page were dropped.
+struct Discovery {
+    issues: Vec<GhIssue>,
+    search_truncated: bool,
+}
+
+/// Resolve the candidate issues for a type's discovery step from its
+/// [`TypeMatchRule`]. Three branches keyed on `tag`/`issue_type`:
+///
+/// - no `issue_type`: REST-only, filtering on `tag` when set else `label`;
+/// - `issue_type` only: GraphQL issue-type search, each number resolved to a
+///   full issue via `issue_view` -- no REST list call is made;
+/// - both `tag` and `issue_type`: the REST list on `tag` INTERSECTED with the
+///   search result set by issue number (AND, per RFC-055 -- never a union).
+fn discover_issues(
+    gh: &dyn GhIssueReader,
+    gh_graphql: &dyn GhGraphql,
+    repo: &str,
+    rule: &TypeMatchRule,
+    fields: &[String],
+    limit: Option<u64>,
+) -> anyhow::Result<Discovery> {
+    match (&rule.tag, &rule.issue_type) {
+        (_, None) => {
+            let label = rule.tag.clone().unwrap_or_else(|| rule.label.clone());
+            let issues = gh.issue_list(repo, &[label], fields, limit)?;
+            Ok(Discovery {
+                issues,
+                search_truncated: false,
+            })
+        }
+        (None, Some(issue_type)) => {
+            let numbers = search_issue_numbers_by_type(gh_graphql, repo, issue_type)?;
+            let search_truncated = numbers.len() == ISSUE_TYPE_SEARCH_PAGE_SIZE;
+            let issues = numbers
+                .into_iter()
+                .map(|n| gh.issue_view(repo, n))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            Ok(Discovery {
+                issues,
+                search_truncated,
+            })
+        }
+        (Some(tag), Some(issue_type)) => {
+            let rest = gh.issue_list(repo, &[tag.clone()], fields, limit)?;
+            let numbers = search_issue_numbers_by_type(gh_graphql, repo, issue_type)?;
+            let search_truncated = numbers.len() == ISSUE_TYPE_SEARCH_PAGE_SIZE;
+            let keep: std::collections::HashSet<u64> = numbers.into_iter().collect();
+            let issues = rest
+                .into_iter()
+                .filter(|i| keep.contains(&i.number))
+                .collect();
+            Ok(Discovery {
+                issues,
+                search_truncated,
+            })
+        }
+    }
+}
+
+/// Warning emitted when a type's issue-type search filled its first page, so
+/// candidates beyond it were not discovered. Mirrors the REST `FETCH_LIMIT`
+/// truncation warning.
+fn search_truncation_warning(type_name: &str) -> RefreshWarning {
+    RefreshWarning {
+        message: format!(
+            "issue-type search for type '{}' returned exactly {} issues; there may be more",
+            type_name, ISSUE_TYPE_SEARCH_PAGE_SIZE
+        ),
     }
 }
 
@@ -777,8 +863,11 @@ mod tests {
         issues: Vec<GhIssue>,
         fail: bool,
         list_call_count: AtomicUsize,
+        list_labels: RefCell<Vec<Vec<String>>>,
         graphql_responses: RefCell<Vec<serde_json::Value>>,
         graphql_call_count: AtomicUsize,
+        view_issues: Vec<GhIssue>,
+        view_call_count: AtomicUsize,
     }
 
     impl MockReader {
@@ -787,19 +876,17 @@ mod tests {
                 issues,
                 fail: false,
                 list_call_count: AtomicUsize::new(0),
+                list_labels: RefCell::new(vec![]),
                 graphql_responses: RefCell::new(vec![]),
                 graphql_call_count: AtomicUsize::new(0),
+                view_issues: vec![],
+                view_call_count: AtomicUsize::new(0),
             }
         }
 
         fn failing() -> Self {
-            Self {
-                issues: vec![],
-                fail: true,
-                list_call_count: AtomicUsize::new(0),
-                graphql_responses: RefCell::new(vec![]),
-                graphql_call_count: AtomicUsize::new(0),
-            }
+            let me = Self::new(vec![]);
+            Self { fail: true, ..me }
         }
 
         fn with_graphql_responses(self, responses: Vec<serde_json::Value>) -> Self {
@@ -807,12 +894,25 @@ mod tests {
             self
         }
 
+        fn with_view_issues(mut self, issues: Vec<GhIssue>) -> Self {
+            self.view_issues = issues;
+            self
+        }
+
         fn call_count(&self) -> usize {
             self.list_call_count.load(Ordering::SeqCst)
         }
 
+        fn recorded_list_labels(&self) -> Vec<Vec<String>> {
+            self.list_labels.borrow().clone()
+        }
+
         fn graphql_call_count(&self) -> usize {
             self.graphql_call_count.load(Ordering::SeqCst)
+        }
+
+        fn view_call_count(&self) -> usize {
+            self.view_call_count.load(Ordering::SeqCst)
         }
     }
 
@@ -858,19 +958,24 @@ mod tests {
         fn issue_list(
             &self,
             _repo: &str,
-            _labels: &[String],
+            labels: &[String],
             _json_fields: &[String],
             _limit: Option<u64>,
         ) -> Result<Vec<GhIssue>> {
             self.list_call_count.fetch_add(1, Ordering::SeqCst);
+            self.list_labels.borrow_mut().push(labels.to_vec());
             if self.fail {
                 anyhow::bail!("API unreachable");
             }
             Ok(self.issues.clone())
         }
 
-        fn issue_view(&self, _repo: &str, _number: u64) -> Result<GhIssue> {
-            unimplemented!()
+        fn issue_view(&self, _repo: &str, number: u64) -> Result<GhIssue> {
+            self.view_call_count.fetch_add(1, Ordering::SeqCst);
+            if let Some(issue) = self.view_issues.iter().find(|i| i.number == number) {
+                return Ok(issue.clone());
+            }
+            Ok(make_gh_issue(number, "Viewed", "Viewed body", &[]))
         }
 
         fn issue_comments(
@@ -1143,6 +1248,197 @@ mod tests {
             cache.read_stale("STORY-11", "story"),
             Some("stale content 2".to_string())
         );
+    }
+
+    // AC: a type configured with only `github_issue_type` refreshes its stale
+    // entries by discovering candidates via the GraphQL issue-type search resolved
+    // through `issue_view`, making zero REST `issue_list` calls.
+    #[test]
+    fn refresh_stale_issue_type_only_discovers_via_search_not_rest_list() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(None, Some("Bug"));
+        let ttl = Duration::seconds(60);
+
+        cache.write("STORY-10", "story", "old 10");
+        cache.write("STORY-11", "story", "old 11");
+        backdate_all(&cache, &["STORY-10", "STORY-11"]);
+
+        // First graphql response is the issue-type search; second is the schema
+        // snapshot refresh that runs at the end of refresh_stale.
+        let gh = MockReader::new(vec![])
+            .with_view_issues(vec![
+                make_gh_issue(10, "STORY-001", "Body 10", &[]),
+                make_gh_issue(11, "STORY-002", "Body 11", &[]),
+            ])
+            .with_graphql_responses(vec![
+                search_response(&[10, 11]),
+                empty_issue_types_response(),
+            ]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache.refresh_stale(
+            tmp.path(),
+            &type_def,
+            &gh,
+            &gh,
+            "owner/repo",
+            &mut issue_map,
+            ttl,
+            &[story_match_rule()],
+            &Config::default(),
+        );
+
+        assert_eq!(
+            gh.call_count(),
+            0,
+            "issue_type-only refresh must make zero REST issue_list calls"
+        );
+        assert_eq!(
+            gh.view_call_count(),
+            2,
+            "each search hit is resolved via issue_view"
+        );
+        assert_eq!(result.refreshed, 2);
+        assert!(
+            result.warnings.is_empty(),
+            "warnings: {:?}",
+            result.warnings
+        );
+        assert!(cache.is_fresh("STORY-10", ttl));
+        assert!(cache.is_fresh("STORY-11", ttl));
+        assert_eq!(issue_map.get("STORY-10").unwrap().issue_number, 10);
+        assert_eq!(issue_map.get("STORY-11").unwrap().issue_number, 11);
+    }
+
+    // AC: with both `tag` and `issue_type` set, refresh_stale refreshes only the
+    // AND of the REST-list and search result sets -- an issue in only one is
+    // dropped from discovery and left stale.
+    #[test]
+    fn refresh_stale_both_signals_keeps_only_intersection() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(Some("Ticket"), Some("Bug"));
+        let ttl = Duration::seconds(60);
+
+        cache.write("STORY-10", "story", "old 10");
+        cache.write("STORY-11", "story", "old 11");
+        cache.write("STORY-12", "story", "old 12");
+        backdate_all(&cache, &["STORY-10", "STORY-11", "STORY-12"]);
+
+        // REST returns 10,11,12; search returns 11,12,99. Intersection: 11,12.
+        let gh = MockReader::new(vec![
+            make_gh_issue(10, "STORY-010", "Body 10", &["Ticket"]),
+            make_gh_issue(11, "STORY-011", "Body 11", &["Ticket"]),
+            make_gh_issue(12, "STORY-012", "Body 12", &["Ticket"]),
+        ])
+        .with_graphql_responses(vec![
+            search_response(&[11, 12, 99]),
+            empty_issue_types_response(),
+        ]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache.refresh_stale(
+            tmp.path(),
+            &type_def,
+            &gh,
+            &gh,
+            "owner/repo",
+            &mut issue_map,
+            ttl,
+            &[story_match_rule()],
+            &Config::default(),
+        );
+
+        assert_eq!(
+            result.refreshed, 2,
+            "only the REST/search intersection is refreshed"
+        );
+        assert_eq!(
+            gh.view_call_count(),
+            0,
+            "both-signals refresh reuses REST data, never re-fetches via issue_view"
+        );
+        assert!(cache.is_fresh("STORY-11", ttl));
+        assert!(cache.is_fresh("STORY-12", ttl));
+        assert!(
+            !cache.is_fresh("STORY-10", ttl),
+            "REST-only issue is dropped from discovery and left stale"
+        );
+    }
+
+    // AC: a full first page from the issue-type search (exactly PAGE_SIZE numbers)
+    // surfaces the truncation warning through refresh_stale's own warnings.
+    #[test]
+    fn refresh_stale_warns_when_issue_type_search_fills_first_page() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(None, Some("Bug"));
+        let ttl = Duration::seconds(60);
+
+        // A stale entry so refresh proceeds past the all-fresh short-circuit.
+        cache.write("STORY-1", "story", "old 1");
+        backdate_all(&cache, &["STORY-1"]);
+
+        let full_page: Vec<u64> = (1..=ISSUE_TYPE_SEARCH_PAGE_SIZE as u64).collect();
+        let gh = MockReader::new(vec![]).with_graphql_responses(vec![
+            search_response(&full_page),
+            empty_issue_types_response(),
+        ]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache.refresh_stale(
+            tmp.path(),
+            &type_def,
+            &gh,
+            &gh,
+            "owner/repo",
+            &mut issue_map,
+            ttl,
+            &[story_match_rule()],
+            &Config::default(),
+        );
+
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("returned exactly 100")),
+            "full-page search should surface a truncation warning via refresh: {:?}",
+            result.warnings
+        );
+    }
+
+    // AC: the tag-only discovery branch filters `issue_list` by the configured
+    // `github_issue_tag` (not the plain type-name label) and issues no GraphQL
+    // issue-type search.
+    #[test]
+    fn discover_issues_tag_only_lists_by_tag_and_skips_search() {
+        let gh = MockReader::new(vec![make_gh_issue(1, "STORY-001", "Body", &["Ticket"])]);
+        let rule = TypeMatchRule {
+            name: "story".to_string(),
+            label: "lazyspec:story".to_string(),
+            tag: Some("Ticket".to_string()),
+            issue_type: None,
+        };
+        let fields = vec!["number".to_string()];
+
+        let discovery = discover_issues(&gh, &gh, "owner/repo", &rule, &fields, None).unwrap();
+
+        assert_eq!(
+            gh.call_count(),
+            1,
+            "tag-only discovery uses exactly one REST issue_list call"
+        );
+        assert_eq!(
+            gh.graphql_call_count(),
+            0,
+            "tag-only discovery makes no GraphQL issue-type search"
+        );
+        assert_eq!(
+            gh.recorded_list_labels(),
+            vec![vec!["Ticket".to_string()]],
+            "issue_list must be filtered by the configured tag, not the type-name label"
+        );
+        assert!(!discovery.search_truncated);
+        assert_eq!(discovery.issues.len(), 1);
     }
 
     // --- fetch_all tests ---
@@ -1429,6 +1725,185 @@ mod tests {
 
         assert_eq!(issue_map.get("STORY-10").unwrap().issue_number, 10);
         assert!(issue_map.get("STORY-999").is_none());
+    }
+
+    fn story_type_def_signals(tag: Option<&str>, issue_type: Option<&str>) -> TypeDef {
+        TypeDef {
+            github_issue_tag: tag.map(|s| s.to_string()),
+            github_issue_type: issue_type.map(|s| s.to_string()),
+            ..story_type_def()
+        }
+    }
+
+    fn search_response(numbers: &[u64]) -> serde_json::Value {
+        let nodes: Vec<serde_json::Value> = numbers
+            .iter()
+            .map(|n| serde_json::json!({ "number": n }))
+            .collect();
+        serde_json::json!({ "data": { "search": { "nodes": nodes } } })
+    }
+
+    // AC: a type configured with only `github_issue_type` discovers candidates via
+    // the GraphQL issue-type search resolved through `issue_view`, making zero REST
+    // `issue_list` calls.
+    #[test]
+    fn fetch_all_issue_type_only_discovers_via_search_not_rest_list() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(None, Some("Bug"));
+
+        let gh = MockReader::new(vec![])
+            .with_view_issues(vec![
+                make_gh_issue(10, "STORY-001", "Body 10", &[]),
+                make_gh_issue(11, "STORY-002", "Body 11", &[]),
+            ])
+            .with_graphql_responses(vec![search_response(&[10, 11])]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache
+            .fetch_all(
+                tmp.path(),
+                &type_def,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            gh.call_count(),
+            0,
+            "issue_type-only discovery must make zero REST issue_list calls"
+        );
+        assert_eq!(
+            gh.view_call_count(),
+            2,
+            "each search hit is resolved via issue_view"
+        );
+        assert_eq!(result.fetched, 2);
+
+        let cache_dir = tmp.path().join(".lazyspec/cache/story");
+        assert!(cache_dir.join("STORY-10.md").exists());
+        assert!(cache_dir.join("STORY-11.md").exists());
+    }
+
+    // AC: with both `tag` and `issue_type` set the candidate set is the AND of the
+    // REST-list result and the search result -- an issue in only one is dropped.
+    #[test]
+    fn fetch_all_both_signals_keeps_only_intersection() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(Some("Ticket"), Some("Bug"));
+
+        // REST returns 10, 11, 12; search returns 11, 12, 99. Intersection: 11, 12.
+        let gh = MockReader::new(vec![
+            make_gh_issue(10, "STORY-010", "Body 10", &["Ticket"]),
+            make_gh_issue(11, "STORY-011", "Body 11", &["Ticket"]),
+            make_gh_issue(12, "STORY-012", "Body 12", &["Ticket"]),
+        ])
+        .with_graphql_responses(vec![search_response(&[11, 12, 99])]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache
+            .fetch_all(
+                tmp.path(),
+                &type_def,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.fetched, 2,
+            "only the REST/search intersection survives"
+        );
+        assert_eq!(
+            gh.view_call_count(),
+            0,
+            "both-signals intersection reuses REST data, never re-fetches via issue_view"
+        );
+        let cache_dir = tmp.path().join(".lazyspec/cache/story");
+        assert!(cache_dir.join("STORY-11.md").exists());
+        assert!(cache_dir.join("STORY-12.md").exists());
+        assert!(
+            !cache_dir.join("STORY-10.md").exists(),
+            "REST-only issue must be dropped"
+        );
+        assert!(
+            !cache_dir.join("STORY-99.md").exists(),
+            "search-only issue must be dropped"
+        );
+    }
+
+    // AC: a full first page from the issue-type search (exactly PAGE_SIZE numbers)
+    // surfaces a truncation warning mirroring the REST FETCH_LIMIT warning.
+    #[test]
+    fn fetch_all_warns_when_issue_type_search_fills_first_page() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(None, Some("Bug"));
+
+        let full_page: Vec<u64> = (1..=ISSUE_TYPE_SEARCH_PAGE_SIZE as u64).collect();
+        let gh = MockReader::new(vec![]).with_graphql_responses(vec![search_response(&full_page)]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache
+            .fetch_all(
+                tmp.path(),
+                &type_def,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("returned exactly 100")),
+            "full-page search should warn about truncation: {:?}",
+            result.warnings
+        );
+    }
+
+    // AC: a partial page from the issue-type search does not warn about truncation.
+    #[test]
+    fn fetch_all_no_truncation_warning_when_search_below_page_size() {
+        let (cache, tmp) = make_cache();
+        let type_def = story_type_def_signals(None, Some("Bug"));
+
+        let gh = MockReader::new(vec![]).with_graphql_responses(vec![search_response(&[1, 2, 3])]);
+
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let result = cache
+            .fetch_all(
+                tmp.path(),
+                &type_def,
+                &gh,
+                &gh,
+                "owner/repo",
+                &mut issue_map,
+                &[story_match_rule()],
+                &Config::default(),
+            )
+            .unwrap();
+
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("returned exactly")),
+            "partial-page search must not warn about truncation: {:?}",
+            result.warnings
+        );
     }
 
     // Custom `label_override`: an issue whose only type label is "Ticket" (no

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::engine::cache_lock::CacheLock;
 use crate::engine::config::{AttrDef, Config, TypeDef};
-use crate::engine::document::{AttrValue, DocMeta, DocType, Relation, RelationType, Status};
-use crate::engine::gh::{type_label, GhGraphql, GhIssue, GhIssueReader};
+use crate::engine::document::{AttrValue, DocMeta, Relation, RelationType, Status};
+use crate::engine::gh::{GhGraphql, GhIssue, GhIssueReader};
 use crate::engine::gh_schema;
 use crate::engine::gh_subissue;
 use crate::engine::issue_body::{self, IssueContext};
@@ -158,7 +158,7 @@ impl IssueCache {
             };
         }
 
-        let label = type_label(&type_def.name);
+        let label = type_def.github_label();
         let labels = vec![label];
         let fields = vec![
             "id".into(),
@@ -175,6 +175,8 @@ impl IssueCache {
         let milestone_rel = config
             .relationship_by_github_native("milestone")
             .map(|r| r.name.as_str());
+
+        let known_type_labels = resolve_known_type_labels(known_types, config);
 
         let issues = match gh.issue_list(repo, &labels, &fields, None) {
             Ok(issues) => issues,
@@ -201,7 +203,7 @@ impl IssueCache {
             let (meta, body) = parse_issue(
                 issue,
                 &type_def.name,
-                known_types,
+                &known_type_labels,
                 &type_def.attributes,
                 milestone_rel,
                 issue_map,
@@ -310,7 +312,7 @@ impl IssueCache {
         known_types: &[String],
         config: &Config,
     ) -> anyhow::Result<FetchResult> {
-        let label = type_label(&type_def.name);
+        let label = type_def.github_label();
         let labels = vec![label];
         const FETCH_LIMIT: u64 = 500;
 
@@ -348,11 +350,12 @@ impl IssueCache {
         let milestone_rel = config
             .relationship_by_github_native("milestone")
             .map(|r| r.name.as_str());
+        let known_type_labels = resolve_known_type_labels(known_types, config);
         for issue in &issues {
             let (meta, body) = parse_issue(
                 issue,
                 &type_def.name,
-                known_types,
+                &known_type_labels,
                 &type_def.attributes,
                 milestone_rel,
                 issue_map,
@@ -550,10 +553,27 @@ fn parse_created_date(created_at: &str) -> chrono::NaiveDate {
         .unwrap_or_else(|_| Utc::now().date_naive())
 }
 
+/// Pair each known type name with its resolved GitHub label (`github_label()`),
+/// so the read-side label matching can compare issue labels against custom
+/// `label_override`s, not just the default `lazyspec:{name}`. A name absent from
+/// the config falls back to the default label.
+fn resolve_known_type_labels(known_types: &[String], config: &Config) -> Vec<(String, String)> {
+    known_types
+        .iter()
+        .map(|name| {
+            let label = config
+                .type_by_name(name)
+                .map(|t| t.github_label())
+                .unwrap_or_else(|| crate::engine::gh::type_label(name));
+            (name.clone(), label)
+        })
+        .collect()
+}
+
 fn parse_issue(
     issue: &GhIssue,
     type_name: &str,
-    known_types: &[String],
+    known_types: &[(String, String)],
     attr_defs: &[AttrDef],
     milestone_rel: Option<&str>,
     issue_map: &IssueMap,
@@ -586,19 +606,16 @@ fn parse_issue(
         Status::new("complete")
     };
 
+    let (doc_type, tags) = issue_body::extract_type_and_tags(&ctx.labels, known_types, type_name);
+
     let mut meta = DocMeta {
         path: PathBuf::new(),
         title: issue.title.clone(),
-        doc_type: DocType::new(type_name),
+        doc_type,
         status,
         author: author.clone(),
         date: parse_created_date(&issue.created_at),
-        tags: issue
-            .labels
-            .iter()
-            .filter(|l| !l.name.starts_with("lazyspec:"))
-            .map(|l| l.name.clone())
-            .collect(),
+        tags,
         provenance: vec![],
         related: vec![],
         validate_ignore: false,
@@ -687,6 +704,7 @@ fn build_cache_content(meta: &DocMeta, body: &str) -> String {
 mod tests {
     use super::*;
     use crate::engine::config::{NumberingStrategy, StoreBackend};
+    use crate::engine::document::DocType;
     use crate::engine::gh::{GhAuthor, GhGraphql, GhIssueReader, GhLabel, GqlVar};
     use anyhow::Result;
     use std::cell::RefCell;
@@ -716,6 +734,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         }
     }
 
@@ -1185,7 +1204,6 @@ mod tests {
 
         // Verify Store::load can find the documents
         use crate::engine::config::{Config, GithubConfig};
-        use crate::engine::document::DocType;
         use crate::engine::store::Store;
         let mut config = Config::default();
         config.documents.types = vec![story_type_def()];
@@ -1407,6 +1425,71 @@ mod tests {
         assert!(issue_map.get("STORY-999").is_none());
     }
 
+    // Custom `label_override`: an issue whose only type label is "Ticket" (no
+    // `lazyspec:` prefix) resolves to that type on read, and the custom label is
+    // not carried as a tag.
+    #[test]
+    fn parse_issue_recognizes_custom_label_type() {
+        let issue = make_gh_issue(
+            5,
+            "Ticketed work",
+            "<!-- lazyspec\n---\ndate: 2026-03-27\n---\n-->\n\nbody",
+            &["Ticket", "team-x"],
+        );
+        let known_types = vec![("ticket".to_string(), "Ticket".to_string())];
+        let (meta, _) = parse_issue(
+            &issue,
+            "ticket",
+            &known_types,
+            &[],
+            None,
+            &IssueMap::default(),
+        );
+        assert_eq!(meta.doc_type.as_str(), "ticket");
+        assert_eq!(meta.tags, vec!["team-x"]);
+    }
+
+    // Regression: a type with no override still resolves via its default
+    // `lazyspec:{name}` label, unchanged from before.
+    #[test]
+    fn parse_issue_recognizes_default_label_type() {
+        let issue = make_gh_issue(
+            6,
+            "Default labelled",
+            "<!-- lazyspec\n---\ndate: 2026-03-27\n---\n-->\n\nbody",
+            &["lazyspec:story", "team-y"],
+        );
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let (meta, _) = parse_issue(
+            &issue,
+            "story",
+            &known_types,
+            &[],
+            None,
+            &IssueMap::default(),
+        );
+        assert_eq!(meta.doc_type.as_str(), "story");
+        assert_eq!(meta.tags, vec!["team-y"]);
+    }
+
+    // Fallback path (no lazyspec comment): a custom label is excluded from tags,
+    // just like the default-prefixed case.
+    #[test]
+    fn parse_issue_fallback_excludes_custom_label_from_tags() {
+        let issue = make_gh_issue(7, "Plain ticket", "Just a plain body", &["Ticket", "extra"]);
+        let known_types = vec![("ticket".to_string(), "Ticket".to_string())];
+        let (meta, _) = parse_issue(
+            &issue,
+            "ticket",
+            &known_types,
+            &[],
+            None,
+            &IssueMap::default(),
+        );
+        assert_eq!(meta.doc_type.as_str(), "ticket");
+        assert_eq!(meta.tags, vec!["extra"]);
+    }
+
     fn make_gh_issue_with_author(
         number: u64,
         title: &str,
@@ -1430,7 +1513,7 @@ mod tests {
             &["lazyspec:story"],
             Some("jkaloger"),
         );
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1451,7 +1534,7 @@ mod tests {
             &["lazyspec:story"],
             None,
         );
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1473,7 +1556,7 @@ mod tests {
             &["lazyspec:story"],
             Some("octocat"),
         );
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1495,7 +1578,7 @@ mod tests {
             &["lazyspec:story"],
             Some("jkaloger"),
         );
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1547,7 +1630,7 @@ mod tests {
     fn parse_issue_uses_created_at_for_date() {
         let mut issue = make_gh_issue(1, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = "2025-06-15T09:30:00Z".to_string();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1566,7 +1649,7 @@ mod tests {
     fn parse_issue_falls_back_to_today_on_bad_created_at() {
         let mut issue = make_gh_issue(2, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = "not-a-date".to_string();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1582,7 +1665,7 @@ mod tests {
     fn parse_issue_falls_back_to_today_on_empty_created_at() {
         let mut issue = make_gh_issue(3, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = String::new();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1605,7 +1688,7 @@ mod tests {
             &["lazyspec:story"],
         );
         issue.issue_type = Some("Bug".to_string());
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1630,7 +1713,7 @@ mod tests {
             &["lazyspec:story"],
         );
         assert!(issue.issue_type.is_none());
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1652,7 +1735,7 @@ mod tests {
             &["lazyspec:story"],
         );
         issue.issue_type = Some("Bug".to_string());
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1673,7 +1756,7 @@ mod tests {
     fn parse_issue_fallback_body_surfaces_issue_type() {
         let mut issue = make_gh_issue(4, "Plain issue", "Just a plain body", &["lazyspec:story"]);
         issue.issue_type = Some("Task".to_string());
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1754,7 +1837,7 @@ mod tests {
         let mut map = IssueMap::default();
         map.insert_kind("MILESTONE-2", 7, "", "", EntryKind::Milestone);
 
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
         let (meta, _) = parse_issue(&issue, "story", &known_types, &[], Some("targets"), &map);
 
         let targets: Vec<(&str, &str)> = meta
@@ -1773,7 +1856,7 @@ mod tests {
 
         let mut issue = make_gh_issue(3, "Test issue", "body", &["lazyspec:story"]);
         issue.milestone = Some(GhIssueMilestone { number: 7 });
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
 
         // Milestone #7 maps to no doc -> skipped even with a configured rel.
         let empty = IssueMap::default();

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -8,7 +8,7 @@ use crate::engine::document::{AttrValue, DocMeta, Relation, RelationType, Status
 use crate::engine::gh::{GhGraphql, GhIssue, GhIssueReader};
 use crate::engine::gh_schema;
 use crate::engine::gh_subissue;
-use crate::engine::issue_body::{self, IssueContext};
+use crate::engine::issue_body::{self, IssueContext, TypeMatchRule};
 use crate::engine::issue_map::IssueMap;
 use crate::engine::store;
 use crate::engine::store_dispatch;
@@ -137,7 +137,7 @@ impl IssueCache {
         repo: &str,
         issue_map: &mut IssueMap,
         ttl: Duration,
-        known_types: &[String],
+        known_types: &[TypeMatchRule],
         config: &Config,
     ) -> RefreshResult {
         let cached_ids = self.list_cached(&type_def.name);
@@ -176,8 +176,6 @@ impl IssueCache {
             .relationship_by_github_native("milestone")
             .map(|r| r.name.as_str());
 
-        let known_type_labels = resolve_known_type_labels(known_types, config);
-
         let issues = match gh.issue_list(repo, &labels, &fields, None) {
             Ok(issues) => issues,
             Err(e) => {
@@ -203,7 +201,7 @@ impl IssueCache {
             let (meta, body) = parse_issue(
                 issue,
                 &type_def.name,
-                &known_type_labels,
+                known_types,
                 &type_def.attributes,
                 milestone_rel,
                 issue_map,
@@ -309,7 +307,7 @@ impl IssueCache {
         gh_graphql: &dyn GhGraphql,
         repo: &str,
         issue_map: &mut IssueMap,
-        known_types: &[String],
+        known_types: &[TypeMatchRule],
         config: &Config,
     ) -> anyhow::Result<FetchResult> {
         let label = type_def.github_label();
@@ -350,12 +348,11 @@ impl IssueCache {
         let milestone_rel = config
             .relationship_by_github_native("milestone")
             .map(|r| r.name.as_str());
-        let known_type_labels = resolve_known_type_labels(known_types, config);
         for issue in &issues {
             let (meta, body) = parse_issue(
                 issue,
                 &type_def.name,
-                &known_type_labels,
+                known_types,
                 &type_def.attributes,
                 milestone_rel,
                 issue_map,
@@ -553,27 +550,10 @@ fn parse_created_date(created_at: &str) -> chrono::NaiveDate {
         .unwrap_or_else(|_| Utc::now().date_naive())
 }
 
-/// Pair each known type name with its resolved GitHub label (`github_label()`),
-/// so the read-side label matching can compare issue labels against custom
-/// `label_override`s, not just the default `lazyspec:{name}`. A name absent from
-/// the config falls back to the default label.
-fn resolve_known_type_labels(known_types: &[String], config: &Config) -> Vec<(String, String)> {
-    known_types
-        .iter()
-        .map(|name| {
-            let label = config
-                .type_by_name(name)
-                .map(|t| t.github_label())
-                .unwrap_or_else(|| crate::engine::gh::type_label(name));
-            (name.clone(), label)
-        })
-        .collect()
-}
-
 fn parse_issue(
     issue: &GhIssue,
     type_name: &str,
-    known_types: &[(String, String)],
+    known_types: &[TypeMatchRule],
     attr_defs: &[AttrDef],
     milestone_rel: Option<&str>,
     issue_map: &IssueMap,
@@ -583,6 +563,7 @@ fn parse_issue(
         labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
         is_open: issue.state.eq_ignore_ascii_case("open"),
         known_types: known_types.to_vec(),
+        issue_type: issue.issue_type.clone(),
         default_type: type_name.to_string(),
         attr_defs: attr_defs.to_vec(),
     };
@@ -606,7 +587,12 @@ fn parse_issue(
         Status::new("complete")
     };
 
-    let (doc_type, tags) = issue_body::extract_type_and_tags(&ctx.labels, known_types, type_name);
+    let (doc_type, tags) = issue_body::extract_type_and_tags(
+        &ctx.labels,
+        known_types,
+        issue.issue_type.as_deref(),
+        type_name,
+    );
 
     let mut meta = DocMeta {
         path: PathBuf::new(),
@@ -737,6 +723,24 @@ mod tests {
             label_override: None,
             github_issue_tag: None,
             github_issue_type: None,
+        }
+    }
+
+    fn story_match_rule() -> TypeMatchRule {
+        TypeMatchRule {
+            name: "story".to_string(),
+            label: "lazyspec:story".to_string(),
+            tag: None,
+            issue_type: None,
+        }
+    }
+
+    fn ticket_match_rule() -> TypeMatchRule {
+        TypeMatchRule {
+            name: "ticket".to_string(),
+            label: "Ticket".to_string(),
+            tag: None,
+            issue_type: None,
         }
     }
 
@@ -978,7 +982,7 @@ mod tests {
         .with_graphql_responses(vec![empty_issue_types_response()]);
 
         let mut issue_map = IssueMap::load(tmp.path()).unwrap();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![story_match_rule()];
         let result = cache.refresh_stale(
             tmp.path(),
             &type_def,
@@ -1046,7 +1050,7 @@ mod tests {
             "octo-org/repo",
             &mut issue_map,
             ttl,
-            &["story".to_string()],
+            &[story_match_rule()],
             &Config::default(),
         );
         assert!(
@@ -1075,7 +1079,7 @@ mod tests {
 
         let gh = MockReader::new(vec![]);
         let mut issue_map = IssueMap::load(tmp.path()).unwrap();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![story_match_rule()];
         let result = cache.refresh_stale(
             tmp.path(),
             &type_def,
@@ -1112,7 +1116,7 @@ mod tests {
 
         let gh = MockReader::failing();
         let mut issue_map = IssueMap::load(tmp.path()).unwrap();
-        let known_types = vec!["story".to_string()];
+        let known_types = vec![story_match_rule()];
         let result = cache.refresh_stale(
             tmp.path(),
             &type_def,
@@ -1163,7 +1167,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1246,7 +1250,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1282,7 +1286,7 @@ mod tests {
                 &initial_gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1305,7 +1309,7 @@ mod tests {
                 &updated_gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1353,7 +1357,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1400,7 +1404,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1438,7 +1442,7 @@ mod tests {
             "<!-- lazyspec\n---\ndate: 2026-03-27\n---\n-->\n\nbody",
             &["Ticket", "team-x"],
         );
-        let known_types = vec![("ticket".to_string(), "Ticket".to_string())];
+        let known_types = vec![ticket_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "ticket",
@@ -1461,7 +1465,7 @@ mod tests {
             "<!-- lazyspec\n---\ndate: 2026-03-27\n---\n-->\n\nbody",
             &["lazyspec:story", "team-y"],
         );
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1479,7 +1483,7 @@ mod tests {
     #[test]
     fn parse_issue_fallback_excludes_custom_label_from_tags() {
         let issue = make_gh_issue(7, "Plain ticket", "Just a plain body", &["Ticket", "extra"]);
-        let known_types = vec![("ticket".to_string(), "Ticket".to_string())];
+        let known_types = vec![ticket_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "ticket",
@@ -1515,7 +1519,7 @@ mod tests {
             &["lazyspec:story"],
             Some("jkaloger"),
         );
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1536,7 +1540,7 @@ mod tests {
             &["lazyspec:story"],
             None,
         );
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1558,7 +1562,7 @@ mod tests {
             &["lazyspec:story"],
             Some("octocat"),
         );
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1580,7 +1584,7 @@ mod tests {
             &["lazyspec:story"],
             Some("jkaloger"),
         );
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1614,7 +1618,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -1632,7 +1636,7 @@ mod tests {
     fn parse_issue_uses_created_at_for_date() {
         let mut issue = make_gh_issue(1, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = "2025-06-15T09:30:00Z".to_string();
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1651,7 +1655,7 @@ mod tests {
     fn parse_issue_falls_back_to_today_on_bad_created_at() {
         let mut issue = make_gh_issue(2, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = "not-a-date".to_string();
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1667,7 +1671,7 @@ mod tests {
     fn parse_issue_falls_back_to_today_on_empty_created_at() {
         let mut issue = make_gh_issue(3, "Test issue", "Just a plain body", &["lazyspec:story"]);
         issue.created_at = String::new();
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1690,7 +1694,7 @@ mod tests {
             &["lazyspec:story"],
         );
         issue.issue_type = Some("Bug".to_string());
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1715,7 +1719,7 @@ mod tests {
             &["lazyspec:story"],
         );
         assert!(issue.issue_type.is_none());
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1737,7 +1741,7 @@ mod tests {
             &["lazyspec:story"],
         );
         issue.issue_type = Some("Bug".to_string());
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1758,7 +1762,7 @@ mod tests {
     fn parse_issue_fallback_body_surfaces_issue_type() {
         let mut issue = make_gh_issue(4, "Plain issue", "Just a plain body", &["lazyspec:story"]);
         issue.issue_type = Some("Task".to_string());
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(
             &issue,
             "story",
@@ -1812,7 +1816,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &config,
             )
             .unwrap();
@@ -1839,7 +1843,7 @@ mod tests {
         let mut map = IssueMap::default();
         map.insert_kind("MILESTONE-2", 7, "", "", EntryKind::Milestone);
 
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
         let (meta, _) = parse_issue(&issue, "story", &known_types, &[], Some("targets"), &map);
 
         let targets: Vec<(&str, &str)> = meta
@@ -1858,7 +1862,7 @@ mod tests {
 
         let mut issue = make_gh_issue(3, "Test issue", "body", &["lazyspec:story"]);
         issue.milestone = Some(GhIssueMilestone { number: 7 });
-        let known_types = vec![("story".to_string(), "lazyspec:story".to_string())];
+        let known_types = vec![story_match_rule()];
 
         // Milestone #7 maps to no doc -> skipped even with a configured rel.
         let empty = IssueMap::default();
@@ -2217,7 +2221,7 @@ mod tests {
                 &gh,
                 "owner/repo",
                 &mut issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap();
@@ -2363,7 +2367,7 @@ mod tests {
                 gh,
                 "owner/repo",
                 issue_map,
-                &["story".to_string()],
+                &[story_match_rule()],
                 &Config::default(),
             )
             .unwrap()

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -735,6 +735,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 

--- a/src/engine/milestone_cache.rs
+++ b/src/engine/milestone_cache.rs
@@ -105,6 +105,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         }
     }
 

--- a/src/engine/milestone_cache.rs
+++ b/src/engine/milestone_cache.rs
@@ -106,6 +106,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -723,6 +723,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         let mut config = Config::default();
@@ -818,6 +820,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         let mut config = Config::default();

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -722,6 +722,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         let mut config = Config::default();
@@ -816,6 +817,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         let mut config = Config::default();

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -274,8 +274,9 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> GithubIssuesStore<G> {
                 .documents
                 .types
                 .iter()
-                .map(|t| (t.name.clone(), t.github_label()))
+                .map(issue_body::TypeMatchRule::from)
                 .collect(),
+            issue_type: remote_issue.issue_type.clone(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
         };
@@ -961,8 +962,9 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
                 .documents
                 .types
                 .iter()
-                .map(|t| (t.name.clone(), t.github_label()))
+                .map(issue_body::TypeMatchRule::from)
                 .collect(),
+            issue_type: remote_issue.issue_type.clone(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
         };
@@ -1098,8 +1100,9 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
                 .documents
                 .types
                 .iter()
-                .map(|t| (t.name.clone(), t.github_label()))
+                .map(issue_body::TypeMatchRule::from)
                 .collect(),
+            issue_type: remote_issue.issue_type.clone(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
         };

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -274,7 +274,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> GithubIssuesStore<G> {
                 .documents
                 .types
                 .iter()
-                .map(|t| t.name.clone())
+                .map(|t| (t.name.clone(), t.github_label()))
                 .collect(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
@@ -492,7 +492,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> GithubIssuesStore<G> {
             .unwrap_or_default();
 
         let issue_body = issue_body::serialize(meta, &body);
-        let label = gh::type_label(&type_def.name);
+        let label = type_def.github_label();
         let color = gh::deterministic_color(&type_def.name);
         let description = format!("lazyspec document type: {}", type_def.name);
         self.client
@@ -894,7 +894,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
         };
 
         let issue_body = issue_body::serialize(&placeholder_meta, body);
-        let label = gh::type_label(&type_def.name);
+        let label = type_def.github_label();
         let color = gh::deterministic_color(&type_def.name);
         let description = format!("lazyspec document type: {}", type_def.name);
         self.client
@@ -961,7 +961,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
                 .documents
                 .types
                 .iter()
-                .map(|t| t.name.clone())
+                .map(|t| (t.name.clone(), t.github_label()))
                 .collect(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
@@ -1098,7 +1098,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
                 .documents
                 .types
                 .iter()
-                .map(|t| t.name.clone())
+                .map(|t| (t.name.clone(), t.github_label()))
                 .collect(),
             default_type: type_def.name.clone(),
             attr_defs: type_def.attributes.clone(),
@@ -1128,7 +1128,7 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
         let (issue_number, remote_issue) = self.check_lock(doc_id)?;
 
         let deleted_title = format!("[DELETED] {}", remote_issue.title);
-        let label = gh::type_label(&type_def.name);
+        let label = type_def.github_label();
         self.client.issue_edit(
             &self.repo,
             issue_number,
@@ -1897,6 +1897,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         }
     }
 
@@ -2043,6 +2044,28 @@ mod tests {
     }
 
     #[test]
+    fn github_issues_create_uses_label_override() {
+        let root = tmp_root("gh_create_label_override");
+        let mut gh_store = GithubIssuesStore {
+            client: MockGhClient::new(),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root).unwrap(),
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let mut td = test_type_def(StoreBackend::GithubIssues);
+        td.label_override = Some("Ticket".to_string());
+        gh_store.create(&td, "custom", "author", "").unwrap();
+
+        assert_eq!(
+            *gh_store.client.last_create_labels.borrow(),
+            vec!["Ticket".to_string()]
+        );
+    }
+
+    #[test]
     fn github_issues_create_persists_issue_map() {
         let root = tmp_root("gh_create_persist");
         let mut gh_store = GithubIssuesStore {
@@ -2109,6 +2132,7 @@ mod tests {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         };
 
         let result = gh_store.create(&td, "test prefix", "author", "").unwrap();

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -900,9 +900,39 @@ impl<G: GhIssueReader + GhIssueWriter + GhGraphql> DocumentStore for GithubIssue
         let description = format!("lazyspec document type: {}", type_def.name);
         self.client
             .label_ensure(&self.repo, &label, &description, &color)?;
+
+        // Resolve the native issue-type offline before any remote write, so an
+        // unresolvable name aborts before `issue_create` fires.
+        let resolved_issue_type_id: Option<String> = match type_def.github_issue_type.as_deref() {
+            Some(name) => {
+                let snapshot = GhSchemaSnapshot::load(&self.root);
+                let id = snapshot.issue_type_id(name).ok_or_else(|| {
+                    if snapshot.issue_types.is_empty() {
+                        let (owner, _) = split_owner_repo(&self.repo)
+                            .unwrap_or((self.repo.as_str(), ""));
+                        anyhow::anyhow!(
+                            "native issue types require an organization-owned repository; '{}' has none",
+                            owner
+                        )
+                    } else {
+                        anyhow::anyhow!(
+                            "invalid issue_type '{}': not a known GitHub issue type",
+                            name
+                        )
+                    }
+                })?;
+                Some(id.to_string())
+            }
+            None => None,
+        };
+
         let issue = self
             .client
             .issue_create(&self.repo, title, &issue_body, &[label])?;
+
+        if let Some(resolved_id) = resolved_issue_type_id.as_deref() {
+            self.push_issue_type(issue.number, Some(resolved_id))?;
+        }
 
         // Use the GitHub issue number as the document number.
         let issue_num_str = issue.number.to_string();
@@ -4268,6 +4298,197 @@ mod tests {
         let (yaml, _) = crate::engine::document::split_frontmatter(&cache_content).unwrap();
         let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed["type"].as_str().unwrap(), "story");
+    }
+
+    // --- STORY-195 / ITERATION-266: push native issue type on create ---
+
+    // AC1: `github_issue_type` configured + resolvable -> create succeeds and
+    // pushes exactly one updateIssue mutation carrying the resolved id.
+    #[test]
+    fn github_create_pushes_configured_issue_type() {
+        let root = tmp_root("gh_create_issue_type_push");
+        write_bug_snapshot(&root);
+        let td = TypeDef {
+            github_issue_type: Some("Bug".to_string()),
+            ..test_type_def(StoreBackend::GithubIssues)
+        };
+
+        let mut gh_store = GithubIssuesStore {
+            client: MockGhClient::new().with_graphql_responses(vec![
+                issue_node_id_response(),
+                serde_json::json!({"data": {"updateIssue": {"issue": {"id": "I_node1"}}}}),
+            ]),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root).unwrap(),
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let result = gh_store
+            .create(&td, "my title", "author", "body text")
+            .unwrap();
+        assert_eq!(result.id, "RFC-1");
+
+        let calls = gh_store.client.graphql_calls.borrow();
+        let mutations: Vec<_> = calls
+            .iter()
+            .filter(|(q, _)| q.contains("updateIssue"))
+            .collect();
+        assert_eq!(mutations.len(), 1, "exactly one updateIssue mutation");
+        let (_, vars) = mutations[0];
+        assert!(
+            vars.contains(&("issueTypeId".to_string(), GqlVar::Str("IT_bug".to_string()))),
+            "mutation must carry resolved issueTypeId=IT_bug, got: {:?}",
+            vars
+        );
+    }
+
+    // AC2: `github_issue_type` unset -> zero GraphQL calls, no push at all, and
+    // plain create behavior is unchanged.
+    #[test]
+    fn github_create_without_issue_type_makes_no_push_call() {
+        let root = tmp_root("gh_create_issue_type_absent");
+        let td = test_type_def(StoreBackend::GithubIssues);
+        assert_eq!(td.github_issue_type, None);
+
+        let mut gh_store = GithubIssuesStore {
+            client: MockGhClient::new(),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root).unwrap(),
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let result = gh_store
+            .create(&td, "my title", "author", "body text")
+            .unwrap();
+        assert_eq!(result.id, "RFC-1");
+        assert_eq!(gh_store.client.create_titles.borrow().len(), 1);
+        assert!(
+            gh_store.client.graphql_calls.borrow().is_empty(),
+            "no issue_type configured -> zero GraphQL calls"
+        );
+    }
+
+    // AC3: `github_issue_type` configured but unresolvable -> create fails
+    // before `issue_create` fires, mirroring `update`'s two rejection message
+    // shapes (name absent from a populated schema; empty schema on a
+    // user-owned repo).
+    #[test]
+    fn github_create_unresolvable_issue_type_fails_before_create() {
+        // Shape 1: populated schema, name not present.
+        let root = tmp_root("gh_create_issue_type_invalid");
+        write_bug_snapshot(&root);
+        let td = TypeDef {
+            github_issue_type: Some("Nonsense".to_string()),
+            ..test_type_def(StoreBackend::GithubIssues)
+        };
+        let mut gh_store = GithubIssuesStore {
+            client: MockGhClient::new(),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root).unwrap(),
+            issue_cache: IssueCache::new(&root),
+        };
+        let err = gh_store
+            .create(&td, "my title", "author", "body text")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Nonsense"),
+            "error must name the invalid value, got: {err}"
+        );
+        assert!(
+            gh_store.client.create_titles.borrow().is_empty(),
+            "issue_create must never fire when the type is unresolvable"
+        );
+        assert!(
+            gh_store.client.graphql_calls.borrow().is_empty(),
+            "zero GraphQL calls on invalid issue_type"
+        );
+
+        // Shape 2: empty schema (user-owned repo) -> org-only message.
+        let root2 = tmp_root("gh_create_issue_type_user_account");
+        GhSchemaSnapshot {
+            issue_types: vec![],
+            ..Default::default()
+        }
+        .save(&root2)
+        .unwrap();
+        let td2 = TypeDef {
+            github_issue_type: Some("Bug".to_string()),
+            ..test_type_def(StoreBackend::GithubIssues)
+        };
+        let mut gh_store2 = GithubIssuesStore {
+            client: MockGhClient::new(),
+            root: root2.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root2).unwrap(),
+            issue_cache: IssueCache::new(&root2),
+        };
+        let err2 = gh_store2
+            .create(&td2, "my title", "author", "body text")
+            .unwrap_err();
+        assert!(
+            err2.to_string().contains("require an organization"),
+            "error must name the org-only constraint, got: {err2}"
+        );
+        assert!(
+            gh_store2.client.create_titles.borrow().is_empty(),
+            "issue_create must never fire when the type is unresolvable"
+        );
+    }
+
+    // AC4: `create_child_subissue` delegates to `create` with zero new logic,
+    // so a configured `github_issue_type` on the child's TypeDef is pushed too.
+    #[test]
+    fn create_child_subissue_pushes_configured_issue_type() {
+        let root = tmp_root("create_child_issue_type");
+        write_bug_snapshot(&root);
+        let td = TypeDef {
+            github_issue_type: Some("Bug".to_string()),
+            ..test_type_def(StoreBackend::GithubIssues)
+        };
+
+        let mut store = GithubIssuesStore {
+            client: MockGhClient::new().with_graphql_responses(vec![
+                issue_node_id_response(),
+                serde_json::json!({"data": {"updateIssue": {"issue": {"id": "I_node1"}}}}),
+                serde_json::json!({"data": {"node": {"subIssues": {"nodes": []}}}}),
+                serde_json::json!({"data": {}}),
+            ]),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: IssueMap::load(&root).unwrap(),
+            issue_cache: IssueCache::new(&root),
+        };
+        store.issue_map.insert("RFC-1", 1, "ts", "I_parent");
+        store.issue_map.save(&root).unwrap();
+
+        store
+            .create_child_subissue(&td, "RFC-1", "Child", "author", "")
+            .unwrap();
+
+        let calls = store.client.graphql_calls.borrow();
+        let mutations: Vec<_> = calls
+            .iter()
+            .filter(|(q, _)| q.contains("updateIssue"))
+            .collect();
+        assert_eq!(
+            mutations.len(),
+            1,
+            "exactly one updateIssue mutation for the child"
+        );
+        let (_, vars) = mutations[0];
+        assert!(
+            vars.contains(&("issueTypeId".to_string(), GqlVar::Str("IT_bug".to_string()))),
+            "child updateIssue must carry resolved issueTypeId=IT_bug, got: {:?}",
+            vars
+        );
     }
 
     // --- Subdir sub-issue materialization (ITERATION-214) ---

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -1898,6 +1898,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         }
     }
 
@@ -2133,6 +2135,8 @@ mod tests {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         };
 
         let result = gh_store.create(&td, "test prefix", "author", "").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -649,11 +649,11 @@ fn refresh_github_cache(cwd: &std::path::Path, config: &Config) {
 
     let mut map_changed = false;
     for type_def in &gh_types {
-        let all_type_names: Vec<String> = config
+        let all_type_rules: Vec<lazyspec::engine::issue_body::TypeMatchRule> = config
             .documents
             .types
             .iter()
-            .map(|t| t.name.clone())
+            .map(lazyspec::engine::issue_body::TypeMatchRule::from)
             .collect();
         let result = cache.refresh_stale(
             cwd,
@@ -663,7 +663,7 @@ fn refresh_github_cache(cwd: &std::path::Path, config: &Config) {
             &repo,
             &mut issue_map,
             ttl,
-            &all_type_names,
+            &all_type_rules,
             config,
         );
         for warning in &result.warnings {

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -3,6 +3,7 @@ use crate::engine::document::split_frontmatter;
 use crate::engine::gh::GhCli;
 use crate::engine::git_ref::GitCli;
 use crate::engine::git_ref_store::GitRefStore;
+use crate::engine::issue_body::TypeMatchRule;
 use crate::engine::issue_cache::IssueCache;
 use crate::engine::issue_map::IssueMap;
 use crate::engine::store::Store;
@@ -523,11 +524,11 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
                         .iter()
                         .filter(|t| t.store == StoreBackend::GithubMilestones)
                         .collect();
-                    let all_type_names: Vec<String> = poll_config
+                    let all_type_rules: Vec<TypeMatchRule> = poll_config
                         .documents
                         .types
                         .iter()
-                        .map(|t| t.name.clone())
+                        .map(TypeMatchRule::from)
                         .collect();
                     let client = GhCli::new();
                     let mut guard = poll_store.lock().unwrap();
@@ -565,7 +566,7 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
                             &client,
                             &store.repo,
                             &mut store.issue_map,
-                            &all_type_names,
+                            &all_type_rules,
                             &poll_config,
                         ) {
                             Ok(result) => {

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -2645,6 +2645,8 @@ impl App {
                     lifecycle: crate::engine::config::default_lifecycle(),
                     attributes: Vec::new(),
                     label_override: None,
+                    github_issue_tag: None,
+                    github_issue_type: None,
                 });
                 self.settings_entry = self.settings_buffer.documents.types.len() - 1;
             }

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -2644,6 +2644,7 @@ impl App {
                     authorship: Default::default(),
                     lifecycle: crate::engine::config::default_lifecycle(),
                     attributes: Vec::new(),
+                    label_override: None,
                 });
                 self.settings_entry = self.settings_buffer.documents.types.len() - 1;
             }

--- a/tests/integration/cli_child_test.rs
+++ b/tests/integration/cli_child_test.rs
@@ -178,6 +178,7 @@ fn create_with_parent_cross_store_rejected_before_mutation() {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     };
     config.documents.types.push(issue_type);
     let store = fixture.store();

--- a/tests/integration/cli_child_test.rs
+++ b/tests/integration/cli_child_test.rs
@@ -179,6 +179,8 @@ fn create_with_parent_cross_store_rejected_before_mutation() {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     };
     config.documents.types.push(issue_type);
     let store = fixture.store();

--- a/tests/integration/cli_convention_test.rs
+++ b/tests/integration/cli_convention_test.rs
@@ -24,6 +24,7 @@ fn convention_config(fixture: &TestFixture) -> Config {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     });
     config.documents.types.push(TypeDef {
         name: "dictum".to_string(),
@@ -41,6 +42,7 @@ fn convention_config(fixture: &TestFixture) -> Config {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     });
     config
 }

--- a/tests/integration/cli_convention_test.rs
+++ b/tests/integration/cli_convention_test.rs
@@ -25,6 +25,8 @@ fn convention_config(fixture: &TestFixture) -> Config {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     });
     config.documents.types.push(TypeDef {
         name: "dictum".to_string(),
@@ -43,6 +45,8 @@ fn convention_config(fixture: &TestFixture) -> Config {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     });
     config
 }

--- a/tests/integration/cli_create_test.rs
+++ b/tests/integration/cli_create_test.rs
@@ -26,6 +26,8 @@ fn milestones_only_config() -> Config {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }];
     config.documents.github = None;
     config
@@ -49,6 +51,8 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }
 }
 

--- a/tests/integration/cli_create_test.rs
+++ b/tests/integration/cli_create_test.rs
@@ -25,6 +25,7 @@ fn milestones_only_config() -> Config {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }];
     config.documents.github = None;
     config
@@ -47,6 +48,7 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }
 }
 

--- a/tests/integration/cli_mutate_test.rs
+++ b/tests/integration/cli_mutate_test.rs
@@ -29,6 +29,7 @@ fn milestones_fixture() -> (TestFixture, Config) {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }];
     config.documents.github = None;
 

--- a/tests/integration/cli_mutate_test.rs
+++ b/tests/integration/cli_mutate_test.rs
@@ -30,6 +30,8 @@ fn milestones_fixture() -> (TestFixture, Config) {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }];
     config.documents.github = None;
 

--- a/tests/integration/cli_validate_test.rs
+++ b/tests/integration/cli_validate_test.rs
@@ -299,6 +299,7 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }
 }
 
@@ -319,6 +320,7 @@ fn child_type(name: &str, dir: &str, prefix: &str, parent: &str) -> TypeDef {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }
 }
 
@@ -476,6 +478,7 @@ fn parent_type_references_non_singleton_error() {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     };
     let config = config_with_extra_types(vec![
         non_singleton_parent,

--- a/tests/integration/cli_validate_test.rs
+++ b/tests/integration/cli_validate_test.rs
@@ -300,6 +300,8 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }
 }
 
@@ -321,6 +323,8 @@ fn child_type(name: &str, dir: &str, prefix: &str, parent: &str) -> TypeDef {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }
 }
 
@@ -479,6 +483,8 @@ fn parent_type_references_non_singleton_error() {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     };
     let config = config_with_extra_types(vec![
         non_singleton_parent,

--- a/tests/integration/fetch_milestone_relation_test.rs
+++ b/tests/integration/fetch_milestone_relation_test.rs
@@ -167,6 +167,7 @@ fn ticket_type() -> TypeDef {
         authorship: Default::default(),
         lifecycle: Default::default(),
         attributes: Default::default(),
+        label_override: None,
     }
 }
 

--- a/tests/integration/fetch_milestone_relation_test.rs
+++ b/tests/integration/fetch_milestone_relation_test.rs
@@ -168,6 +168,8 @@ fn ticket_type() -> TypeDef {
         lifecycle: Default::default(),
         attributes: Default::default(),
         label_override: None,
+        github_issue_tag: None,
+        github_issue_type: None,
     }
 }
 

--- a/tests/integration/tui_graph_test.rs
+++ b/tests/integration/tui_graph_test.rs
@@ -410,6 +410,7 @@ fn custom_types_populate_doc_types_and_icons() {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         },
         TypeDef {
             name: "task".into(),
@@ -427,6 +428,7 @@ fn custom_types_populate_doc_types_and_icons() {
             authorship: Default::default(),
             lifecycle: Default::default(),
             attributes: Default::default(),
+            label_override: None,
         },
     ];
     let store = Store::load(fixture.root(), &config).unwrap();

--- a/tests/integration/tui_graph_test.rs
+++ b/tests/integration/tui_graph_test.rs
@@ -411,6 +411,8 @@ fn custom_types_populate_doc_types_and_icons() {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         },
         TypeDef {
             name: "task".into(),
@@ -429,6 +431,8 @@ fn custom_types_populate_doc_types_and_icons() {
             lifecycle: Default::default(),
             attributes: Default::default(),
             label_override: None,
+            github_issue_tag: None,
+            github_issue_type: None,
         },
     ];
     let store = Store::load(fixture.root(), &config).unwrap();


### PR DESCRIPTION
## Why

Type classification for `github-issues`-store types was label-only: the `lazyspec:{type}` label, or (per STORY-190) a custom `github_label` string. Teams that already classify GitHub issues with native Issue Types or arbitrary tags had no way to express "issues with issue type Feature become stories" (RFC-055).

## What this enables

A `[[types]]` entry can now set `github_issue_tag` and/or `github_issue_type` to classify independently of the `lazyspec:{type}` label, combined with AND when both are set. Two types are allowed to match the same issue: `fetch` dual-materializes one doc per matching type from that single issue, each independently `update`-able (last-write-wins on shared fields). Issue-type discovery adds a GraphQL search path alongside the existing label-filtered `gh issue list`. `create` on a type with `github_issue_type` configured now pushes that type onto the new issue via the existing `push_issue_type` mutation. A type's `github_label` field (STORY-190) also lands, letting a `github-issues`-backed type replace its default `lazyspec:{name}` label with an arbitrary string.

## Related

Implements RFC-055, STORY-190 through STORY-196, ITERATION-263 through ITERATION-267.
