### PR TITLE
feat: scope clickup-tasks types to a custom task type

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
   --icon "◆" --parent-type rfc --intent "throwaway exploration" \
   --authorship generated
 # also accepts --singleton, --store <filesystem|github-issues|github-milestones|github-projects|git-ref|clickup-tasks>,
-# --numbering <incremental|sqids|reserved>
+# --numbering <incremental|sqids|reserved>, --clickup-task-type <id> (clickup-tasks only)
 
 # Replace a type's lifecycle (states + edges; `*` matches any source state)
 lazyspec config set-lifecycle iteration \
@@ -661,6 +661,25 @@ prefix = "TASK"
 store = "clickup-tasks"
 clickup_list_id = "901234567890"
 ```
+
+An optional per-type `clickup_task_type` binds the type to a ClickUp **custom
+task type** by its numeric `custom_item_id`:
+
+```toml
+[[types]]
+name = "bug"
+plural = "bugs"
+dir = "docs/bugs"
+prefix = "BUG"
+store = "clickup-tasks"
+clickup_list_id = "901234567890"
+clickup_task_type = 1001
+```
+
+The value is a numeric id only -- name-to-id resolution is not supported. It is
+valid **only** on `store = "clickup-tasks"`; setting it on any other store is a
+config error. `config add-type ... --clickup-task-type <id>` writes it, and it
+surfaces in `config --json`.
 
 `lazyspec fetch` (optionally `--type <name>`) pulls the bound List's tasks
 (`GET /list/{id}/task`, paginated) using the token from `setup clickup`, and

--- a/docs/iterations/ITERATION-289-clickup-task-type-config-plumbing-and-validation.md
+++ b/docs/iterations/ITERATION-289-clickup-task-type-config-plumbing-and-validation.md
@@ -1,0 +1,52 @@
+---
+title: clickup_task_type config plumbing and validation
+type: iteration
+status: complete
+author: unknown
+date: 2026-07-10
+tags: []
+related:
+- implements: STORY-204
+- blocks: ITERATION-290
+---
+
+## Objective
+
+Add `clickup_task_type` field to `TypeDef`, round-tripping through `.lazyspec.toml` and `config --json`, valid only on `store = clickup-tasks`.
+
+## Satisfies
+
+STORY-204 AC1, AC2 (numeric `custom_item_id` only — name→id resolution deferred), AC5, AC6, and the config-layer part of AC7 (round-trip + validation-error tests). AC3, AC4 deferred — see Out of scope.
+
+## Context
+
+- Story + ACs: STORY-204
+- Design + field semantics (`custom_item_id`, per-type binding): RFC-056 §"Field mapping", §"Config"
+- Precedent to mirror: `github_issue_type` — schema-only `TypeDef` field with store guard (grep `github_issue_type` in `src/engine/config.rs`)
+- Conventions: docs/convention (dictum 5 ecosystem norms, dictum 6 indirection); `--json` on every command (principle 2)
+- Touch: `src/engine/config.rs` (`TypeDef` field + serde + store-mismatch validation, mirror `github_issue_type` guard), config-write CLI mutators / `config add-type` path, README store docs
+
+## Tasks
+
+1. Add `clickup_task_type: Option<i64>` (numeric `custom_item_id`) to `TypeDef`, mirroring `github_issue_type` serde/skip-if-none so it round-trips `.lazyspec.toml` and surfaces in `config --json`.
+2. Add validation: `clickup_task_type` set on any `store != clickup-tasks` errors clearly — mirror the existing store/field guard for `github_issue_type` in config.rs.
+3. Wire the field through the config-write CLI (`config add-type` and relevant mutators) so it can be set/cleared from the CLI.
+4. Test-first: config round-trip (set → `config --json` → reload) and store-mismatch validation error.
+5. Update README store docs with the new field, scoped to `clickup-tasks`.
+
+## Out of scope
+
+- Read filter on `custom_item_id` (AC3) → ITER-02.
+- Create-payload stamping (AC4) → ITER-02.
+- Name→`custom_item_id` API resolution (AC2 stretch) — v1 accepts numeric id only.
+
+## Principles/conventions
+
+- docs/convention dicta (esp. dictum 5 ecosystem norms, dictum 6 no premature indirection).
+- Trait-seam + real-by-default I/O (principle 4) — no new trait needed here; pure config.
+- Layer separation (principle 3): field lives in engine; CLI only formats.
+
+## Verification
+
+`config --json` shows `clickup_task_type` for a `clickup-tasks` type; setting it on a `filesystem` type errors with a clear store-mismatch message.
+

--- a/docs/iterations/ITERATION-290-clickup-tasks-read-filter-and-create-stamping.md
+++ b/docs/iterations/ITERATION-290-clickup-tasks-read-filter-and-create-stamping.md
@@ -1,0 +1,51 @@
+---
+title: clickup-tasks read filter and create stamping
+type: iteration
+status: complete
+author: unknown
+date: 2026-07-10
+tags: []
+related:
+- implements: STORY-204
+---
+
+## Objective
+
+Wire the `clickup_task_type` `custom_item_id` into the ClickUp store's read filter and create payload, so a bound List materializes only matching tasks and new tasks are stamped with the type.
+
+## Satisfies
+
+STORY-204 AC3, AC4, AC8 (parity: fully wired end to end), and the store-layer part of AC7 (read-filter match+skip + create-stamping tests). Blocked by ITERATION-289 (needs the `clickup_task_type` config field).
+
+## Context
+
+- Story + ACs: STORY-204
+- Design (`custom_item_id` read shape, create payload, custom-field applicability): RFC-056 §"Field mapping"
+- Config field landed in ITERATION-289 (`TypeDef.clickup_task_type: Option<i64>`)
+- `custom_item_id` read site: `src/engine/clickup.rs:239`
+- Test seam: `ClickupClient` fake impl (per RFC-056 — mirror `GhCli` fake split)
+- Conventions: docs/convention (principle 4 fakes at trait seams, principle 3 layering)
+- Touch: `src/engine/clickup.rs` (read filter near `:239`, `task_create` payload), `ClickupTasksStore`
+
+## Tasks
+
+1. Test-first: with a fake `ClickupClient`, assert read filter keeps tasks whose `custom_item_id` matches the type's `clickup_task_type` and skips non-matching, and that create sends the asserted `custom_item_id`.
+2. Read filter: when `clickup_task_type` is set, drop tasks whose `custom_item_id` differs during `task_list`/sync; when unset, materialize all (no behavior change).
+3. Create stamping: when `clickup_task_type` is set, include `custom_item_id` in the `task_create` POST body.
+4. Confirm TUI/web/CLI stay consistent (project rule) — no new surface, field is engine-resolved; note any view touch needed.
+
+## Out of scope
+
+- Retagging or migrating existing ClickUp tasks (STORY-204 Non-Goal).
+- Name→`custom_item_id` resolution (numeric only, per ITERATION-289 decision).
+- Any `github_issue_type` behavior change (Non-Goal).
+
+## Principles/conventions
+
+- docs/convention dicta; principle 4 (fake only at the `ClickupClient` seam, real impl by default).
+- Layer separation (principle 3): filter/stamping live in engine; no CLI/TUI logic duplication.
+
+## Verification
+
+Read: a bound List with mixed `custom_item_id` values materializes only the matching subset. Create: a new task POST carries the asserted `custom_item_id`; with the field unset, read/create behavior is unchanged.
+

--- a/docs/stories/STORY-204-assert-clickup-custom-task-type-on-clickup-tasks-types.md
+++ b/docs/stories/STORY-204-assert-clickup-custom-task-type-on-clickup-tasks-types.md
@@ -1,0 +1,34 @@
+---
+title: Assert ClickUp custom task type on clickup-tasks types
+type: story
+status: in-progress
+author: unknown
+date: 2026-07-10
+tags: []
+related:
+- implements: RFC-056
+---
+
+## Context
+
+`clickup-tasks` document types bind to a ClickUp List but cannot constrain *which* ClickUp custom task type their tasks are. `github-issues` types already carry a `github_issue_type` field for this classification (schema-only today, per RFC-056 / config.rs). ClickUp exposes the custom task type as the task's `custom_item_id` (integer) on read (`src/engine/clickup.rs:239`), but there is no config binding, no read filter, and no create-payload field for it. This story adds a fully-wired equivalent.
+
+## User Story
+
+As a lazyspec user binding a document type to a ClickUp List, I want to assert a specific ClickUp custom task type for that type, so that the List materializes only tasks of that type and new tasks are created with it.
+
+## Acceptance Criteria
+
+- `TypeDef` gains a `clickup_task_type` field that round-trips through `.lazyspec.toml` and appears in `config --json`.
+- The field is resolved to ClickUp's numeric `custom_item_id` (accept a numeric id directly; name-to-id resolution via the ClickUp API is a stretch decision to nail down at iteration time).
+- Read filter: a `clickup-tasks` type with `clickup_task_type` set materializes only tasks whose `custom_item_id` matches; non-matching tasks in the bound List are skipped during sync/`task_list`.
+- Write on create: `create` sends the asserted `custom_item_id` in the `TaskCreate` POST body, so new ClickUp tasks are stamped with the type.
+- Validation: `clickup_task_type` is only valid on `store = clickup-tasks`; any other store errors clearly (mirror the existing store/field guards in config.rs).
+- Config CLI (`config add-type` and relevant mutators) accepts the new field; README store docs updated.
+- Tests cover: config round-trip, read filter (match + skip), create-payload stamping, and the store-mismatch validation error.
+- Parity note: unlike `github_issue_type` (schema-only), this field is fully wired end to end. TUI, web view, and CLI stay consistent per project rule.
+
+## Non-Goals
+
+- Retagging or migrating existing ClickUp tasks.
+- Changing `github_issue_type` behavior.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -46,6 +46,9 @@ pub enum ConfigCommand {
         /// Authorship ceiling: human, assisted, or generated
         #[arg(long)]
         authorship: Option<String>,
+        /// ClickUp custom task type (numeric custom_item_id); only valid on store = clickup-tasks
+        #[arg(long)]
+        clickup_task_type: Option<i64>,
     },
     /// Replace a type's lifecycle states and edges
     SetLifecycle {
@@ -87,6 +90,7 @@ pub fn run_add_type(
     numbering: Option<&str>,
     intent: Option<&str>,
     authorship: Option<&str>,
+    clickup_task_type: Option<i64>,
 ) -> Result<()> {
     let path = root.join(".lazyspec.toml");
     let src = fs.read_to_string(&path)?;
@@ -122,6 +126,7 @@ pub fn run_add_type(
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type,
         clickup_custom_field_map: None,
     });
 
@@ -394,6 +399,7 @@ require_parent_status = "accepted"
             None,
             Some("throwaway exploration"),
             Some("generated"),
+            None,
         )
         .unwrap();
 
@@ -414,6 +420,34 @@ require_parent_status = "accepted"
         assert_eq!(first, second);
     }
 
+    // A clickup_task_type supplied to add-type is written for a clickup-tasks type
+    // and surfaces in `config --json` as a number after a reload.
+    #[test]
+    fn add_type_writes_clickup_task_type() {
+        let (_dir, path, fs) = fixture(SRC);
+        run_add_type(
+            path.parent().unwrap(),
+            &fs,
+            "task",
+            "tasks",
+            "docs/tasks",
+            "TASK",
+            None,
+            None,
+            false,
+            Some("clickup-tasks"),
+            None,
+            None,
+            None,
+            Some(1001),
+        )
+        .unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let json = show(&after);
+        assert_eq!(type_named(&json, "task")["clickup_task_type"], 1001);
+    }
+
     #[test]
     fn add_type_rejects_duplicate_without_writing() {
         let (_dir, path, fs) = fixture(SRC);
@@ -428,6 +462,7 @@ require_parent_status = "accepted"
             None,
             None,
             false,
+            None,
             None,
             None,
             None,
@@ -531,6 +566,7 @@ require_parent_status = "accepted"
             None,
             None,
             false,
+            None,
             None,
             None,
             None,

--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -570,6 +570,7 @@ name = "related-to"
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/cli/fix/relations.rs
+++ b/src/cli/fix/relations.rs
@@ -164,6 +164,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
         let mut config = Config::default();

--- a/src/cli/lease.rs
+++ b/src/cli/lease.rs
@@ -380,6 +380,7 @@ mod tests {
                         github_issue_tag: None,
                         github_issue_type: None,
                         clickup_list_id: None,
+                        clickup_task_type: None,
                         clickup_custom_field_map: None,
                     },
                     TypeDef {
@@ -402,6 +403,7 @@ mod tests {
                         github_issue_tag: None,
                         github_issue_type: None,
                         clickup_list_id: None,
+                        clickup_task_type: None,
                         clickup_custom_field_map: None,
                     },
                     TypeDef {
@@ -424,6 +426,7 @@ mod tests {
                         github_issue_tag: None,
                         github_issue_type: None,
                         clickup_list_id: None,
+                        clickup_task_type: None,
                         clickup_custom_field_map: None,
                     },
                 ],

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -775,6 +775,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
         let mut config = Config::default();
@@ -1405,6 +1406,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
         let mut config = Config::default();
@@ -1768,6 +1770,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
         let story_type = TypeDef {
@@ -1790,6 +1793,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
 
@@ -2304,6 +2308,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
         let story_type = TypeDef {
@@ -2326,6 +2331,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
 

--- a/src/engine/clickup.rs
+++ b/src/engine/clickup.rs
@@ -312,6 +312,12 @@ pub struct TaskCreate {
     pub start_date: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_estimate: Option<i64>,
+    /// The ClickUp custom task type's `custom_item_id`, stamped from the bound
+    /// type's `clickup_task_type` config so a new task materializes under that
+    /// type (RFC-056 §Field mapping). Omitted when unset, so ClickUp defaults the
+    /// task to the List's native "Task" type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_item_id: Option<i64>,
 }
 
 /// The *write* shape of an edit, sent as the JSON body of `PUT /task/{id}`.
@@ -1257,6 +1263,7 @@ mod tests {
             due_date: Some(1_748_541_600_000),
             start_date: None,
             time_estimate: Some(3_600_000),
+            custom_item_id: None,
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert_eq!(json["name"], "Wire create");
@@ -1267,6 +1274,31 @@ mod tests {
         assert_eq!(json["time_estimate"], 3_600_000i64);
         // A `None` field is omitted entirely, not sent as JSON null.
         assert!(json.get("start_date").is_none());
+    }
+
+    #[test]
+    fn task_create_serializes_custom_item_id_when_set() {
+        // A type-stamped create carries the ClickUp custom_item_id so the new task
+        // materializes under the bound List's configured task type (RFC-056).
+        let payload = TaskCreate {
+            name: "Wire create".to_string(),
+            custom_item_id: Some(1001),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["custom_item_id"], 1001i64);
+    }
+
+    #[test]
+    fn task_create_omits_custom_item_id_when_unset() {
+        // No configured task type: the field is omitted, so ClickUp defaults the
+        // new task to the List's native "Task" type (no behavior change).
+        let payload = TaskCreate {
+            name: "Wire create".to_string(),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json.get("custom_item_id").is_none());
     }
 
     #[test]

--- a/src/engine/clickup_cache.rs
+++ b/src/engine/clickup_cache.rs
@@ -53,6 +53,17 @@ pub fn fetch_tasks(
         .task_list(token, list_id)
         .with_context(|| format!("fetching ClickUp tasks for list {}", list_id))?;
 
+    // When the type binds a custom task type, materialize only tasks of that type:
+    // a List can hold several task types, but a lazyspec type maps to exactly one.
+    // Unset means the type spans the whole List, so every task materializes.
+    let tasks: Vec<ClickupTask> = match type_def.clickup_task_type {
+        Some(expected) => tasks
+            .into_iter()
+            .filter(|task| task.custom_item_id == Some(expected))
+            .collect(),
+        None => tasks,
+    };
+
     let cache_dir = root.join(".lazyspec/cache").join(&type_def.name);
     let previously_cached: HashSet<String> = list_cached_ids(&cache_dir);
 
@@ -336,15 +347,20 @@ fn json_value_to_attr(value: &serde_json::Value) -> Option<AttrValue> {
 /// - `priority` <- the priority *name* mapped to ClickUp's bare integer
 ///   (`urgent=1 high=2 normal=3 low=4`); an unrecognized name is dropped;
 /// - `due_date`/`time_estimate` <- the integer epoch-ms / duration-ms attributes.
+/// - `custom_item_id` <- `task_type` (the type's configured `clickup_task_type`),
+///   omitted when `None` so ClickUp defaults the task to the List's native "Task"
+///   type; set, it stamps the new task with the bound custom task type (RFC-056).
 ///
 /// A `create` has no attributes yet (its signature carries only title/author/
-/// body), so it passes an empty map and only `name`/`markdown_content` are sent;
-/// the attribute mapping is exercised by the write path directly.
+/// body), so it passes an empty map and only `name`/`markdown_content` (plus the
+/// stamped `custom_item_id`, when set) are sent; the attribute mapping is
+/// exercised by the write path directly.
 pub(crate) fn build_task_create(
     title: &str,
     body: &str,
     status: Option<&str>,
     attributes: &std::collections::BTreeMap<String, AttrValue>,
+    task_type: Option<i64>,
 ) -> TaskCreate {
     let priority = match attributes.get("priority") {
         Some(AttrValue::Str(name)) => priority_name_to_int(name),
@@ -371,6 +387,7 @@ pub(crate) fn build_task_create(
         due_date,
         start_date: None,
         time_estimate,
+        custom_item_id: task_type,
     }
 }
 
@@ -548,6 +565,71 @@ mod tests {
     }
 
     #[test]
+    fn fetch_keeps_only_tasks_matching_configured_task_type() {
+        // A type bound to custom_item_id 1001 materializes only the tasks whose
+        // custom_item_id matches; a task of another type drops out of the cache.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let mut td = clickup_type();
+        td.clickup_task_type = Some(1001);
+
+        let matching = task_from_json(
+            r#"{"id":"a","name":"A","status":{"status":"open"},"custom_item_id":1001}"#,
+        );
+        let other = task_from_json(
+            r#"{"id":"b","name":"B","status":{"status":"open"},"custom_item_id":2002}"#,
+        );
+        let client = FakeClickupClient::with_tasks(vec![matching, other]);
+        let mut task_map = TaskMap::load(root).unwrap();
+
+        let result = fetch_tasks(root, &td, &client, "pk_x", &mut task_map).unwrap();
+
+        assert_eq!(result.fetched, 1);
+        assert_eq!(result.new, 1);
+        assert!(root.join(".lazyspec/cache/task/TASK-a.md").exists());
+        assert!(!root.join(".lazyspec/cache/task/TASK-b.md").exists());
+        assert!(task_map.get("TASK-a").is_some());
+        assert!(task_map.get("TASK-b").is_none());
+    }
+
+    #[test]
+    fn fetch_without_task_type_materializes_all_tasks() {
+        // Field unset: every task materializes regardless of custom_item_id (no
+        // behavior change from before task-type filtering existed).
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let td = clickup_type();
+        assert!(td.clickup_task_type.is_none());
+
+        let t1 = task_from_json(
+            r#"{"id":"a","name":"A","status":{"status":"open"},"custom_item_id":1001}"#,
+        );
+        let t2 = task_from_json(
+            r#"{"id":"b","name":"B","status":{"status":"open"},"custom_item_id":2002}"#,
+        );
+        let client = FakeClickupClient::with_tasks(vec![t1, t2]);
+        let mut task_map = TaskMap::load(root).unwrap();
+
+        let result = fetch_tasks(root, &td, &client, "pk_x", &mut task_map).unwrap();
+
+        assert_eq!(result.fetched, 2);
+        assert!(root.join(".lazyspec/cache/task/TASK-a.md").exists());
+        assert!(root.join(".lazyspec/cache/task/TASK-b.md").exists());
+    }
+
+    #[test]
+    fn build_task_create_stamps_custom_item_id_when_task_type_set() {
+        let payload = build_task_create("t", "b", None, &Default::default(), Some(1001));
+        assert_eq!(payload.custom_item_id, Some(1001));
+    }
+
+    #[test]
+    fn build_task_create_omits_custom_item_id_when_task_type_unset() {
+        let payload = build_task_create("t", "b", None, &Default::default(), None);
+        assert_eq!(payload.custom_item_id, None);
+    }
+
+    #[test]
     fn body_falls_back_to_text_content_when_markdown_empty() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
@@ -687,7 +769,7 @@ mod tests {
     #[test]
     fn build_task_create_maps_title_and_body_only_for_a_bare_create() {
         // A create carries no attributes and no status; only name + body are sent.
-        let payload = build_task_create("My task", "the body", None, &Default::default());
+        let payload = build_task_create("My task", "the body", None, &Default::default(), None);
         assert_eq!(payload.name, "My task");
         assert_eq!(payload.markdown_content, Some("the body".to_string()));
         assert_eq!(payload.status, None);
@@ -698,7 +780,7 @@ mod tests {
 
     #[test]
     fn build_task_create_omits_markdown_content_when_body_blank() {
-        let payload = build_task_create("t", "   ", None, &Default::default());
+        let payload = build_task_create("t", "   ", None, &Default::default(), None);
         assert_eq!(payload.markdown_content, None);
     }
 
@@ -711,7 +793,7 @@ mod tests {
         attrs.insert("due".to_string(), AttrValue::Int(1_748_541_600_000));
         attrs.insert("estimate".to_string(), AttrValue::Int(3_600_000));
 
-        let payload = build_task_create("t", "b", Some("in progress"), &attrs);
+        let payload = build_task_create("t", "b", Some("in progress"), &attrs, None);
         assert_eq!(payload.status, Some("in progress".to_string()));
         assert_eq!(payload.priority, Some(2));
         assert_eq!(payload.due_date, Some(1_748_541_600_000));
@@ -785,7 +867,7 @@ mod tests {
     fn build_task_create_drops_unrecognized_priority_name() {
         let mut attrs = std::collections::BTreeMap::new();
         attrs.insert("priority".to_string(), AttrValue::Str("bogus".to_string()));
-        let payload = build_task_create("t", "b", None, &attrs);
+        let payload = build_task_create("t", "b", None, &attrs, None);
         assert_eq!(payload.priority, None);
     }
 

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -286,6 +286,12 @@ pub struct TypeDef {
     /// other stores.
     #[serde(default)]
     pub clickup_list_id: Option<String>,
+    /// The ClickUp custom task type (`custom_item_id`) stamped on this type's
+    /// tasks, for `clickup-tasks`-backed types. A numeric id only -- name->id
+    /// resolution is deferred. Setting it on any other store is a config error.
+    /// Unused by other stores.
+    #[serde(default)]
+    pub clickup_task_type: Option<i64>,
     /// Maps a lazyspec name to the ClickUp custom-field uuid that holds it, for
     /// anything with no native ClickUp field (RFC-056 §Field mapping). The
     /// reserved key [`CLICKUP_RELATIONS_FIELD`] names the *text* field carrying
@@ -685,6 +691,7 @@ pub fn starter_types() -> Vec<TypeDef> {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     };
     vec![
@@ -719,6 +726,7 @@ pub fn starter_types() -> Vec<TypeDef> {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         },
         TypeDef {
@@ -741,6 +749,7 @@ pub fn starter_types() -> Vec<TypeDef> {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         },
     ]
@@ -912,6 +921,17 @@ impl Config {
         });
         if any_github && raw.github.is_none() {
             bail!("store = \"github-issues\", \"github-milestones\", or \"github-projects\" requires a [github] section");
+        }
+
+        if let Some(t) = types
+            .iter()
+            .find(|t| t.clickup_task_type.is_some() && t.store != StoreBackend::ClickupTasks)
+        {
+            bail!(
+                "type \"{}\" sets clickup_task_type but store = \"{}\"; clickup_task_type is only valid on store = \"clickup-tasks\"",
+                t.name,
+                t.store
+            );
         }
 
         let ref_count_ceiling = raw.ref_count_ceiling.unwrap_or(15);
@@ -1102,6 +1122,7 @@ impl TypeDef {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }
@@ -2257,6 +2278,63 @@ owner = "uuid-owner"
         let config = Config::parse(TYPES).unwrap();
         let td = config.type_by_name("rfc").unwrap();
         assert!(td.clickup_custom_field_map.is_none());
+    }
+
+    #[test]
+    fn toml_clickup_task_type_parses_and_round_trips() {
+        let toml_str = format!(
+            "{TYPES}{}",
+            r#"
+[[types]]
+name = "task"
+plural = "tasks"
+dir = "docs/tasks"
+prefix = "TASK"
+store = "clickup-tasks"
+clickup_list_id = "list123"
+clickup_task_type = 1001
+"#
+        );
+        let config = Config::parse(&toml_str).unwrap();
+        let td = config.type_by_name("task").unwrap();
+        assert_eq!(td.clickup_task_type, Some(1001));
+
+        // Survives the config_write round-trip (to_toml -> parse) and surfaces
+        // in `config --json`.
+        let emitted = config.to_toml().unwrap();
+        let reparsed = Config::parse(&emitted).unwrap();
+        let td = reparsed.type_by_name("task").unwrap();
+        assert_eq!(td.clickup_task_type, Some(1001));
+        let json = serde_json::to_value(td).unwrap();
+        assert_eq!(json["clickup_task_type"], serde_json::json!(1001));
+    }
+
+    #[test]
+    fn toml_without_clickup_task_type_leaves_it_none() {
+        let config = Config::parse(TYPES).unwrap();
+        let td = config.type_by_name("rfc").unwrap();
+        assert_eq!(td.clickup_task_type, None);
+        let json = serde_json::to_value(td).unwrap();
+        assert_eq!(json["clickup_task_type"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn clickup_task_type_on_non_clickup_store_is_rejected() {
+        let toml_str = format!(
+            "{TYPES}{}",
+            r#"
+[[types]]
+name = "task"
+plural = "tasks"
+dir = "docs/tasks"
+prefix = "TASK"
+clickup_task_type = 1001
+"#
+        );
+        let err = Config::parse(&toml_str).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("clickup_task_type"), "got: {msg}");
+        assert!(msg.contains("clickup-tasks"), "got: {msg}");
     }
 
     #[test]

--- a/src/engine/config_write.rs
+++ b/src/engine/config_write.rs
@@ -93,6 +93,7 @@ fn update_type_table(entry: &mut Table, def: &TypeDef) {
         authorship_str(&def.authorship),
         "assisted",
     );
+    set_opt_int(entry, "clickup_task_type", def.clickup_task_type);
     set_lifecycle(entry, &def.lifecycle);
 }
 
@@ -593,6 +594,16 @@ fn set_int_defaulted(table: &mut dyn toml_edit::TableLike, key: &str, value: i64
     set_int(table, key, value);
 }
 
+// An `Option<i64>` field: Some writes/updates the key, None removes a present key.
+fn set_opt_int(table: &mut dyn toml_edit::TableLike, key: &str, value: Option<i64>) {
+    match value {
+        Some(v) => set_int(table, key, v),
+        None => {
+            table.remove(key);
+        }
+    }
+}
+
 // An `Option<String>` field: Some writes/updates the key (adding it within an
 // existing table is allowed), None removes a present key.
 fn set_opt_str(table: &mut dyn toml_edit::TableLike, key: &str, value: Option<&str>) {
@@ -983,6 +994,7 @@ require_parent_status = "accepted"
                 github_issue_tag: None,
                 github_issue_type: None,
                 clickup_list_id: None,
+                clickup_task_type: None,
                 clickup_custom_field_map: None,
             });
             c
@@ -1075,6 +1087,7 @@ name = "related-to"
                 github_issue_tag: None,
                 github_issue_type: None,
                 clickup_list_id: None,
+                clickup_task_type: None,
                 clickup_custom_field_map: None,
             });
             c.rules.clear();

--- a/src/engine/document.rs
+++ b/src/engine/document.rs
@@ -848,6 +848,7 @@ Body.
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/engine/git_ref_store.rs
+++ b/src/engine/git_ref_store.rs
@@ -373,6 +373,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -810,6 +810,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }
@@ -838,6 +839,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/engine/milestone_cache.rs
+++ b/src/engine/milestone_cache.rs
@@ -109,6 +109,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -727,6 +727,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
 
@@ -826,6 +827,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
 

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -186,8 +186,15 @@ impl DocumentStore for ClickupTasksStore {
         })?;
 
         // A create carries no attributes or status yet, so only name + body are
-        // sent; ClickUp assigns the List's default status.
-        let payload = clickup_cache::build_task_create(title, body, None, &BTreeMap::new());
+        // sent; ClickUp assigns the List's default status. The type's configured
+        // task type (if any) stamps the new task's custom_item_id.
+        let payload = clickup_cache::build_task_create(
+            title,
+            body,
+            None,
+            &BTreeMap::new(),
+            type_def.clickup_task_type,
+        );
         let task = self.client.create_task(token.expose(), list_id, &payload)?;
 
         let id = type_def.make_id(&task.id);
@@ -2481,6 +2488,62 @@ mod tests {
         assert_eq!(recorded[0].1.markdown_content, Some("the body".to_string()));
         // A create sends no status; ClickUp assigns the List default.
         assert_eq!(recorded[0].1.status, None);
+    }
+
+    #[test]
+    fn clickup_create_stamps_configured_task_type_into_payload() {
+        use crate::engine::clickup::FakeClickupClient;
+        use crate::engine::credentials::Token;
+
+        let root = tmp_root("clickup_create_task_type");
+        let mut td = clickup_type_def(Some("list123"));
+        td.clickup_task_type = Some(1001);
+
+        let created = scripted_task(
+            r#"{"id":"90abc","name":"My task","status":{"status":"open"},"custom_item_id":1001}"#,
+        );
+        let fake = FakeClickupClient::valid(clickup_user()).with_created_task(created);
+        let calls = fake.create_calls();
+
+        let mut store = ClickupTasksStore {
+            client: Box::new(fake),
+            root,
+            config: Config::default(),
+            token: Some(Token::new("pk_x")),
+        };
+
+        store.create(&td, "My task", "author", "body").unwrap();
+
+        let recorded = calls.borrow();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].1.custom_item_id, Some(1001));
+    }
+
+    #[test]
+    fn clickup_create_without_task_type_omits_custom_item_id() {
+        use crate::engine::clickup::FakeClickupClient;
+        use crate::engine::credentials::Token;
+
+        let root = tmp_root("clickup_create_no_task_type");
+        let td = clickup_type_def(Some("list123"));
+        assert!(td.clickup_task_type.is_none());
+
+        let created =
+            scripted_task(r#"{"id":"90abc","name":"My task","status":{"status":"open"}}"#);
+        let fake = FakeClickupClient::valid(clickup_user()).with_created_task(created);
+        let calls = fake.create_calls();
+
+        let mut store = ClickupTasksStore {
+            client: Box::new(fake),
+            root,
+            config: Config::default(),
+            token: Some(Token::new("pk_x")),
+        };
+
+        store.create(&td, "My task", "author", "body").unwrap();
+
+        let recorded = calls.borrow();
+        assert_eq!(recorded[0].1.custom_item_id, None);
     }
 
     #[test]

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -2353,6 +2353,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }
@@ -3256,6 +3257,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         };
 

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -546,6 +546,7 @@ mod tests {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,7 @@ fn main() -> anyhow::Result<()> {
                     numbering,
                     intent,
                     authorship,
+                    clickup_task_type,
                 }) => {
                     lazyspec::cli::config::run_add_type(
                         &cwd,
@@ -481,6 +482,7 @@ fn main() -> anyhow::Result<()> {
                         numbering.as_deref(),
                         intent.as_deref(),
                         authorship.as_deref(),
+                        clickup_task_type,
                     )?;
                 }
                 Some(ConfigCommand::SetLifecycle {

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -2648,6 +2648,7 @@ impl App {
                     github_issue_tag: None,
                     github_issue_type: None,
                     clickup_list_id: None,
+                    clickup_task_type: None,
                     clickup_custom_field_map: None,
                 });
                 self.settings_entry = self.settings_buffer.documents.types.len() - 1;

--- a/tests/integration/cli_child_test.rs
+++ b/tests/integration/cli_child_test.rs
@@ -182,6 +182,7 @@ fn create_with_parent_cross_store_rejected_before_mutation() {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     };
     config.documents.types.push(issue_type);

--- a/tests/integration/cli_convention_test.rs
+++ b/tests/integration/cli_convention_test.rs
@@ -28,6 +28,7 @@ fn convention_config(fixture: &TestFixture) -> Config {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     });
     config.documents.types.push(TypeDef {
@@ -50,6 +51,7 @@ fn convention_config(fixture: &TestFixture) -> Config {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     });
     config

--- a/tests/integration/cli_create_test.rs
+++ b/tests/integration/cli_create_test.rs
@@ -29,6 +29,7 @@ fn milestones_only_config() -> Config {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }];
     config.documents.github = None;
@@ -56,6 +57,7 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }
 }

--- a/tests/integration/cli_mutate_test.rs
+++ b/tests/integration/cli_mutate_test.rs
@@ -33,6 +33,7 @@ fn milestones_fixture() -> (TestFixture, Config) {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }];
     config.documents.github = None;

--- a/tests/integration/cli_validate_test.rs
+++ b/tests/integration/cli_validate_test.rs
@@ -303,6 +303,7 @@ fn singleton_type(name: &str, dir: &str, prefix: &str) -> TypeDef {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }
 }
@@ -328,6 +329,7 @@ fn child_type(name: &str, dir: &str, prefix: &str, parent: &str) -> TypeDef {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }
 }
@@ -490,6 +492,7 @@ fn parent_type_references_non_singleton_error() {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     };
     let config = config_with_extra_types(vec![

--- a/tests/integration/fetch_milestone_relation_test.rs
+++ b/tests/integration/fetch_milestone_relation_test.rs
@@ -171,6 +171,7 @@ fn ticket_type() -> TypeDef {
         github_issue_tag: None,
         github_issue_type: None,
         clickup_list_id: None,
+        clickup_task_type: None,
         clickup_custom_field_map: None,
     }
 }

--- a/tests/integration/tui_graph_test.rs
+++ b/tests/integration/tui_graph_test.rs
@@ -414,6 +414,7 @@ fn custom_types_populate_doc_types_and_icons() {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         },
         TypeDef {
@@ -436,6 +437,7 @@ fn custom_types_populate_doc_types_and_icons() {
             github_issue_tag: None,
             github_issue_type: None,
             clickup_list_id: None,
+            clickup_task_type: None,
             clickup_custom_field_map: None,
         },
     ];


### PR DESCRIPTION
## Why

`clickup-tasks` typed docs mapped to a ClickUp list had no way to scope themselves to one custom task type (`custom_item_id`) within that list — every list-bound document type saw and created every task in the list regardless of ClickUp's own type distinction (RFC-056).

## What this enables

A `[[types]]` entry can now set `clickup_task_type` (numeric `custom_item_id`) alongside `store = "clickup-tasks"`. Reads filter fetched tasks to that type; creates stamp the field into the `task_create` body. Types without the field behave exactly as before (no filter, no stamp). Config validation rejects `clickup_task_type` on any other store, and it round-trips through `.lazyspec.toml` and `config --json`.

## Related

Implements STORY-204 (RFC-056) via ITERATION-289 and ITERATION-290.
