### PR TITLE
feat: interactive config wizard, spinners, and mascot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3033,7 @@ dependencies = [
  "console",
  "crossbeam-channel",
  "crossterm 0.28.1",
+ "dialoguer",
  "dirs",
  "http",
  "image",
@@ -5305,6 +5319,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ http = { version = "1", optional = true }
 dirs = { version = "6", optional = true }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls"] }
 keyring = { version = "4.1.4", features = ["apple-native-keyring-store"] }
+dialoguer = "0.11"
 
 [build-dependencies]
 tauri-build = { version = "2", optional = true }

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Every mutation's `--json` output also reports whether the change reached the doc
 | `skills install [--runtime <claude\|agents-md>]`                | Install the embedded agent skill set into the project (both runtimes by default)                |
 | `config [--json]`                                               | Print the resolved `.lazyspec.toml` as JSON                                                     |
 | `config schema`                                                 | Print a JSON Schema for `.lazyspec.toml` (runs from any directory)                              |
-| `config add-type <name> <plural> <dir> <prefix>`                | Append a new document type to `.lazyspec.toml` (bare, on a TTY, prompts for the core fields)     |
+| `config add-type <name> <plural> <dir> <prefix>`                | Append a new document type to `.lazyspec.toml` (bare, on a TTY, runs the interactive wizard) |
 | `config set-lifecycle <type> [--state X] [--edge from:to]`      | Replace a type's lifecycle states and edges                                                     |
 | `config add-gate <rule> --status X`                             | Set the `require_parent_status` gate on a parent-child rule                                     |
 | `provenance add <id> <citation>`                                | Append a citation to a document's provenance list                                               |
@@ -519,10 +519,17 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
   --icon "◆" --parent-type rfc --intent "throwaway exploration" \
   --authorship generated
 
-# With no positionals on a TTY, add-type prompts for the core fields
-# interactively (name, plural, dir, prefix, icon, store, numbering, singleton,
-# authorship). Flags, --json, and non-TTY invocations stay the canonical
-# scriptable path and still require all four positionals.
+# With no positionals on a TTY, add-type prompts interactively. After the core
+# fields (name, plural, dir, prefix, icon, store, numbering, singleton,
+# authorship) it optionally walks through: attributes (repeat until declined; a
+# malformed or duplicate spec re-asks in place), a parent type (chosen only from
+# already-defined types), a custom lifecycle (states then FROM:TO edges, where an
+# edge naming an unknown state re-asks; decline to inherit the store preset), and
+# a gate on an existing parent-child rule (the status must be one the parent
+# type's lifecycle carries). The wizard drives the same add-type / set-lifecycle
+# / add-gate writers as the flags, so it produces an identical .lazyspec.toml.
+# Flags, --json, and non-TTY invocations stay the canonical scriptable path and
+# still require all four positionals.
 lazyspec config add-type
 # also accepts --singleton, --store <filesystem|github-issues|github-milestones|github-projects|git-ref|clickup-tasks>,
 # --numbering <incremental|sqids|reserved>, --clickup-task-type <id> (clickup-tasks only)

--- a/README.md
+++ b/README.md
@@ -545,9 +545,9 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
 # comma-separated line, then FROM:TO edges, where an edge naming an unknown state
 # re-asks; decline to inherit the store preset), and a gate on an existing
 # parent-child rule (the status must be one the parent type's lifecycle carries).
-# Single-choice prompts (store, numbering, authorship, ...) render a numbered
-# list -- pick by number or exact name; an out-of-list answer is rejected and
-# re-asked. The wizard drives the same add-type / set-lifecycle
+# Single-choice prompts (store, numbering, authorship, ...) are coloured
+# arrow-key menus -- move the highlight with up/down, Enter picks it, no typing
+# required. The wizard drives the same add-type / set-lifecycle
 # / add-gate writers as the flags, so it produces an identical .lazyspec.toml.
 # Flags, --json, and non-TTY invocations stay the canonical scriptable path and
 # still require all four positionals.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Every mutation's `--json` output also reports whether the change reached the doc
 
 | Command                                                         | Description                                                                                     |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `init`                                                          | Initialise lazyspec in the current project                                                      |
+| `init [--non-interactive] [--json]`                             | Initialise lazyspec in the current project. Runs an interactive starter-config wizard on a TTY; `--non-interactive`/`--json`/non-TTY write the starter config unchanged |
 | `create <type> <title> [--author X] [--parent ID] [--body / --body-file]` | Create a document (rfc, adr, story, iteration); seed body inline, from a file, or `-` for stdin. `--parent <ID>` makes the new doc a child of an existing doc; the child must be the same store as its parent. For filesystem-store types the child is authored as a sibling `.md` inside the parent's subdir (promoting a flat parent to `TYPE-n-slug/index.md` on the first child). For `github-issues`-store types the child is created as a real GitHub issue and bound as a native sub-issue of the parent at create time; a later `fetch` mirrors them into the nested cache layout (`.lazyspec/cache/<type>/<PARENT>/index.md` + `NN-<child>.md`) |
 | `list [type] [--status X]`                                      | List documents with optional filters; each list card shows the assignee (as `@name`) when one is set, and nothing when unset |
 | `show <id> [-e] [--open]`                                       | Display a document by path or shorthand ID (e.g. `RFC-001`); `--open` opens it in a browser or viewer instead. The detail header adds an `Assignee:` line when the document has one (omitted when unset), mirroring the `Tags:` line. The `--json` output includes an `assignee` field (a string, or `null` when unset) alongside `status`/`tags`; `status --json` reports it for every document too |
@@ -452,7 +452,12 @@ Unresolvable refs render as:
 <summary><h2>Configuration</h2></summary>
 
 `lazyspec init` creates a `.lazyspec.toml` in your project root with a starter set
-of document types, relationships, and validation rules. The engine carries no
+of document types, relationships, and validation rules. On a TTY it runs an
+interactive wizard first, letting you tweak the starter config -- set the naming
+pattern, keep or drop each starter type, and add new types -- before it scaffolds
+the project. Pass `--non-interactive` (or `--json`, which implies it), or run in a
+non-TTY context (a pipe or CI), to skip the wizard and write the starter config
+unchanged. The engine carries no
 built-in document types or relationship vocabulary: the `[[types]]`,
 `[[relationships]]`, and `[[rules]]` declared in `.lazyspec.toml` are the sole
 source of truth. A missing `.lazyspec.toml`, or a config with no `[[types]]`, is a

--- a/README.md
+++ b/README.md
@@ -539,7 +539,10 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
 
 # With no positionals on a TTY, add-type prompts interactively. After the core
 # fields (name, plural, dir, prefix, icon, store, numbering, singleton,
-# authorship) it optionally walks through: attributes (repeat until declined; a
+# authorship) -- where choosing store = github-issues additionally prompts for
+# the GitHub issue tag/label and issue type, and store = clickup-tasks for the
+# ClickUp list id and task type (other stores prompt for neither) -- it
+# optionally walks through: attributes (repeat until declined; a
 # malformed or duplicate spec re-asks in place), a parent type (chosen only from
 # already-defined types), a custom lifecycle (enter the states as one
 # comma-separated line, then FROM:TO edges, where an edge naming an unknown state
@@ -553,7 +556,8 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
 # still require all four positionals.
 lazyspec config add-type
 # also accepts --singleton, --store <filesystem|github-issues|github-milestones|github-projects|git-ref|clickup-tasks>,
-# --numbering <incremental|sqids|reserved>, --clickup-task-type <id> (clickup-tasks only)
+# --numbering <incremental|sqids|reserved>, --github-issue-tag <str> / --github-issue-type <str>
+# (github-issues only), and --clickup-list-id <str> / --clickup-task-type <id> (clickup-tasks only)
 
 # Declare custom frontmatter attributes with the type (repeat --attribute per
 # attribute; spec is NAME:KIND[:required][:VAL1,VAL2,...], kinds: int, float,
@@ -628,6 +632,10 @@ github_issue_type = "Feature"
   Issue Type equals that value; the label is not checked.
 - Both set: an issue must carry the tag **and** have the native issue type --
   AND, not OR.
+
+`config add-type ... --github-issue-tag <str>` and `--github-issue-type <str>`
+write these keys (both valid **only** on `store = "github-issues"`), and they
+surface in `config --json`.
 
 Because these are independent per-type rules, two types may legitimately
 match the same issue (e.g. both set `github_issue_type = "Feature"`). `fetch`
@@ -747,8 +755,9 @@ clickup_task_type = 1001
 
 The value is a numeric id only -- name-to-id resolution is not supported. It is
 valid **only** on `store = "clickup-tasks"`; setting it on any other store is a
-config error. `config add-type ... --clickup-task-type <id>` writes it, and it
-surfaces in `config --json`.
+config error. `config add-type ... --clickup-list-id <str>` (the List binding)
+and `--clickup-task-type <id>` write these keys -- both valid only on
+`store = "clickup-tasks"` -- and they surface in `config --json`.
 
 `lazyspec fetch` (optionally `--type <name>`) pulls the bound List's tasks
 (`GET /list/{id}/task`, paginated) using the token from `setup clickup`, and

--- a/README.md
+++ b/README.md
@@ -538,10 +538,13 @@ lazyspec config add-type spike spikes docs/spikes SPIKE \
 # fields (name, plural, dir, prefix, icon, store, numbering, singleton,
 # authorship) it optionally walks through: attributes (repeat until declined; a
 # malformed or duplicate spec re-asks in place), a parent type (chosen only from
-# already-defined types), a custom lifecycle (states then FROM:TO edges, where an
-# edge naming an unknown state re-asks; decline to inherit the store preset), and
-# a gate on an existing parent-child rule (the status must be one the parent
-# type's lifecycle carries). The wizard drives the same add-type / set-lifecycle
+# already-defined types), a custom lifecycle (enter the states as one
+# comma-separated line, then FROM:TO edges, where an edge naming an unknown state
+# re-asks; decline to inherit the store preset), and a gate on an existing
+# parent-child rule (the status must be one the parent type's lifecycle carries).
+# Single-choice prompts (store, numbering, authorship, ...) render a numbered
+# list -- pick by number or exact name; an out-of-list answer is rejected and
+# re-asked. The wizard drives the same add-type / set-lifecycle
 # / add-gate writers as the flags, so it produces an identical .lazyspec.toml.
 # Flags, --json, and non-TTY invocations stay the canonical scriptable path and
 # still require all four positionals.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Every mutation's `--json` output also reports whether the change reached the doc
 | `skills install [--runtime <claude\|agents-md>]`                | Install the embedded agent skill set into the project (both runtimes by default)                |
 | `config [--json]`                                               | Print the resolved `.lazyspec.toml` as JSON                                                     |
 | `config schema`                                                 | Print a JSON Schema for `.lazyspec.toml` (runs from any directory)                              |
-| `config add-type <name> <plural> <dir> <prefix>`                | Append a new document type to `.lazyspec.toml`                                                  |
+| `config add-type <name> <plural> <dir> <prefix>`                | Append a new document type to `.lazyspec.toml` (bare, on a TTY, prompts for the core fields)     |
 | `config set-lifecycle <type> [--state X] [--edge from:to]`      | Replace a type's lifecycle states and edges                                                     |
 | `config add-gate <rule> --status X`                             | Set the `require_parent_status` gate on a parent-child rule                                     |
 | `provenance add <id> <citation>`                                | Append a citation to a document's provenance list                                               |
@@ -518,6 +518,12 @@ lazyspec config schema                      # print a JSON Schema for .lazyspec.
 lazyspec config add-type spike spikes docs/spikes SPIKE \
   --icon "◆" --parent-type rfc --intent "throwaway exploration" \
   --authorship generated
+
+# With no positionals on a TTY, add-type prompts for the core fields
+# interactively (name, plural, dir, prefix, icon, store, numbering, singleton,
+# authorship). Flags, --json, and non-TTY invocations stay the canonical
+# scriptable path and still require all four positionals.
+lazyspec config add-type
 # also accepts --singleton, --store <filesystem|github-issues|github-milestones|github-projects|git-ref|clickup-tasks>,
 # --numbering <incremental|sqids|reserved>, --clickup-task-type <id> (clickup-tasks only)
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Every mutation's `--json` output also reports whether the change reached the doc
 
 | Command                                                         | Description                                                                                     |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `init [--non-interactive] [--json]`                             | Initialise lazyspec in the current project. On a TTY runs an interactive wizard offering two paths -- tweak the starter DAG or design one from scratch; `--non-interactive`/`--json`/non-TTY write the starter config unchanged |
+| `init [--non-interactive] [--json] [--template starter]`        | Initialise lazyspec in the current project. On a TTY runs an interactive wizard that defaults to designing a blank DAG; `--template starter` (or picking `starter` on the first screen) tweaks the built-in starter DAG instead. `--non-interactive`/`--json`/non-TTY write the starter config unchanged (`--template` is ignored) |
 | `create <type> <title> [--author X] [--parent ID] [--body / --body-file]` | Create a document (rfc, adr, story, iteration); seed body inline, from a file, or `-` for stdin. `--parent <ID>` makes the new doc a child of an existing doc; the child must be the same store as its parent. For filesystem-store types the child is authored as a sibling `.md` inside the parent's subdir (promoting a flat parent to `TYPE-n-slug/index.md` on the first child). For `github-issues`-store types the child is created as a real GitHub issue and bound as a native sub-issue of the parent at create time; a later `fetch` mirrors them into the nested cache layout (`.lazyspec/cache/<type>/<PARENT>/index.md` + `NN-<child>.md`) |
 | `list [type] [--status X]`                                      | List documents with optional filters; each list card shows the assignee (as `@name`) when one is set, and nothing when unset |
 | `show <id> [-e] [--open]`                                       | Display a document by path or shorthand ID (e.g. `RFC-001`); `--open` opens it in a browser or viewer instead. The detail header adds an `Assignee:` line when the document has one (omitted when unset), mirroring the `Tags:` line. The `--json` output includes an `assignee` field (a string, or `null` when unset) alongside `status`/`tags`; `status --json` reports it for every document too |
@@ -451,23 +451,26 @@ Unresolvable refs render as:
 <details>
 <summary><h2>Configuration</h2></summary>
 
-`lazyspec init` creates a `.lazyspec.toml` in your project root with a starter set
-of document types, relationships, and validation rules. On a TTY it first asks
-whether to start from the starter DAG or from scratch:
+`lazyspec init` creates a `.lazyspec.toml` in your project root. On a TTY it walks
+an interactive wizard that defaults to designing a **blank** DAG from scratch; pass
+`--template starter` to opt into tweaking the built-in starter DAG instead:
 
-- **Start from the starter** (the default) lets you tweak the starter config --
-  set the naming pattern, keep or drop each starter type, and add new types --
-  before it scaffolds the project.
-- **Start from scratch** designs the whole type DAG from nothing: it prompts for
+- **Blank** (the default) designs the whole type DAG from nothing: it prompts for
   each type (and its lifecycle), then -- once at least two types exist -- for
   parent-child rules with a severity and an optional parent-status gate, defaults
   the relationship vocabulary to the type-agnostic starter set, renders a summary
   of the designed DAG, and asks to confirm before writing. Declining the
   confirmation discards the session and starts over; nothing is written.
+- **Starter** (`lazyspec init --template starter`, or picking `starter` on the
+  first screen) starts from the built-in starter set of document types,
+  relationships, and validation rules and lets you tweak it -- set the naming
+  pattern, keep or drop each starter type, and add new types -- before it
+  scaffolds the project. `--template starter` skips the first-screen prompt and
+  goes straight to the starter designer.
 
 Pass `--non-interactive` (or `--json`, which implies it), or run in a
-non-TTY context (a pipe or CI), to skip both wizards and write the starter config
-unchanged. The engine carries no
+non-TTY context (a pipe or CI), to skip the wizard and write the starter config
+unchanged; `--template` is ignored on those paths. The engine carries no
 built-in document types or relationship vocabulary: the `[[types]]`,
 `[[relationships]]`, and `[[rules]]` declared in `.lazyspec.toml` are the sole
 source of truth. A missing `.lazyspec.toml`, or a config with no `[[types]]`, is a

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Every mutation's `--json` output also reports whether the change reached the doc
 
 | Command                                                         | Description                                                                                     |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `init [--non-interactive] [--json]`                             | Initialise lazyspec in the current project. Runs an interactive starter-config wizard on a TTY; `--non-interactive`/`--json`/non-TTY write the starter config unchanged |
+| `init [--non-interactive] [--json]`                             | Initialise lazyspec in the current project. On a TTY runs an interactive wizard offering two paths -- tweak the starter DAG or design one from scratch; `--non-interactive`/`--json`/non-TTY write the starter config unchanged |
 | `create <type> <title> [--author X] [--parent ID] [--body / --body-file]` | Create a document (rfc, adr, story, iteration); seed body inline, from a file, or `-` for stdin. `--parent <ID>` makes the new doc a child of an existing doc; the child must be the same store as its parent. For filesystem-store types the child is authored as a sibling `.md` inside the parent's subdir (promoting a flat parent to `TYPE-n-slug/index.md` on the first child). For `github-issues`-store types the child is created as a real GitHub issue and bound as a native sub-issue of the parent at create time; a later `fetch` mirrors them into the nested cache layout (`.lazyspec/cache/<type>/<PARENT>/index.md` + `NN-<child>.md`) |
 | `list [type] [--status X]`                                      | List documents with optional filters; each list card shows the assignee (as `@name`) when one is set, and nothing when unset |
 | `show <id> [-e] [--open]`                                       | Display a document by path or shorthand ID (e.g. `RFC-001`); `--open` opens it in a browser or viewer instead. The detail header adds an `Assignee:` line when the document has one (omitted when unset), mirroring the `Tags:` line. The `--json` output includes an `assignee` field (a string, or `null` when unset) alongside `status`/`tags`; `status --json` reports it for every document too |
@@ -452,11 +452,21 @@ Unresolvable refs render as:
 <summary><h2>Configuration</h2></summary>
 
 `lazyspec init` creates a `.lazyspec.toml` in your project root with a starter set
-of document types, relationships, and validation rules. On a TTY it runs an
-interactive wizard first, letting you tweak the starter config -- set the naming
-pattern, keep or drop each starter type, and add new types -- before it scaffolds
-the project. Pass `--non-interactive` (or `--json`, which implies it), or run in a
-non-TTY context (a pipe or CI), to skip the wizard and write the starter config
+of document types, relationships, and validation rules. On a TTY it first asks
+whether to start from the starter DAG or from scratch:
+
+- **Start from the starter** (the default) lets you tweak the starter config --
+  set the naming pattern, keep or drop each starter type, and add new types --
+  before it scaffolds the project.
+- **Start from scratch** designs the whole type DAG from nothing: it prompts for
+  each type (and its lifecycle), then -- once at least two types exist -- for
+  parent-child rules with a severity and an optional parent-status gate, defaults
+  the relationship vocabulary to the type-agnostic starter set, renders a summary
+  of the designed DAG, and asks to confirm before writing. Declining the
+  confirmation discards the session and starts over; nothing is written.
+
+Pass `--non-interactive` (or `--json`, which implies it), or run in a
+non-TTY context (a pipe or CI), to skip both wizards and write the starter config
 unchanged. The engine carries no
 built-in document types or relationship vocabulary: the `[[types]]`,
 `[[relationships]]`, and `[[rules]]` declared in `.lazyspec.toml` are the sole

--- a/docs/iterations/ITERATION-325-interactive-config-add-type-tty-wizard-for-core-fields.md
+++ b/docs/iterations/ITERATION-325-interactive-config-add-type-tty-wizard-for-core-fields.md
@@ -1,0 +1,49 @@
+---
+title: 'Interactive config add-type: TTY wizard for core fields'
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- implements: STORY-225
+---Implements STORY-225 (walking skeleton for the config wizard, RFC-062). One bounded slice: make `config add-type` prompt for its core fields on a TTY when given no positional args, reusing the existing `run_add_type` writer. Nothing here touches lifecycle, attributes, gates, or relations — those are STORY-226.
+
+## Context
+
+- `ConfigCommand::AddType` (`src/cli/config.rs:29`) declares 4 **required** positionals (`name`, `plural`, `dir`, `prefix`) + optional flags.
+- Dispatch: `src/main.rs:612` destructures the variant → calls `run_add_type(&cwd, &fs, &name, …)` (`src/cli/config.rs:98`), which parses config, rejects duplicate name, pushes `TypeDef`, writes via `write_config_in_place`.
+- No prompt/terminal crate in `Cargo.toml`. Use `std::io::IsTerminal` (std) + hand-rolled stdin reads. No new dependency.
+
+## Approach
+
+1. Make the 4 positionals `Option<String>` in the `AddType` clap variant. Trigger the wizard only when **all four are `None`**.
+2. New CLI-layer prompt seam: `trait Prompter { fn ask(&mut self, label, default: Option<&str>) -> Result<String>; fn confirm(...); fn select(label, options, default) -> Result<String>; }`. Real impl reads stdin/writes stdout; a `ScriptedPrompter` (Vec queue) drives tests. Seam lives in `src/cli/` (Convention P3/P4).
+3. New `run_add_type_interactive(root, fs, prompter) -> Result<()>`: prompt core fields (name, plural, dir[default `docs/<plural>`], prefix[default UPPER(name)], icon, store[default filesystem], numbering[default incremental], singleton[y/N], authorship[default assisted]) → re-prompt loop on duplicate name/prefix against loaded config → delegate to existing `run_add_type`. No second write path.
+4. Dispatch (`src/main.rs`): if all 4 positionals `None` AND `stdin().is_terminal() && stdout().is_terminal()` AND not `--json` → `run_add_type_interactive`. Else if any positional present → existing `run_add_type` (unwrap the 4, error if partially supplied — clap-style required-together). Else (missing + non-TTY) → error as today.
+
+## Task breakdown
+
+- [ ] `AddType` positionals → `Option<String>`; add `#[arg(requires_all)]` or manual "all-or-none" check so partial positionals error.
+- [ ] Define `Prompter` trait + `StdinPrompter` real impl + `ScriptedPrompter` test fake in `src/cli/` (new `wizard.rs` module).
+- [ ] `run_add_type_interactive` in `src/cli/config.rs`: collect fields, defaults, duplicate re-prompt, delegate to `run_add_type`.
+- [ ] Wire dispatch in `src/main.rs` with TTY + `--json` gating.
+- [ ] README: `config add-type` prompts interactively on TTY with no args; flags/`--json`/non-TTY unchanged.
+
+## Acceptance criteria
+
+- **Given** a `ScriptedPrompter` queued with valid core-field answers, **when** `run_add_type_interactive` runs against a temp config, **then** the type is appended identically to the equivalent `run_add_type` flag call (assert TOML round-trip).
+- **Given** the first queued name duplicates an existing type, **when** the wizard validates, **then** it re-prompts (consumes next answer) rather than erroring or writing a duplicate.
+- **Given** `dir`/`prefix` answers are left blank, **then** defaults `docs/<plural>` and `UPPER(name)` are used.
+- **Given** any positional arg is supplied, **then** dispatch takes the existing non-interactive `run_add_type` path (no prompting); **and** partial positionals error.
+- **Given** `--json` or a non-terminal stdin/stdout, **then** no prompt is emitted and behaviour matches today.
+- **Given** the wizard completes, **then** `lazyspec validate` passes on the resulting config.
+
+## Test plan
+
+- Unit tests in `src/cli/config.rs` / `wizard.rs` using `ScriptedPrompter` — no real TTY. Cover: happy path round-trip, duplicate-name re-prompt, blank-default fill, all-or-none positional guard.
+- Reuse existing `run_add_type` round-trip test style (`add_type_round_trips`, `config.rs:498`).
+
+## Out of scope
+
+Lifecycle/attributes/gate/relation prompts (STORY-226); `init` wizard (STORY-227/228); prompt-crate adoption (hand-rolled stdin stands unless a later story justifies one).

--- a/docs/iterations/ITERATION-326-interactive-add-type-attributes-lifecycle-gate-and-parent-relation.md
+++ b/docs/iterations/ITERATION-326-interactive-add-type-attributes-lifecycle-gate-and-parent-relation.md
@@ -1,0 +1,65 @@
+---
+title: 'Interactive add-type: attributes, lifecycle, gate and parent relation'
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-226
+---
+Implements STORY-226. One slice: grow ITERATION-325 add-type wizard past core fields → also prompt attributes, custom lifecycle, parent type, gate. Drive same three writers flag path drive. No new write path. RFC-062 add-type flow (`docs/rfcs/RFC-062-...md` §"Add-type wizard flow", §"Layering", §"Validation & re-prompt").
+
+## Context
+
+Wizard seam + core-field flow already built (ITERATION-325, STORY-225). This slice only extends the collector; every value object + writer exist.
+
+- Prompter trait seam: `src/cli/wizard.rs:7` (`ask`/`confirm`/`select`). Real `StdinPrompter`, test `ScriptedPrompter` (`wizard.rs:92`). CLI layer (Convention P3/P4). Reuse as-is; no new methods needed.
+- `run_add_type_interactive` (`src/cli/config.rs:195`) = extension point. Today prompts core fields only, then delegates `run_add_type(... parent=None, ... attributes=&[])` (`config.rs:255-271`). Loop at `config.rs:212` already re-prompts dup name/prefix.
+- Writers (all read→mutate→`write_config_in_place`→write, one per pass):
+  - `run_add_type` (`config.rs:100`) — takes `parent_type: Option<&str>` + `attributes: &[String]`. Already parses specs via `parse_attr_spec` + rejects dup attr names (`config.rs:125-135`).
+  - `run_set_lifecycle` (`config.rs:274`) — replaces states+edges on a type.
+  - `run_add_gate` (`config.rs:301`) — sets `require_parent_status` on an existing **parent-child rule by name**; rejects unknown/relation-existence rule. Does NOT validate status membership.
+- Validators to reuse: `parse_attr_spec` (`config.rs:351`, module-private) — kind/enum/segment rules. `parse_edge` (`config.rs:335`) — FROM:TO **syntax only**, no state membership.
+- Lifecycle model: `Lifecycle{states,edges}` (`config.rs:158`). Decline custom → leave `Lifecycle::default()` (empty) → resolves to preset via `effective_lifecycle()` (`config.rs:1312`); so decline = do NOT call set-lifecycle.
+- Gate target lifecycle: rule `parent` type → `effective_lifecycle().states` (`config.rs:1312`). `ParentChild` fields (`config.rs:31`).
+- Dispatch already gates TTY + `!--json` (`src/main.rs:658`); no dispatch change.
+
+## Approach
+
+Extend `run_add_type_interactive` body only (after existing core-field loop, before/around the single `run_add_type` call). Four optional sections, each prompt-side pre-validated → re-prompt on fail, never abort session (RFC §"Validation & re-prompt"). Writers stay untouched.
+
+1. **Attributes** — loop: `confirm("Add an attribute", false)`; if yes `ask` spec `NAME:KIND[:required][:VAL,…]` → `parse_attr_spec` → on `Err` print msg + re-ask (same iteration, no dup-add prompt consumed); dup name vs already-collected → same re-ask. Collect `Vec<String>` of raw specs. Pass to `run_add_type` `attributes` arg (drop the `&[]`).
+2. **Parent** — build `&[&str]` of existing type names from `config.documents.types`. If empty skip. Else `confirm("Set a parent type")` → `select("Parent", &names, first)`; only listed names selectable (re-ask if answer ∉ names). Pass as `parent_type` to `run_add_type`.
+3. **Lifecycle** — `confirm("Design a custom lifecycle", false)`. No → nothing (inherits preset). Yes → collect states (repeat `ask`, blank ends, ≥1 required) then edges (repeat `ask` FROM:TO, blank ends): `parse_edge` for syntax, then membership — `to ∈ states` and (`from ∈ states` or `from=="*"`) else re-ask. After type written, call `run_set_lifecycle(root,fs,&name,&states,&edges)`.
+4. **Gate** — collect `ParentChild` rule names from `config.rules`. If none skip. Else `confirm("Gate a parent-child rule")` → `select` rule → `ask` status → resolve rule.parent type `effective_lifecycle().states`; status ∈ that set else re-ask. Call `run_add_gate(root,fs,&rule,&status)`.
+
+Order of writer passes: `run_add_type` (type + attrs + parent) → `run_set_lifecycle` (if custom) → `run_add_gate` (if gated). Same chain as flag callers; each re-reads config so ordering safe.
+
+## Task breakdown
+
+- [ ] Attributes loop in `run_add_type_interactive`; reuse `parse_attr_spec`; pass collected specs to `run_add_type`.
+- [ ] Parent select from existing type names; pass to `run_add_type` `parent_type`.
+- [ ] Custom-lifecycle collector (states then edges, `parse_edge` + membership re-prompt); call `run_set_lifecycle` only when opted in.
+- [ ] Gate collector over existing parent-child rules; status membership check vs parent `effective_lifecycle().states`; call `run_add_gate`.
+- [ ] README: extend `config add-type` interactive section — attributes, lifecycle, parent, gate prompts; flags/`--json`/non-TTY path unchanged.
+
+## Acceptance criteria
+
+- **G** wizard running **W** I add attribute `priority:enum:low,medium,high` **T** validated + written; **and** malformed spec (unknown kind, enum w/o values) rejected + re-prompted. (STORY-226 AC1) — test `interactive_add_type_collects_attributes`, `interactive_add_type_reprompts_bad_attr`.
+- **G** I opt into custom lifecycle **W** I enter states + edges **T** edge naming a non-existent state rejected + re-prompted; **and** if I decline, type inherits standard preset (no `[lifecycle]` written / empty lifecycle). (STORY-226 AC2) — test `interactive_add_type_custom_lifecycle_reprompts_bad_edge`, `interactive_add_type_declined_lifecycle_inherits_preset`.
+- **G** I set a parent **W** offered choices **T** only already-defined types offered; unknown parent not enterable. (STORY-226 AC3) — test `interactive_add_type_parent_only_from_existing`.
+- **G** I gate a parent-child rule with a status the parent lifecycle lacks **T** rejected + re-prompted; valid status written. (STORY-226 AC4) — test `interactive_add_type_gate_reprompts_unknown_status`.
+- **G** I complete the full flow **T** result is byte-identical to the equivalent non-interactive `add-type`(+attrs+parent) → `set-lifecycle` → `add-gate` flag chain, and reparses clean. (STORY-226 AC5) — test `interactive_full_flow_matches_flag_chain`.
+
+## Test plan
+
+- `ScriptedPrompter`-driven unit tests in `src/cli/config.rs` `mod tests`, no real TTY (extend existing `interactive_*` tests, `config.rs:823+`). Fixture `SRC` (`config.rs:458`) already carries rfc/story types + `stories-need-rfcs` parent-child rule → gate target ready.
+- AC5 equivalence: run wizard into fixture A, run flag chain (`run_add_type` + `run_set_lifecycle` + `run_add_gate`) into fixture B, assert file bytes equal (mirrors `interactive_add_type_matches_flag_call`, `config.rs:824`).
+- Re-prompt tests assert queue-consume behaviour + no duplicate/abort + final `Config::parse` ok.
+
+## Out of scope / notes
+
+- Creating **new** parent-child rules or **new** named relationship vocabulary: no engine writer exists (only `write_config_in_place`; CLI exposes only add-type/set-lifecycle/add-gate). Gate step operates on rules that already exist. Deferred — not in STORY-226 ACs (AC5 fixes the scriptable equivalent to add-type+set-lifecycle+add-gate). Do NOT invent an add-rule/add-relationship writer.
+- Editing an existing type's lifecycle/gates (RFC non-goal). `init` bootstrap wizard (STORY-227/228). Prompt-crate adoption. TUI/web parity — none (CLI-only authoring, produces same `.lazyspec.toml`; RFC §"Impact").
+- Conventions: `docs/CONVENTIONS.md` P3 (prompt seam in CLI), P4 (fake at trait seam = `ScriptedPrompter`), P6 (no second config path). `--json`/non-TTY suppression already enforced at `main.rs:658`.

--- a/docs/iterations/ITERATION-327-interactive-init-bootstrap-from-the-starter-config.md
+++ b/docs/iterations/ITERATION-327-interactive-init-bootstrap-from-the-starter-config.md
@@ -1,0 +1,80 @@
+---
+title: Interactive init bootstrap from the starter config
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-227
+---
+<!-- intent: plan the concrete changes that satisfy a story's acceptance criteria -->
+
+Implements STORY-227 (RFC-062 bootstrap wizard, "start from starter + tweak" path). ONE slice: `init` on TTY, no flags -> walk author + naming + per-starter-type keep/drop + add-type, then run existing scaffold seeded from designed `Config`. From-scratch/blank-slate DAG designer = STORY-228, EXCLUDED.
+
+## Objective
+
+`lazyspec init` on TTY prompts user to tweak `starter_config()` (author, naming, keep/drop starter types, add types) before scaffold; non-TTY/`--json`/`--non-interactive` = today's behaviour byte-for-byte.
+
+## Satisfies
+
+STORY-227 all 5 AC. (blank-slate designer NOT an AC here — STORY-228.)
+
+## Context (file:line)
+
+- `Init` = unit variant, no args (`src/cli.rs:75`). Dispatch early-returns `init::run(&cwd)` (`src/main.rs:25-28`) BEFORE `Config::load` — no config file yet, same class as Completions/Fix/Skills.
+- `init::run` (`src/cli/init.rs:42-66`): bail if `.lazyspec.toml` exists (44-46); `config = starter_config()` (48); mkdir per type (50-52); templates dir + `template.md` (53-55); `scaffold_skeleton_files` (57); write toml (59); `ensure_github_labels` (61); `ensure_gitignore` (62). Scaffold logic is INLINE in `run` — must extract to reuse.
+- `starter_config()` (`src/cli/init.rs:14-40`): `starter_types()`, naming `{type}-{n:03}-{title}.md` (NOTE `.md` suffix; story says `{type}-{n:03}-{title}` — starter's real default wins for parity), `starter_relationships()`, `default_rules()`.
+- Prompter seam DONE: `trait Prompter{ask,confirm,select}` + `StdinPrompter` + `ScriptedPrompter` (`src/cli/wizard.rs:7-139`). REUSE, add nothing.
+- Add-type interactive collection loop (`src/cli/config.rs:197-416`): reads `.lazyspec.toml` from disk first (202-204) THEN prompts fields (214-389). Disk-read makes it un-reusable from `init` (no file yet) as-is — extract the prompt-only collection.
+- Git author default: `git config user.name` reader exists at `src/engine/agent.rs:32-45` — reuse for author prefault.
+- No `default_author` field on `Config`/`DocumentConfig` (`src/engine/config.rs:477-482`, `Naming` 667-668). Author has NO config home. See Notes.
+- Prior slice pattern to mirror: `ITERATION-325` (add-type TTY wizard), `ITERATION-326` (STORY-226 attrs/lifecycle/gate).
+
+## Approach
+
+Split prompting (pure, testable) from scaffolding (IO). Three seams:
+
+1. `Init { non_interactive: bool, json: bool }` (was unit). `--non-interactive` + `--json` flags. `--json` implies non-interactive (RFC-062 §json).
+2. `design_config_interactive(base: Config, prompter: &mut dyn Prompter) -> Result<Config>` in `src/cli/init.rs` — PURE, no disk. Start from `base = starter_config()`; prompt author (prefault git `user.name`), naming pattern (default `base.documents.naming.pattern`), per starter type keep/drop, then add-type loop; return mutated `Config`. Accept-all-defaults => returns `base` unchanged (parity).
+3. `write_project(root, &Config) -> Result<()>` — extract `init::run` body lines 50-62 verbatim. Both `run` (non-interactive) and interactive path call it. ONE scaffold path, ONE config writer (Convention P6).
+4. Reuse add-type flow: extract `collect_type_interactive(cfg: &Config, prompter) -> Result<CollectedType>` from `config.rs:214-389` (prompt-only, in-memory cfg for dup/parent/gate checks, NO disk). `run_add_type_interactive` keeps disk read then delegates; init wizard calls it against the in-progress `Config` and applies result in-memory. If extraction proves heavy, MINIMUM: reuse core-field collection (name/plural/dir/prefix/icon/store/numbering/singleton/authorship + dup guard). Lifecycle/attrs/gate reuse is bonus, not blocking.
+
+## Task breakdown
+
+1. `src/cli.rs:75`: `Init` -> struct variant `{ #[arg(long)] non_interactive: bool, #[arg(long)] json: bool }`.
+2. `src/main.rs:25-28`: destructure `Init { non_interactive, json }`; `interactive = !non_interactive && !json && stdin().is_terminal() && stdout().is_terminal()` (mirror `main.rs:650-652`); still return early. If `.lazyspec.toml` exists -> `init::run` bails as today (keep the existence check inside run/write path). Interactive -> `StdinPrompter::new()` + `run_init_interactive`; else `init::run`.
+3. `src/cli/init.rs`: extract `write_project(root, &Config)` from `run` body; `run` = `write_project(root, &starter_config())` after existence bail.
+4. `src/cli/init.rs`: `design_config_interactive(base, prompter)` — author prompt (prefault git user.name), naming prompt, keep/drop loop over `base.documents.types` (confirm "Keep type <name>?" default y; dropped names removed), add-type loop (`confirm "Add another type"` -> collect -> push, dup name/prefix re-prompt), final `confirm "Write this config"` (default y) else re-loop or abort-clean.
+5. `src/cli/init.rs`: `run_init_interactive(root, prompter)` = existence bail + `write_project(root, &design_config_interactive(starter_config(), prompter)?)`.
+6. `src/cli/config.rs`: extract `collect_type_interactive` (prompt-only) shared by `run_add_type_interactive` + init wizard.
+7. README: TTY-triggered interactive `init`, `--non-interactive` opt-out, `--json`/non-TTY unchanged (project rule: CLI change -> README).
+
+## Acceptance criteria (each test-backed)
+
+- AC1 walk: **Given** `ScriptedPrompter` queued [author, naming, keep-all, no-add, write=y], **When** `design_config_interactive(starter_config(), p)`, **Then** returns Config with prompted author-effect + naming, all starter types present. -> `test design_prompts_author_naming_types`.
+- AC2 parity: **Given** `ScriptedPrompter` all-blank (accept every default), **When** `design_config_interactive(starter_config(), p)`, **Then** result `== starter_config()` (assert `to_toml()` byte-equal). -> `test design_all_defaults_equals_starter`.
+- AC3 suppression: **Given** `--non-interactive` OR `--json` OR non-TTY, **When** init dispatches, **Then** no prompt, `write_project` receives `starter_config()` unchanged. -> `test init_noninteractive_writes_starter` (call `write_project(tmp, &starter_config())`, assert toml == starter) + dispatch-gate unit `test json_suppresses_interactive`.
+- AC4 exists-bails: **Given** `.lazyspec.toml` present, **When** init (interactive or not), **Then** bails "already exists", no overwrite. -> `test init_bails_when_config_exists`.
+- AC5 drop/add valid: **Given** `ScriptedPrompter` dropping one starter type + adding one new type, **When** design then `validate`, **Then** dropped type absent, new type present, `write_project` output passes `lazyspec validate`; dirs/templates/skeletons match designed types. -> `test design_drop_and_add` (Config assertions) + `test write_project_scaffold_validates` (temp dir round-trip + validate).
+
+## Test plan
+
+- All unit, `ScriptedPrompter`-driven, NO real TTY (mirror `config.rs:990+` scripted tests). Cover: all-defaults parity byte-equal, author+naming applied, keep-all, drop-one, add-one dup-name re-prompt, write-confirm=n path, exists-bail.
+- Scaffold round-trip: temp dir, `write_project(tmp, &designed)`, assert per-type dirs + `template.md` + skeletons, then load + `validate` clean (reuse init.rs test style `src/cli/init.rs:232-302`).
+- Dispatch gating unit for `--json`/`--non-interactive` suppression (no prompter constructed).
+
+## Out of scope
+
+- STORY-228 from-scratch / blank-slate full DAG designer (custom lifecycles-from-zero, relation-vocabulary authoring, first-screen "starter vs blank" choice). This slice ONLY tweaks the starter.
+- Persisting a project default author: `Config` has NO `default_author` field (`config.rs:477`). Adding one = schema change AND breaks AC2 byte-parity (starter carries no author). This slice PROMPTS author (prefault git user.name) but does NOT write it to config — deferred pending schema work. Naming pattern IS persisted (real `Naming.pattern` field, default == starter -> parity holds).
+- Editing lifecycle/gates of the KEPT starter types (RFC-062 non-goal: add not edit).
+- Remote-store auth (`setup github-issues`/`clickup`) — `init` may already trigger labels via `ensure_github_labels`; no new auth flow.
+- TUI/web: none — CLI-only authoring, produces standard `.lazyspec.toml` all layers already read (RFC-062 §parity).
+
+## Notes
+
+- Convention: prompt seam stays in CLI layer (P3); `Prompter` trait fake at seam (P4); non-TTY/`--json` -> unchanged non-interactive path (byte parity is AC2/AC3). NO second config writer — `write_project` is the single scaffold path (P6).
+- Parity trap: starter naming pattern carries `.md` suffix (`init.rs:19`); default the naming prompt to `base.documents.naming.pattern`, NOT the story's `{type}-{n:03}-{title}` (missing `.md`), or blank-accept diverges from starter and breaks AC2.
+- `run_add_type_interactive` reads disk first (`config.rs:202`); init has no file. Extract prompt-only `collect_type_interactive` operating on in-memory `Config` so both callers share it.
+- Author gap is the one real design fork — resolved above (prompt, don't persist). Flag to reviewer if they want a `default_author` field (own story).

--- a/docs/iterations/ITERATION-328-interactive-init-blank-slate-full-dag-designer-from-scratch.md
+++ b/docs/iterations/ITERATION-328-interactive-init-blank-slate-full-dag-designer-from-scratch.md
@@ -1,0 +1,101 @@
+---
+title: Interactive init blank-slate full DAG designer from scratch
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-228
+---
+<!-- intent: plan the concrete changes that satisfy a story's acceptance criteria -->
+
+Implements STORY-228 (RFC-062 bootstrap wizard, "blank slate / full DAG designer" path). BUILDS ON STORY-227 (ITERATION-327). ONE slice: first-screen "starter vs scratch" branch -> from-scratch design (types -> per-type lifecycle -> parent-child rules+severity -> gates -> relation vocab default -> DAG summary -> confirm) -> existing `write_project`. Reuse `collect_type_interactive`/`apply_collected_type`/`Prompter`/`write_project`. NO second config writer.
+
+## Objective
+
+`lazyspec init` on TTY offers "blank slate" beside STORY-227's "start from starter"; blank slate designs the WHOLE type DAG from nothing (types, lifecycles, parent-child rules with severity, gates), renders a DAG summary, confirms, then scaffolds a `Config` that owes nothing to `starter_config()` and passes `validate`.
+
+## Satisfies
+
+STORY-228 all 6 AC (5 CLI-behaviour + non-func non-TTY suppression).
+
+## Context (file:line)
+
+- STORY-227 delivered the reusable spine — READ IT FIRST:
+  - `run_init_interactive(root, prompter)` (`src/cli/init.rs:95-99`): existence bail -> `design_config_interactive(starter_config(), prompter)` -> `write_project`. Blank-slate branch goes HERE.
+  - `design_config_interactive(base, prompter) -> Result<Config>` (`src/cli/init.rs:125-155`): PURE, no disk. Author(discard)/naming/keep-drop/add-type loop/write-confirm-else-reloop. MIRROR its purity + confirm-loop shape for the from-scratch twin.
+  - `write_project(root, &Config)` (`src/cli/init.rs:72-91`): THE single scaffold+writer path (mkdir per type, templates dir+`template.md`, `scaffold_skeleton_files`, write toml, gh labels, gitignore). REUSE unchanged.
+  - `init_is_interactive(non_interactive, json, stdin_tty, stdout_tty)` (`src/cli/init.rs:47-54`): gate already suppresses wizard for `--json`/`--non-interactive`/non-TTY. Blank slate lives INSIDE the interactive branch => inherits suppression free (STORY-228 non-func AC).
+- Reusable type collector (`src/cli/config.rs`):
+  - `collect_type_interactive(config, prompter) -> Result<CollectedType>` (`config.rs:252-456`): PURE prompt-only; validates name/prefix dup (270-277), parent from defined types (337-353), custom lifecycle states+edges with edge-target re-prompt (358-395), gate on EXISTING parent-child rule with status-in-parent-lifecycle re-prompt (399-439). REUSE for the types loop.
+  - `apply_collected_type(config, collected) -> Result<()>` (`config.rs:461-515`): pushes `TypeDef`, applies lifecycle, attaches gate to existing rule. REUSE.
+  - `CollectedType` (`config.rs:232-246`); `type_def_from_parts` (`config.rs:168-206`).
+- Rule/vocab primitives (`src/engine/config.rs`):
+  - `ValidationRule::ParentChild{name,child,parent,severity,require_parent_status}` (`config.rs:31-38`); `RelationExistence` (`40-46`). `Severity{Error,Warning}` `#[serde lowercase]` (`config.rs:10-13`).
+  - `default_rules()` (`config.rs:938-961`): references `story/rfc/iteration/adr` — DO NOT seed blank slate with this (dangling-rule trap; see Notes).
+  - `starter_relationships()` (`config.rs:414-432`): type-agnostic vocab (implements/supersedes/blocks/related-to). SAFE default for blank slate.
+  - `starter_config()` (`src/cli/init.rs:17-43`): naming `{type}-{n:03}-{title}.md` (the `.md` suffix parity default — 327 Notes), `FilesystemConfig`, `UiConfig::default`, `ref_count_ceiling:15`, `CertificationConfig::default`. Blank base copies the NON-type/NON-rule scaffolding from here.
+- `run_add_gate` (`config.rs:601-626`) = existing gate-attach reference (attaches `require_parent_status` to a parent-child rule). No CLI command creates parent-child rules today => rule authoring is the NEW surface.
+- `Prompter` trait + `ScriptedPrompter` (`src/cli/wizard.rs:7-15,92-139`). REUSE, add nothing.
+
+## Approach
+
+Add a from-scratch PURE designer twin beside `design_config_interactive`, branched by a first-screen select. One writer, one gate function, reuse the type collector.
+
+1. **First-screen branch** — in `run_init_interactive` (`init.rs:95`), after existence bail, `prompter.select("Start from", &["starter","scratch"], "starter")`. `starter` -> existing `design_config_interactive(starter_config(), p)`; `scratch` -> new `design_config_from_scratch(p)`. Both -> same `write_project`. Keeps designers PURE/testable (branch is one select).
+2. **Blank base** — helper `blank_config() -> Config`: clone `starter_config()` scaffolding but `documents.types = vec![]` and `rules = vec![]`, KEEP `relationships = starter_relationships()`, naming `{type}-{n:03}-{title}.md`, filesystem/ui/ceiling/certification. Rules EMPTY is the dangling-rule guard.
+3. **`design_config_from_scratch(prompter) -> Result<Config>`** — PURE, no disk, confirm-loop like `design_config_interactive`:
+   - author (prompt+discard, prefault git user.name — mirror 327), naming (default blank base pattern).
+   - **types loop**: `while confirm("Add a type", true-first/false-after)` -> `collect_type_interactive(&config, p)` -> `apply_collected_type`. Require >=1 type before leaving (re-prompt if none). (Per-type gate section inside collector stays inert here: no rules yet.)
+   - **parent-child rules loop**: only when >=2 types. `while confirm("Add a parent-child rule", false)`: select child + parent from DEFINED type names (re-prompt unknown), auto-name `"{child_plural?}-need-{parent}"` or `"{child}s-need-{parent}s"` (stable, dedup-guarded), `select("Severity",&["warning","error"],"warning")`, then optional `confirm("Gate on a parent status")` -> pick status from parent's `effective_lifecycle().states` (re-prompt unknown) -> `require_parent_status`. Push `ValidationRule::ParentChild`.
+   - relation vocab: default `starter_relationships()` (already on base); no authoring UI this slice (see Out of scope).
+   - **DAG summary**: `render_dag_summary(&config)` -> println types (name/plural/dir/prefix/store), each type's effective lifecycle states+edges, parent-child rules (child->parent, severity, gate status), relation vocab names. Then `confirm("Write this config", true)`; `n` -> discard clean + reloop (no IO).
+4. **Severity parse** — small `parse_severity(&str)->Result<Severity>` (warning/error) in `config.rs`, reused by the rule loop.
+5. **README** — document blank-slate DAG designer beside 327's starter path; `--non-interactive`/`--json`/non-TTY still write `starter_config()` (project rule: CLI change -> README).
+
+## Task breakdown
+
+1. `src/cli/init.rs`: add `blank_config()` helper (starter scaffolding, empty types+rules, starter relationships).
+2. `src/cli/init.rs`: add `design_config_from_scratch(prompter)` — author/naming/types-loop(>=1)/rules-loop/summary/confirm-reloop; PURE.
+3. `src/cli/init.rs`: `render_dag_summary(&Config) -> String` (or println helper) listing types+lifecycles+rules+gates+relations.
+4. `src/cli/init.rs`: branch `run_init_interactive` on `select("Start from",["starter","scratch"],"starter")`.
+5. `src/cli/config.rs`: add `parse_severity`; expose a small pure rule-collect helper if it keeps `design_config_from_scratch` readable (else inline). Reuse `collect_type_interactive`/`apply_collected_type` as-is.
+6. `README.md`: blank-slate designer section; note suppression unchanged.
+
+## Acceptance criteria (each test-backed)
+
+- **AC1 lifecycle/gate ref only defined states** (STORY-228 AC1): **Given** `ScriptedPrompter` adding a type with a custom lifecycle whose edge, then a gate status, name an UNDEFINED state first, **When** `design_config_from_scratch`, **Then** each invalid ref re-prompts and only defined states/statuses are accepted. -> `test scratch_lifecycle_and_gate_reject_unknown_states` (drives collector re-prompt reuse).
+- **AC2 parent-child rule from defined types + severity** (AC2): **Given** two defined types, `ScriptedPrompter` adds a rule picking child+parent from them and severity=error, **When** design, **Then** a `ValidationRule::ParentChild{child,parent,severity:Error}` is present; an unknown child/parent re-prompts. -> `test scratch_parent_child_rule_defined_types_and_severity`.
+- **AC3 DAG summary + confirm** (AC3): **Given** a designed DAG, **When** the wizard renders the summary, **Then** output names every type, its lifecycle, every rule+gate, and the relation vocab, and a `confirm("Write this config")` is asked before returning. -> `test scratch_summary_lists_dag` (assert rendered string contains type/lifecycle/rule/relation tokens).
+- **AC4 confirm -> valid scaffold** (AC4): **Given** a full from-scratch design (>=2 types, >=1 rule, custom + inherited lifecycles), **When** `write_project` scaffolds it into a temp dir, **Then** per-type dirs + `template.md` exist, config LOADS, and `validate_full` returns NO errors (no dangling rules/relationships). -> `test scratch_scaffold_validates_clean` (temp-dir round-trip, mirror `init.rs:474-508`).
+- **AC5 decline at summary -> nothing written** (AC5): **Given** `ScriptedPrompter` answering write-confirm=`n` then aborting, **When** `run_init_interactive` on a temp root, **Then** no `.lazyspec.toml` and no per-type dirs are created (design is pure; `write_project` never runs). -> `test scratch_decline_writes_nothing`.
+- **AC6 non-TTY/non-interactive suppressed** (AC6 non-func): **Given** `--json`/`--non-interactive`/non-TTY, **When** init dispatches, **Then** blank slate is unreachable and `starter_config()` is written. -> reuse `test json_suppresses_interactive` (`init.rs:385`) + `test init_noninteractive_writes_starter` (branch select never constructed when non-interactive).
+
+## Test plan
+
+- All unit, `ScriptedPrompter`-driven, NO real TTY (mirror `init.rs:307+` / `config.rs` scripted tests).
+- From-scratch happy path: >=2 types (one custom lifecycle, one inherited), 1 parent-child rule + gate, accept relation-vocab default, write=y -> assert types/rules/relations on returned `Config`.
+- Re-prompt coverage: unknown lifecycle edge state, unknown gate status, unknown rule child/parent, dup type name/prefix (collector reuse) each re-ask not abort.
+- Blank base parity: `blank_config()` has empty types+rules, `starter_relationships()`, starter naming pattern.
+- Scaffold round-trip: temp dir `write_project(tmp,&designed)` -> per-type dirs + template + skeletons -> `Config::load` -> `validate_full` errors empty (explicit dangling-rule assertion: no rule references an absent type).
+- Decline path: write=n -> reloop then abort -> no files/dirs on disk.
+- Suppression: `init_is_interactive` false for json/non-interactive/non-TTY (existing tests hold).
+
+## Out of scope
+
+- **Relation-vocabulary authoring UI** (RFC-062 §5 "advanced users add named relations w/ inverses"): this slice DEFAULTS to `starter_relationships()` and does not prompt to add/edit relations. Deferred — a follow-up may add a relation-authoring loop. (Keeps slice bounded; blank slate is still valid because default vocab is type-agnostic.)
+- **Editing** an existing type/rule/lifecycle interactively (RFC-062 non-goal: add not edit).
+- **Persisting default author** — no `Config.default_author` field (`config.rs:477`); prompt+discard as in 327.
+- **STORY-227 starter path internals** — unchanged; blank slate only adds the first-screen branch + twin designer.
+- **Remote-store auth** (`setup github-issues`/`clickup`) — `write_project` may already emit labels via `ensure_github_labels`; no new auth flow.
+- **TUI/web** — CLI-only authoring; produces standard `.lazyspec.toml` all layers already read (RFC-062 §parity). No TUI/web work.
+
+## Notes
+
+- Convention: prompt seam in CLI layer (P3); `Prompter` fake at seam (P4); non-TTY/`--json` -> unchanged non-interactive path (P2, byte parity via `starter_config()`); ONE writer `write_project` + ONE gate-attach shape (P6) — NO second config write path.
+- **Dangling-rule trap (STORY-228 core validity concern)**: `blank_config().rules` MUST start EMPTY. Seeding `default_rules()` would reference `story/rfc/adr` that a from-scratch DAG need not contain -> `validate` errors on rules pointing at absent types. Rules are BUILT only from the user's authored parent-child steps, so every rule endpoint is a defined type by construction. Relation vocab is type-agnostic so `starter_relationships()` is safe.
+- **Naming parity trap (from 327)**: default the naming prompt to `{type}-{n:03}-{title}.md` (WITH `.md`), i.e. `starter_config().documents.naming.pattern`, not the story's suffix-less form.
+- **Ordering** (RFC-062 §"Ordering matters"): types -> (per-type lifecycle inside collector) -> parent-child rules -> gates. Gates can only attach after rules exist, and rules only reference already-defined types; the prompt sequence enforces this, not post-hoc validation. The collector's own per-type gate section stays inert during the types loop (no rules yet); real gating happens in the rules loop.
+- Require >=1 type before finishing (a zero-type config is degenerate); parent-child rule loop only offered when >=2 types exist.
+- Blank slate is opt-in: default the first-screen select to `starter` so the STORY-227 path stays the zero-effort default (RFC-062 step 7 "start from the starter DAG and tweak" as first choice).

--- a/docs/iterations/ITERATION-329-pick-from-list-prompts-and-multi-select-in-the-wizard-prompter.md
+++ b/docs/iterations/ITERATION-329-pick-from-list-prompts-and-multi-select-in-the-wizard-prompter.md
@@ -1,0 +1,96 @@
+---
+title: Pick-from-list prompts and multi_select in the wizard Prompter
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-229
+- blocks: ITERATION-331
+---
+
+# Iteration: pick-from-list prompts and `multi_select` in the wizard `Prompter`
+
+## Objective
+
+Wizard single-choice prompts become a real numbered chooser (number OR exact option text, out-of-list rejected + re-asked in real impl); add `multi_select` for choosing several (lifecycle states). CLI-only; engine untouched.
+
+## Satisfies
+
+STORY-229 AC group "Multi-select / pick-from-list prompts" (all three) + cross-cutting layering AC. Blank-default first screen -> Slice 2; colours -> Slice 3 (see Out of scope).
+
+## Context
+
+- Parent story + AC text: `docs/stories/STORY-229-interactive-init-wizard-ux-polish.md` (§Scope bullet 1, §"Multi-select / pick-from-list prompts"). Do NOT restate.
+- Convention principles 2/3/4: cited inline below.
+- Touch:
+  - `src/cli/wizard.rs` — `Prompter` trait, `StdinPrompter<R,W>`, `ScriptedPrompter`.
+  - `src/cli/config.rs` — `collect_type_interactive`, `collect_parent_child_rule` (select callsites + lifecycle-states loop).
+  - `src/cli/init.rs` — `run_init_interactive` "Start from" select; test scripts `full_scratch_answers`, `scratch_lifecycle_and_gate_reject_unknown_states`.
+  - `README.md` — interactive add-type flow prose (~L537-544) IF it documents prompt rendering.
+
+## Callsite inventory (ground truth — read before touching)
+
+Single-choice `select` callsites:
+1. `config.rs:283` — `select("Store", &[filesystem, github-issues, github-milestones, github-projects, git-ref, clickup-tasks], "filesystem")`. Static list. Return later parsed by `parse_store` (bails on unknown).
+2. `config.rs:295` — `select("Numbering", &[incremental, sqids, reserved], "incremental")`. Static. `parse_numbering`.
+3. `config.rs:301` — `select("Authorship", &[human, assisted, generated], default_authorship)`. Static. `parse_authorship`.
+4. `config.rs:345` — `select("Parent", &type_names, type_names[0])` inside outer re-ask loop (L344-350). Dynamic list.
+5. `config.rs:414` — `select("Rule", &rule_names, rule_names[0])` inside outer re-ask loop (L413-419). Dynamic.
+6. `config.rs:515` — `select("Severity", &[warning, error], "warning")`. Static. `parse_severity`.
+7. `config.rs:502` — `pick` closure `select(label, &type_names, type_names[0])` inside outer re-ask loop (L501-508); called for "Child type" (L510) and "Parent type" (L511). Dynamic.
+8. `init.rs:102` — `select("Start from", &[starter, scratch], "starter")`. Static.
+
+Lifecycle-states collection (the "multiple verbatim values" to migrate -> `multi_select`):
+- `config.rs:359-370` in `collect_type_interactive`: `loop { ask("Lifecycle state (blank to finish)", None) ... }`, blank-to-finish, guard "at least one state is required" when empty. Shared by BOTH `design_config_interactive` and `design_config_from_scratch` (both call `collect_type_interactive`).
+- Edges loop `config.rs:371-391` (`ask("Edge FROM:TO ...")` + `parse_edge`) is FROM:TO, NOT a list-pick -> LEAVE AS-IS this slice.
+
+## Design decisions (resolve before coding)
+
+- **Validation lives in the real impl only.** Trait doc + `StdinPrompter::select` reject out-of-list and re-prompt. `ScriptedPrompter::select` stays verbatim (principle 4 — fake returns queued answers, no validation). Consequence -> the existing OUTER re-ask loops for dynamic lists (callsites 4,5,7 at L344-350, L413-419, L501-508) MUST REMAIN: they are the seam the `ScriptedPrompter` tests drive (feeding `bogus`/`ghost` then a valid name). Removing them breaks `interactive_add_type_parent_only_from_existing`, `scratch_parent_child_rule_defined_types_and_severity`, etc. Real usage double-checks (select re-asks, outer loop re-checks) — harmless.
+- **Static-list callsites (1,2,3,6,8) have no outer loop today** — verbatim text is parsed later by `parse_*` which bails. Migration = real `select` now rejects out-of-list up front (friendlier, earlier). Scripted tests feed blanks (-> default) or exact option strings (`filesystem`/`incremental`/`generated`/`error`/`scratch`) — all still accepted, no answer changes.
+- **`multi_select` signature:** `fn multi_select(&mut self, label: &str, options: &[&str], defaults: &[&str]) -> Result<Vec<String>>`. When `options` is EMPTY (the lifecycle-states case — states are user-invented, not from a fixed set) it is freeform: split the one input line on `,`, trim, drop empties. When `options` is non-empty: accept comma-separated numbers and/or exact names (reject unknown in real impl). Blank input -> `defaults.to_vec()`.
+- **Lifecycle-states migration:** replace the L359-370 blank-to-finish loop with a single `multi_select("Lifecycle states", &[], &[])?` call, KEEPING the "at least one state is required" re-ask guard at the callsite (re-ask if returned Vec is empty).
+
+## Tasks
+
+1. **Trait (`wizard.rs`).** Update `Prompter::select` doc to specify numbered-chooser + out-of-list rejection (real impl). Add `fn multi_select(&mut self, label: &str, options: &[&str], defaults: &[&str]) -> Result<Vec<String>>` with doc.
+2. **`StdinPrompter` real impl (`wizard.rs`).** Rewrite `select` (L78-86): render numbered list (`1) opt` ... with `[default]` cue), read line, empty -> default, else resolve a 1-based number into `options` OR match exact option text; unknown -> print a rejection line and re-read (loop). Implement `multi_select`: if `options` empty, split line on `,` (trim, drop empties), blank -> `defaults`; else render numbered list, parse comma-separated tokens as numbers-or-names, reject any unknown token (re-read), blank -> `defaults`; return `Vec<String>` in input order, de-duplicated.
+3. **`ScriptedPrompter` fake (`wizard.rs`).** Keep `select` verbatim (blank -> default). Add `multi_select`: pop one queued answer, blank -> `defaults.to_vec()`, else split on `,` (trim, drop empties) -> `Vec<String>`. Update the struct doc comment (L89-91) to describe `multi_select` grammar.
+4. **Migrate lifecycle states (`config.rs`).** Replace `collect_type_interactive` L359-370 states loop with `multi_select("Lifecycle states", &[], &[])` + empty-guard re-ask. Leave edges loop untouched. (Static/dynamic `select` callsites need no code change beyond benefiting from the new real-impl validation; outer re-ask loops stay.)
+5. **Update scripted test grammar (states only).** Change every script that fed states as `"state", "state", ""` (blank-to-finish) to a single comma-joined answer:
+   - `config.rs::interactive_add_type_custom_lifecycle_reprompts_bad_edge`: `"draft","done",""` -> `"draft,done"` (edge lines unchanged).
+   - `config.rs::interactive_full_flow_matches_flag_chain`: `"draft","done","", "draft:done",""` -> `"draft,done","draft:done",""`.
+   - `init.rs::full_scratch_answers`: `"draft","accepted","","draft:accepted",""` -> `"draft,accepted","draft:accepted",""`.
+   - `init.rs::scratch_lifecycle_and_gate_reject_unknown_states`: `"draft","done",""` -> `"draft,done"` (edge re-ask lines unchanged).
+   Verify `design_all_defaults_equals_starter` / `interactive_add_type_matches_flag_call` still pass unchanged (blanks -> defaults; exact option strings still accepted).
+6. **New tests (`wizard.rs` `#[cfg(test)]` mod — construct `StdinPrompter { reader: Cursor<..>, writer: Vec<u8> }` directly; fields are private but same-module).**
+   - real `select`: input `"bogus\nfilesystem\n"` over options `[filesystem, git-ref]` -> returns `"filesystem"`; assert writer contains a re-prompt/rejection cue.
+   - real `select`: input `"2\n"` -> returns second option (number resolves to list).
+   - real `multi_select` (options non-empty): input `"1,3\n"` -> returns first+third; unknown token `"9\n"`/`"nope\n"` re-asks.
+   - real `multi_select` (options empty): input `"draft, accepted\n"` -> `vec!["draft","accepted"]` (trimmed).
+   - `ScriptedPrompter::multi_select`: queued `"a,b,c"` -> `vec!["a","b","c"]`; blank -> `defaults`.
+7. **Migration integration test (`config.rs`).** Add a test that `collect_type_interactive` with a `multi_select` states answer `"draft,review,done"` yields a lifecycle with all three states (drives via `ScriptedPrompter`), and that a blank states answer re-asks (empty-guard) before accepting a valid one.
+8. **README.** If the interactive add-type flow prose (~L537-544) narrates the prompt sequence, update the lifecycle-states step to "enter comma-separated states" and note single-choice prompts are now pick-from-list. No flag/CLI-surface change this slice, so the command tables (~L302, L329) are untouched.
+
+## Out of scope
+
+- Blank-by-default first screen + `--template starter` flag (STORY-229 "Blank-by-default" AC) -> Slice 2. `run_init_interactive`'s `select("Start from", ...)` keeps today's `starter`/`scratch` labels and `starter` default here.
+- Wizard colours / `src/cli/style.rs` wiring (STORY-229 "Wizard colours" AC) -> Slice 3.
+- Edges loop redesign (`config.rs:371-391`) — FROM:TO stays an `ask`+`parse_edge` loop.
+- Non-interactive `run()` and `--json` paths (`init.rs:65-68`) — untouched (principle 2).
+- Engine writers (`config_write`, `Config`) — untouched (principle 3).
+
+## Principles / conventions
+
+- **Principle 2 (parity):** non-interactive `run()` + `--json` byte-for-byte unchanged; scriptability preserved through `multi_select` (AC "remains fully scriptable via queued answers").
+- **Principle 3 (layering):** every change under `src/cli/`; engine untouched.
+- **Principle 4 (test seam):** `Prompter` trait is the only fake seam; validation added to `StdinPrompter` only, `ScriptedPrompter` stays verbatim; no other `Prompter` impls exist (only two, both in `wizard.rs`; `main.rs:38,674` construct `StdinPrompter::new()`).
+
+## Verification
+
+- `cargo test` green — all pre-existing `ScriptedPrompter`-driven tests in `config.rs` and `init.rs` pass after the states-grammar update; new wizard/config tests pass.
+- Boundary: real `select` fed an out-of-list value then a valid one returns the valid one and emitted a rejection line (proves re-prompt, not silent-accept). Real `multi_select` fed `"1,3"` returns exactly two selections (proves multi-capture).
+- `cargo run -- init` on a TTY (manual, if runnable): store/numbering/authorship/severity render numbered; lifecycle states accept one comma-separated line.
+

--- a/docs/iterations/ITERATION-329-pick-from-list-prompts-and-multi-select-in-the-wizard-prompter.md
+++ b/docs/iterations/ITERATION-329-pick-from-list-prompts-and-multi-select-in-the-wizard-prompter.md
@@ -1,7 +1,7 @@
 ---
 title: Pick-from-list prompts and multi_select in the wizard Prompter
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-20
 tags: []

--- a/docs/iterations/ITERATION-330-blank-by-default-init-wizard-with-template-starter.md
+++ b/docs/iterations/ITERATION-330-blank-by-default-init-wizard-with-template-starter.md
@@ -1,7 +1,7 @@
 ---
 title: Blank-by-default init wizard with --template starter
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-20
 tags: []

--- a/docs/iterations/ITERATION-330-blank-by-default-init-wizard-with-template-starter.md
+++ b/docs/iterations/ITERATION-330-blank-by-default-init-wizard-with-template-starter.md
@@ -1,0 +1,70 @@
+---
+title: Blank-by-default init wizard with --template starter
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-229
+---
+
+# Iteration: Blank-by-default init wizard with `--template starter`
+
+## Objective
+
+Interactive `init` wizard default first-screen -> BLANK DAG; opt into starter DAG via `lazyspec init --template starter`. Rename option `scratch`->`blank`. Non-interactive path byte-for-byte unchanged.
+
+## Satisfies
+
+STORY-229 AC "Blank-by-default + `--template starter`" (all 3 bullets). Resolves RFC-062 open question (first-screen choice vs separate command) -> flag-selected template.
+
+## Context
+
+- Parent story + full ACs: STORY-229 (`docs/stories/STORY-229-interactive-init-wizard-ux-polish.md`), scope bullet "Blank-by-default + `--template starter`".
+- RFC-062 (implements link on story) -> one-config-writing-path guarantee + parity contract.
+- Touch:
+  - `src/cli.rs` — clap `Commands::Init` variant (line 76). Add `--template` arg beside `non_interactive`/`json`.
+  - `src/main.rs` — dispatch block (lines 25-44). Destructure new `template` field; thread into interactive call.
+  - `src/cli/init.rs` — `run_init_interactive` (line 100): first-screen select + branch. Signature grows a template param. `run()` (line 65) NOT touched.
+  - `README.md` — init section (~line 144) + CLI table row (line 302).
+- Do NOT touch (load-bearing): `run()` (init.rs:65) writes `starter_config()`; `write_project`; engine.
+
+## Design decisions (bake into ACs)
+
+- `--template` values: only `starter`. Enforce at clap parse (`value_parser` w/ possible value `starter`) -> unknown value errors before any IO. Default = absent = blank.
+- `--template starter` PRE-SELECTS the starter designer -> wizard SKIPS first "Start from" screen, goes straight to `design_config_interactive(starter_config())`. No `--template` (or any non-`starter` future value handled by clap) -> first screen shown, default `blank`.
+- First screen options `["blank", "starter"]`, default `"blank"`. Choice `"blank"` -> `design_config_from_scratch`; `"starter"` -> `design_config_interactive(starter_config())`.
+- `--template` affects INTERACTIVE branch selection ONLY. Non-interactive/`--json`/non-TTY -> `run()` -> `starter_config()`, never consults `--template`. `--template` w/ `--non-interactive` = silently ignored (acceptable; `run()` already writes starter).
+
+## Tasks
+
+1. `src/cli.rs`: add `template: Option<String>` (or dedicated enum) to `Commands::Init` w/ `#[arg(long, value_parser = ["starter"])]` and doc comment (only `starter` supported; default blank). Order after `json`.
+2. `src/main.rs`: extend the `Commands::Init { non_interactive, json }` destructure (line 25-28) to bind `template`; pass `template.as_deref()` into `run_init_interactive`. Non-interactive branch (`run(&cwd)`) unchanged.
+3. `src/cli/init.rs` `run_init_interactive`: add param `template: Option<&str>`. If `template == Some("starter")` -> skip select, `config = design_config_interactive(starter_config(), prompter)?`. Else `select("Start from", &["blank", "starter"], "blank")`; `"starter"` -> starter designer, else (`"blank"`/default) -> `design_config_from_scratch(prompter)?`. Update the fn doc comment (lines 95-99).
+4. `src/cli/init.rs` tests: fix callers of `run_init_interactive` (`init_bails_when_config_exists` ~line 554, `scratch_decline_writes_nothing` ~line 952) to pass the new `None` template arg. In `scratch_decline_writes_nothing` rename first-screen answer `"scratch"` (line 935) -> `"blank"`.
+5. Add tests: (a) `--template starter` (call `run_init_interactive(root, &mut p, Some("starter"))`) routes to starter designer WITHOUT consuming a first-screen answer (script starts at author prompt) and produces starter types; (b) no template -> first-screen default `"blank"` routes to from-scratch designer (queue blank first answer, then a minimal scratch script).
+6. `README.md`: init section (~144) — document blank-default first screen + `lazyspec init --template starter`; CLI table row (line 302) — replace "offering two paths -- tweak the starter DAG or design one from scratch" wording w/ blank-default + `--template starter`; note `--non-interactive`/`--json`/non-TTY still write starter config unchanged.
+
+## Out of scope
+
+- Pick-from-list `Prompter`/`multi_select` prompts -> STORY-229 slice 1.
+- Wizard colours (`src/cli/style.rs`) -> STORY-229 slice 3.
+- Wiring `--template` into non-interactive `run()` — explicitly excluded (parity).
+- TUI/web: none (CLI-only; wizard emits standard `.lazyspec.toml`).
+
+## Principles / conventions
+
+- CLAUDE.md: update README when CLI interface changes (task 6).
+- RFC-062 / STORY-229 Principle 2 (parity): non-interactive + `--json` byte-for-byte identical to today; `run()` untouched — THE load-bearing constraint. Guarded by existing `init_noninteractive_writes_starter` (init.rs:516) + `json_suppresses_interactive` (init.rs:526), both must pass unchanged.
+- Principle 3 (layering): CLI layer only; engine untouched.
+- Principle 4 (test seam): every flow scriptable via `ScriptedPrompter`; `--template starter` path scriptable via the flag.
+
+## Verification
+
+- `cargo test` — `init_noninteractive_writes_starter` + `json_suppresses_interactive` pass UNCHANGED (parity proof).
+- New test: `--template starter` reaches starter designer without a queued first-screen answer.
+- New test: default (no flag, blank first answer) -> from-scratch designer.
+- `cargo run -- init --template bogus` errors at clap parse (unknown value).
+- README init section + table row mention blank default and `--template starter`.
+

--- a/docs/iterations/ITERATION-331-colourise-init-wizard-prompts-and-dag-summary.md
+++ b/docs/iterations/ITERATION-331-colourise-init-wizard-prompts-and-dag-summary.md
@@ -1,0 +1,70 @@
+---
+title: Colourise init wizard prompts and DAG summary
+type: iteration
+status: in-progress
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-229
+---
+
+# Iteration: Colourise init wizard prompts and DAG summary
+
+## Objective
+
+Wire `src/cli/style.rs` colour helpers into interactive `init` wizard prompts + `render_dag_summary`; plain-text fallback when colours off. Presentation only.
+
+## Satisfies
+
+STORY-229 "Wizard colours" ACs (both):
+- colour-capable TTY -> prompts + DAG summary use `src/cli/style.rs` helpers.
+- colours off (`colors_enabled()` false: piped, `NO_COLOR`, non-TTY, `--json`) -> plain text, zero ANSI escapes.
+
+Cross-cutting: layering AC (all in `src/cli/`, engine untouched); one config-writing path unchanged.
+
+## Context
+
+- Story + AC text: STORY-229 (`docs/stories/STORY-229-interactive-init-wizard-ux-polish.md`), "Wizard colours" block.
+- Parent spec: RFC-062 (one-config-writing-path + parity contract). Point, don't restate.
+- Colour helpers (READ, reuse): `src/cli/style.rs` -> `bold(text)`, `dim(text)`, `type_header(&DocType)`, `separator()`, `error_prefix()`, `warning_prefix()`, `styled_status(...)`. All route through `console::colors_enabled()` already (see `separator`/`error_prefix`/`warning_prefix` bodies -> plain branch when false). Pattern to copy for new helpers: `if colors_enabled() { styled } else { plain }`.
+- Prompt strings (TOUCH): `src/cli/wizard.rs` -> `StdinPrompter::ask`/`confirm`/`select` build plain `format!` prompts (~lines 54-86). Colour goes on label + default/hint here. `ScriptedPrompter` emits no output -> leave untouched.
+- Init flow (TOUCH): `src/cli/init.rs`:
+  - `render_dag_summary` (~242): plain `writeln!` builder returning `String`. Colourise here.
+  - `run_init_interactive` (~100): "Start from" flow -> section transitions.
+  - `write_project` (~91): success line `Initialized lazyspec in {}`.
+  - inline msgs: `"discarded; starting over"` (~163, ~234), `"at least one type is required"` (~214).
+
+## Tasks
+
+1. Add to `src/cli/style.rs` (only if a plain `bold`/`dim` compose won't do): small `colors_enabled()`-aware wizard helpers, each with a plain fallback branch:
+   - `section_header(text: &str) -> String` — styled section divider for flow transitions (reuse `separator()` idiom; plain = the text as-is or `--- text ---`).
+   - `prompt_label(label: &str) -> String` — bold label for `StdinPrompter` (plain = `label` verbatim).
+   - `success_line(text: &str) -> String` — success cue (e.g. green check prefix, mirror `error_prefix`/`warning_prefix` shape; plain = `text`).
+   Keep signatures generic (`&str`), no engine imports beyond existing.
+2. `src/cli/wizard.rs` `StdinPrompter` only: route the label (and `[default]`/`[Y/n]`/`(opts) [default]`) through the style helpers in `ask`/`confirm`/`select`. Style the label bold, defaults/hints `dim`. Preserve exact trailing `: ` and bracket layout so scripted parity + read parsing unaffected. `ScriptedPrompter` unchanged.
+3. `src/cli/init.rs`:
+   - `render_dag_summary`: type names `bold`, edges/gates/dirs/prefixes `dim`, the `Types:`/`Parent-child rules:`/`Relation vocabulary:` headers via `section_header` (or `bold`). Keep the returned-`String` shape and field order identical.
+   - `run_init_interactive`: wrap "Start from" transition with a `section_header`.
+   - `write_project` success line -> `success_line`.
+   - warn/error inline msgs -> prepend `warning_prefix()` / `error_prefix()` (`at least one type is required` = warning; `discarded; starting over` = warning/dim).
+4. Tests (in `src/cli/init.rs` `#[cfg(test)]` and/or `src/cli/style.rs`): add a plain-parity test asserting no ESC (`\x1b`) in rendered output when colours disabled, and that content is byte-identical to today's plain form. See Verification for the `colors_enabled()` toggle mechanism.
+
+## Out of scope
+
+- Slice 1 (pick-from-list / `multi_select` on `Prompter`): deferred. **Dependency:** this slice edits the same `StdinPrompter` prompt-building code slice 1 touches — land slice 1 first to avoid churn.
+- Slice 2 (blank-by-default first screen + `--template starter`): deferred.
+- Non-interactive `run()` / `starter_config()` write path: unchanged (parity).
+- Any engine change, TUI, web view.
+
+## Principles / conventions
+
+- CLAUDE.md: dogfood via `cargo run`; update README only if CLI surface changes (this slice adds none — colour is automatic).
+- RFC-062 Principle 2 (parity): `--json`/non-TTY produce zero colour; output content byte-for-byte unchanged. Principle 3 (layering): all edits under `src/cli/`; engine untouched. Principle 4 (test seam): colour is presentational, not a `Prompter` behaviour change — `ScriptedPrompter` produces no output and stays as-is.
+- Global: no comments restating code; keep new helpers terse.
+
+## Verification
+
+- Assert plain parity with colours forced off. `console::colors_enabled()` reads global state; set it deterministically in tests via `console::set_colors_enabled(false)` before rendering, and assert `!summary.contains('\u{1b}')` plus equality against the known plain string. (If a global toggle proves flaky across tests, gate the assertion on `colors_enabled()` already being false under `cargo test`'s non-TTY stdout — the default — and additionally add an explicit `set_colors_enabled(true)` case asserting an ESC IS present, then reset.)
+- Existing `scratch_summary_lists_dag` (init.rs ~856) must still pass: its `summary.contains("rfc")`, `"draft -> accepted"`, `"story -> rfc"`, `"parent status = accepted"`, `"implements"` substring assertions must survive colourisation — so do NOT inject ANSI mid-substring in the plain path, and ensure the styled path still contains those raw substrings (ANSI wraps whole tokens, not split them). Run `cargo test` (or `cargo run` build if warnings block) and confirm the full init/style suites green.
+

--- a/docs/iterations/ITERATION-331-colourise-init-wizard-prompts-and-dag-summary.md
+++ b/docs/iterations/ITERATION-331-colourise-init-wizard-prompts-and-dag-summary.md
@@ -1,7 +1,7 @@
 ---
 title: Colourise init wizard prompts and DAG summary
 type: iteration
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-20
 tags: []

--- a/docs/iterations/ITERATION-332-spinner-framework-and-face-in-src-spinners-rs.md
+++ b/docs/iterations/ITERATION-332-spinner-framework-and-face-in-src-spinners-rs.md
@@ -1,7 +1,7 @@
 ---
 title: "Spinner framework and face in src/spinners.rs"
 type: iteration
-status: draft
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [foundation]

--- a/docs/iterations/ITERATION-332-spinner-framework-and-face-in-src-spinners-rs.md
+++ b/docs/iterations/ITERATION-332-spinner-framework-and-face-in-src-spinners-rs.md
@@ -1,0 +1,52 @@
+---
+title: "Spinner framework and face in src/spinners.rs"
+type: iteration
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [foundation]
+related:
+- implements: STORY-230
+---
+
+# Iteration: Spinner framework and face in src/spinners.rs
+
+## Objective
+
+New pure crate-root `src/spinners.rs`: `Spinner` trait + registry + `FaceSpinner` frames + tests. No I/O, no ratatui/crossterm. Foundation for all other slices.
+
+## Satisfies
+
+STORY-230 AC1 (framework). Partial: purity precondition for the `FrameColour`→terminal ACs (mapping itself deferred to consumers).
+
+## Context
+
+- Story + AC: STORY-230.
+- Design (types, frame catalogue, ASCII fallback): RFC-063 §Design, §"The face — frame catalogue". Point, don't restate.
+- Placement rationale: RFC-063 ADR "spinner logic lives at crate root". Register `mod spinners;` in crate root (`src/main.rs` / lib root beside existing root modules).
+
+## Tasks
+
+1. New `src/spinners.rs`; `mod spinners;` at crate root.
+2. Types: `SpinnerState {Idle,Loading,Success,Error}`, `FrameColour {Accent,Dim,Success,Error}`, `Frame { lines: Vec<String>, colour: FrameColour }`.
+3. `trait Spinner { fn compact(&self, state: SpinnerState, idx: u64) -> Frame; fn full(&self, state: SpinnerState, idx: u64) -> Frame; }`.
+4. `struct FaceSpinner { ascii: bool }` impl per RFC-063 catalogue: idle 2f, loading 4f, success/error 1f held. `idx % cycle_len`. Unicode + ASCII glyph sets.
+5. Registry `fn spinner(name: &str) -> &'static dyn Spinner`, default `"face"`.
+
+## Test Plan
+
+- idx→frame per state (all 4), cycle wrap at boundary.
+- ASCII set selected when `ascii=true`; no non-ASCII bytes in output.
+- Box-width invariant: every `full` frame = equal line count + equal display width across all states/frames.
+- Registry returns `FaceSpinner` for `"face"` + default.
+
+## Notes / conventions
+
+- Convention dictum 3: crate-root module, not `engine`; no CLI/TUI dep.
+- Dictum 6: registry indirection accepted — RFC goal is pluggable spinners (stated exception).
+- No `FrameColour`→`Style`/ANSI here; consumers own it (333/334).
+
+## Out of scope
+
+- All wiring: TUI overlay 333, TUI header 336, CLI spinner 334, greeting 335.
+- Colour→terminal mapping. Extra spinner styles.

--- a/docs/iterations/ITERATION-333-tui-create-overlay-loading-face.md
+++ b/docs/iterations/ITERATION-333-tui-create-overlay-loading-face.md
@@ -1,0 +1,51 @@
+---
+title: "TUI create-overlay loading face"
+type: iteration
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [tui]
+related:
+- implements: STORY-230
+---
+
+# Iteration: TUI create-overlay loading face
+
+## Objective
+
+Full-box face in the TUI create overlay: animate loading off the render loop; show success/error on finish.
+
+## Satisfies
+
+STORY-230 AC2 (loading animates), AC3 (success/error on finish), colour AC (`FrameColour`→`ratatui::Style`).
+
+## Context
+
+- Story + AC: STORY-230. Design: RFC-063 §Design (TUI). Point, don't restate.
+- Foundation (consume): `src/spinners.rs` (ITERATION-332) — `spinner("face").full(state, idx)`.
+- Overlay render (TOUCH): `src/tui/views/overlays.rs:131-136` (status line).
+- Form state (TOUCH): `src/tui/state/forms.rs:55` (`loading`, `status_message`); add `state: SpinnerState`.
+- Progress source (READ): create thread `src/tui/state/app.rs:2444-2486`; `AppEvent::CreateProgress` handler `src/tui/infra/event_loop.rs:590-593`; `ReservationProgress` enum `src/engine/reservation.rs:14-42`.
+- Clock (READ): render loop `event_loop.rs:751-799`, `loop_count:751`.
+
+## Tasks
+
+1. Map `ReservationProgress`→`SpinnerState`: `QueryingRemote|PushAttempt|PushRejected`→`Loading`; `Reserved`→`Success`; create error→`Error`. Store on create-form when handling `CreateProgress` (event_loop.rs:590-593).
+2. Surface frame idx into `draw`: pass `loop_count` (or store on `App`).
+3. `overlays.rs`: while `form.loading`, render `spinner("face").full(form.state, idx)` above/replacing the status line.
+4. `FrameColour`→`ratatui::Style` helper (TUI side): `Accent`→default fg, `Dim`→`Modifier::DIM`, `Success`→`Green`, `Error`→`Red`. No hex.
+5. Hold success/error frame briefly on finish (reuse existing dismissal timing).
+
+## Test Plan
+
+- Unit: `ReservationProgress`→`SpinnerState` map; `FrameColour`→`Style` map.
+- Manual TUI: create into remote store → loading animates, success face on done, error face on failure.
+
+## Notes / conventions
+
+- Dictum 3: TUI-only; no CLI dep. Dictum 6: reuse 332, no new abstraction.
+- Only `Loading` animates; success/error held.
+
+## Out of scope
+
+- Header face (336). CLI (334/335). Idle state (overlay hidden when not loading).

--- a/docs/iterations/ITERATION-333-tui-create-overlay-loading-face.md
+++ b/docs/iterations/ITERATION-333-tui-create-overlay-loading-face.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI create-overlay loading face"
 type: iteration
-status: draft
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [tui]

--- a/docs/iterations/ITERATION-334-cli-operation-spinner-via-indicatif-for-create-fetch-prune.md
+++ b/docs/iterations/ITERATION-334-cli-operation-spinner-via-indicatif-for-create-fetch-prune.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI operation spinner via indicatif for create fetch prune"
 type: iteration
-status: draft
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [cli]

--- a/docs/iterations/ITERATION-334-cli-operation-spinner-via-indicatif-for-create-fetch-prune.md
+++ b/docs/iterations/ITERATION-334-cli-operation-spinner-via-indicatif-for-create-fetch-prune.md
@@ -1,0 +1,55 @@
+---
+title: "CLI operation spinner via indicatif for create fetch prune"
+type: iteration
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [cli]
+related:
+- implements: STORY-231
+---
+
+# Iteration: CLI operation spinner via indicatif for create fetch prune
+
+## Objective
+
+Animate the compact face during `create`/`fetch`/prune network waits via `indicatif` steady-tick; guard `--json`/non-TTY; draw to stderr.
+
+## Satisfies
+
+STORY-231 AC1 (spinner + finish glyph), AC2 (json/non-TTY unchanged bytes), AC3 (steady-tick motion), AC4 (stderr, clean teardown), colour AC (`FrameColour`→ANSI).
+
+## Context
+
+- Story + AC: STORY-231. Design: RFC-063 §Design (CLI). Point, don't restate.
+- Dep (already present): `indicatif` `Cargo.toml:45` (unused today).
+- Foundation (consume): `src/spinners.rs` (ITERATION-332) — compact frames.
+- Create hook (TOUCH): no-op closures `src/main.rs:194,207`; plumbing `src/cli/create.rs:19,44`.
+- Fetch hook (TOUCH): `src/cli/fetch.rs` `run` ~68-226.
+- Prune hook (TOUCH): `src/cli/reservations.rs:109-192` (already prints `PruneProgress` lines).
+- Progress enums (READ): `ReservationProgress`/`PruneProgress` `src/engine/reservation.rs:14-42`.
+- Colour: `console::colors_enabled()` + existing `src/cli/style.rs` idiom.
+
+## Tasks
+
+1. CLI helper (new `src/cli/spinner.rs`): `fn op_spinner(msg, json: bool) -> Option<ProgressBar>` — `None` if `json || !stderr.is_terminal()`; else `ProgressBar` on stderr, `enable_steady_tick(~120ms)`, `ProgressStyle` `tick_strings` = face compact loading frames.
+2. `FrameColour`→ANSI map (CLI side) via `console`/existing style helpers. No hex.
+3. Wire create closures `main.rs:194,207`: `on_progress` maps `ReservationProgress`→state, `pb.set_message`; `finish_with_message` green ✔ / abandon red ✗.
+4. `fetch.rs` + prune: wrap network span with `op_spinner`. Prune keeps its existing line output on the json/non-TTY path; spinner only when `Some`.
+5. Ensure clear/finish leaves stdout unsmeared.
+
+## Test Plan
+
+- `create --json` and piped (non-TTY): assert no ESC (`\x1b`), stdout bytes == pre-change (parity fixture).
+- Unit: `ReservationProgress`→`SpinnerState` map; `op_spinner` returns `None` under json/non-TTY.
+- Manual TTY: run each op → face animates, finishes ✔/✗.
+
+## Notes / conventions
+
+- Dictum 2 (parity): json/non-TTY → zero animation, bytes unchanged.
+- Dictum 3: CLI-only, engine untouched. Dictum 5: reuse `indicatif` idioms.
+- Motion from steady-tick, not `on_progress` (fires only on state change; op blocking).
+
+## Out of scope
+
+- Init greeting (335). TUI (333/336). New spinner styles.

--- a/docs/iterations/ITERATION-335-init-wizard-talking-face-greeting.md
+++ b/docs/iterations/ITERATION-335-init-wizard-talking-face-greeting.md
@@ -1,0 +1,48 @@
+---
+title: "Init wizard talking face greeting"
+type: iteration
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [cli]
+related:
+- implements: STORY-231
+---
+
+# Iteration: Init wizard talking face greeting
+
+## Objective
+
+Talking full-box face greets interactive `init` (eyes/mouth cycle per word, rest happy); suppressed under `--json`/non-TTY.
+
+## Satisfies
+
+STORY-231 AC5 (talking greeting + guard), colour AC (`FrameColour`→ANSI).
+
+## Context
+
+- Story + AC: STORY-231. Design: RFC-063 §Design (CLI greeting); Houston `say` pattern. Point, don't restate.
+- Foundation (consume): `src/spinners.rs` (ITERATION-332) — `full` frames + face glyph sets.
+- Init flow (TOUCH): `src/cli/init.rs` `run_init_interactive` ~100; `write_project` ~91.
+- Guard: `console::colors_enabled()` / `is_terminal()` (existing `src/cli/style.rs`).
+- ANSI colour map: reuse ITERATION-334 `FrameColour`→ANSI.
+
+## Tasks
+
+1. Hand-rolled `fn say(msg: &str)` in CLI (new; NOT indicatif): render full-box face, cycle eyes/mouth per word (`sleep` 75-200ms), redraw in place (crossterm cursor / reprint). Settle on the success/happy face.
+2. Call at start of `run_init_interactive`; guard `stdout.is_terminal() && !json && colors_enabled()`.
+3. `FrameColour`→ANSI reuse.
+
+## Test Plan
+
+- `init --json` and piped: assert no greeting emitted, no ESC.
+- Manual TTY: greeting talks then rests.
+
+## Notes / conventions
+
+- Dictum 2: json/non-TTY → no output. Dictum 3: CLI-only.
+- Greeting is bespoke animation (per-word), distinct from op steady-tick (334) — hand-rolled per RFC ADR.
+
+## Out of scope
+
+- Op spinners (334). TUI (333/336). Multi-message queue (single greeting only).

--- a/docs/iterations/ITERATION-335-init-wizard-talking-face-greeting.md
+++ b/docs/iterations/ITERATION-335-init-wizard-talking-face-greeting.md
@@ -1,7 +1,7 @@
 ---
 title: "Init wizard talking face greeting"
 type: iteration
-status: draft
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [cli]

--- a/docs/iterations/ITERATION-336-tui-header-sync-and-push-face.md
+++ b/docs/iterations/ITERATION-336-tui-header-sync-and-push-face.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI header sync and push face"
 type: iteration
-status: draft
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [tui]

--- a/docs/iterations/ITERATION-336-tui-header-sync-and-push-face.md
+++ b/docs/iterations/ITERATION-336-tui-header-sync-and-push-face.md
@@ -1,0 +1,50 @@
+---
+title: "TUI header sync and push face"
+type: iteration
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [tui]
+related:
+- implements: STORY-230
+---
+
+# Iteration: TUI header sync and push face
+
+## Objective
+
+Compact face top-right reflecting GitHub poll/push: loading while in flight, brief success, then idle.
+
+## Satisfies
+
+STORY-230 AC4 (poll/push loading face), AC5 (idle/success static, no churn), colour AC.
+
+## Context
+
+- Story + AC: STORY-230. Design: RFC-063 §Design (TUI). Point, don't restate.
+- Foundation (consume): `src/spinners.rs` (ITERATION-332) — `spinner("face").compact(state, idx)`.
+- Header render (TOUCH): `src/tui/views.rs:150-180` (`right_spans`); existing `sync_indicator_text:45-63`.
+- Flags (READ/surface): `gh_push_in_flight` (used views.rs:165); `refresh_in_flight` `AtomicBool` `event_loop.rs:813`; `last_sync` set `event_loop.rs:564`.
+- Clock: `loop_count` (`event_loop.rs:751`).
+- Colour helper: reuse `FrameColour`→`Style` from ITERATION-333.
+
+## Tasks
+
+1. Surface `refresh_in_flight` onto `App` (mirror `AtomicBool`→`bool` each loop iteration, or hold the `Arc` and read in view).
+2. `views.rs` `right_spans`: derive `SpinnerState` — `Loading` if `refresh_in_flight || gh_push_in_flight`; `Success` if within N ms of `last_sync`; else `Idle`. Render `spinner("face").compact(state, idx)`.
+3. Idx used only for `Loading`; `Idle`/`Success` are static frames — cheap match, no per-tick recompute.
+4. Keep/relocate `sync_indicator_text` wording beside the face (face = activity, text = "synced Ns ago").
+
+## Test Plan
+
+- Unit: state-selection given (`refresh_in_flight`, `gh_push_in_flight`, `last_sync`) → `SpinnerState`.
+- Manual TUI: trigger poll/push → loading face; on complete → brief success → idle.
+
+## Notes / conventions
+
+- Dictum 3: TUI-only. Dictum 6: reuse 332/333 helpers.
+- Depends on ITERATION-333 for the `Style` mapper (land 333 first).
+
+## Out of scope
+
+- Create overlay (333). CLI (334/335). Reworking sync polling itself.

--- a/docs/iterations/ITERATION-337-dialoguer-backed-arrow-key-select-and-colourised-wizard-prompts.md
+++ b/docs/iterations/ITERATION-337-dialoguer-backed-arrow-key-select-and-colourised-wizard-prompts.md
@@ -1,0 +1,58 @@
+---
+title: Dialoguer-backed arrow-key select and colourised wizard prompts
+type: iteration
+status: complete
+author: Jack Kaloger
+date: 2026-07-20
+tags:
+- cli
+- wizard
+- ux
+related:
+- implements: STORY-229
+---
+<!-- intent: plan the concrete changes that satisfy a story's acceptance criteria -->
+
+## Objective
+
+Init wizard prompts navigate by ↑/↓ (Enter to pick, Space to toggle multiselect) and render coloured, replacing numbered typing + bold/dim-only styling.
+
+## Satisfies
+
+STORY-229 (wizard UX polish). Extends the colour work from ITERATION-331 — fixes root cause: prompts today use only `bold`/`dim` (no hue), `multi_select` unstyled (`src/cli/wizard.rs:130-142`).
+
+## Context
+
+- Story: STORY-229.
+- Seam: `Prompter` trait — `src/cli/wizard.rs:8` (`ask`/`confirm`/`select`/`multi_select`). Real impl `StdinPrompter` (`:38-167`); test fake `ScriptedPrompter` (`:206`).
+- Wizard is TTY-gated: `src/main.rs:668-669`. Real prompter only runs on a TTY.
+- Colour crate `console` (`Cargo.toml:35`) already in tree via `indicatif`. `dialoguer` builds on the same `console 0.15` → shares colour state, no new colour stack.
+- Callsites: `src/cli/init.rs`, `src/cli/config.rs` (add-type). Style helpers `src/cli/style.rs`.
+
+## Changes
+
+1. Add `dialoguer` dep (`cargo add dialoguer`, pin to the `console 0.15`-compatible line, e.g. `0.11`). No default `password`/`fuzzy` features needed.
+2. Reimplement `StdinPrompter` real path over dialoguer + `ColorfulTheme`, drawing to `console::Term`:
+   - `ask` → `Input`, `confirm` → `Confirm`, `select` → `Select`, `multi_select` → `MultiSelect` (empty-`options` freeform branch stays an `Input` split on `,`, per current contract wizard.rs:129-135).
+   - Preserve the trait contract exactly: blank→default, 1-based/exact resolution now handled by nav (no typed numbers), de-dup + input-order for multiselect.
+   - Drop the `R: BufRead, W: Write` generics on the real impl (dialoguer owns the terminal). `ScriptedPrompter` unchanged — remains the callsite test seam.
+3. Delete the now-redundant `StdinPrompter` Cursor-based re-ask/validation unit tests (wizard.rs:284-345) — dialoguer owns navigation/validation; don't re-test the library. Keep `ScriptedPrompter` tests.
+4. Update README wizard section (project rule: CLI-interface change → README): numbered prompts → arrow-key.
+
+## Test Plan
+
+- Callsite tests (`init.rs`, `config.rs`) via `ScriptedPrompter` stay green — prove wizard logic unchanged.
+- Manual (TTY): `cargo run -- init` → blank-slate designer; select prompts move on ↑/↓, multiselect toggles on Space, selection line coloured.
+- `--json` and non-TTY: wizard skipped (main.rs gate) → output bytes unchanged; assert existing non-interactive init tests unaffected.
+
+## Out of scope
+
+- TUI (no dialoguer in TUI layer — dictum 3).
+- Non-wizard CLI prompts; mascot RFC-063 spinners.
+- Changing `ScriptedPrompter` semantics or the `Prompter` trait signatures.
+
+## Notes
+
+- Key decision: real prompter becomes TTY-only (acceptable — wizard already gated main.rs:668). Dead non-TTY line path removed; trait seam + `ScriptedPrompter` keep tests hermetic (dictum 4).
+- `ColorfulTheme` uses `console`'s colour state → honours `NO_COLOR`/`CLICOLOR` automatically; no separate gate.
+- Principles: `.claude` conventions (TDD, trait seams for I/O — dictum 4; ecosystem norm over hand-roll — dictum 5).

--- a/docs/iterations/ITERATION-338-collect-remote-store-defaults-in-type-authoring-wizard.md
+++ b/docs/iterations/ITERATION-338-collect-remote-store-defaults-in-type-authoring-wizard.md
@@ -1,0 +1,66 @@
+---
+title: Collect remote-store defaults in type-authoring wizard
+type: iteration
+status: complete
+author: unknown
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-229
+---
+
+## Objective
+
+When the type-authoring wizard picks a remote store, prompt for that store's
+sensible defaults so the written `TypeDef` is sync-ready instead of hard-nulled.
+
+## Satisfies
+
+STORY-229 — extends its type-authoring wizard with a new capability
+(remote-store defaults). No prior STORY-229 AC covers this; new behaviour.
+
+## Context
+
+- Story: STORY-229 (init wizard UX polish — this adds capability, not polish)
+- RFC: docs/rfcs/RFC-062 (interactive config wizard + type authoring)
+- Prompter seam + conventions: src/cli/wizard.rs (Prompter/ScriptedPrompter)
+- Touch:
+  - src/cli/config.rs — CollectedType (add remote fields), collect_type_interactive
+    (store-conditional prompts), type_def_from_parts (thread fields, stop hard-nulling),
+    apply_collected_type, AddType clap args + run_add_type parity flags
+  - src/main.rs (~641) — wire new add-type flags
+  - README.md — document new prompts + flags
+
+## Tasks
+
+1. Extend `CollectedType` with `github_issue_tag`, `github_issue_type`,
+   `clickup_list_id` (`clickup_task_type` already threads).
+2. In `collect_type_interactive`, after store select, branch on chosen store:
+   - `clickup-tasks` → prompt clickup_list_id (blank allowed, fill later) + clickup_task_type
+   - `github-issues` → prompt github_issue_tag + github_issue_type
+   - others → collect nothing
+3. Thread the fields through `type_def_from_parts` (remove the unconditional
+   `None`s for github_issue_tag/type + clickup_list_id) and `apply_collected_type`.
+4. Add `--github-issue-tag`, `--github-issue-type`, `--clickup-list-id` flags to
+   `config add-type` + `run_add_type`; wire in src/main.rs (non-interactive parity).
+5. Test-first: ScriptedPrompter cases — clickup-tasks type captures list id + task
+   type; github-issues type captures tag + type; filesystem type prompts neither.
+6. README: new prompts + add-type flags.
+
+## Out of scope
+
+- github-milestones defaults (no meaningful per-type field).
+- clickup_custom_field_map / label_override collection.
+- Engine/TUI/web — CLI-only; no sync-logic change (fields already consumed by
+  clickup_cache.rs / sync.rs).
+
+## Principles/conventions
+
+- .lazyspec convention: --json/non-interactive byte-parity, layering (CLI only),
+  fakes only at the Prompter seam (principle 4).
+
+## Verification
+
+- clickup-tasks type built via wizard now writes clickup_list_id → no longer
+  errors at clickup_cache.rs:47 / sync.rs:234.
+

--- a/docs/iterations/ITERATION-339-interactive-add-type-talking-face-greeting.md
+++ b/docs/iterations/ITERATION-339-interactive-add-type-talking-face-greeting.md
@@ -1,0 +1,46 @@
+---
+title: "Interactive add-type talking face greeting"
+type: iteration
+status: complete
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [cli]
+related:
+- implements: STORY-231
+---
+<!-- intent: plan the concrete changes that satisfy a story's acceptance criteria -->
+
+## Objective
+
+Interactive `config add-type` greets with the talking full-box face, same as `init`.
+
+## Satisfies
+
+STORY-231 AC5 (talking greeting + `--json`/non-TTY guard), extended to the add-type wizard.
+
+## Context
+
+- Story + AC: STORY-231. `say` pattern already built (ITERATION-335).
+- Reuse (no new code): `spinner::say`, `spinner::should_greet` (`src/cli/spinner.rs`); `console::colors_enabled` (see `init.rs:117`).
+- Precedent (copy gate): `init.rs:117-118` — greet inside interactive flow, gated `should_greet(false, stdout.is_terminal(), colors_enabled())`.
+- TOUCH: `src/main.rs` `Config`/`AddType`/`AddTypeInvocation::Prompt` branch — greet AFTER the `interactive` guard, BEFORE `run_add_type_interactive`.
+
+## Changes
+
+1. `main.rs` Prompt branch: after `interactive` confirmed, `if should_greet(json, stdout.is_terminal(), colors_enabled()) { say("...let's add a document type"); }`. Import `console::colors_enabled`.
+2. Greeting stays at dispatch site (not inside `run_add_type_interactive`) → keeps that fn pure/`ScriptedPrompter`-driveable, no ESC in tests.
+
+## Test Plan
+
+- No new unit test: `should_greet` guard already covered (`spinner.rs`); greeting is terminal side-effect, not in the pure path.
+- Manual TTY: `config add-type` (no args) talks then prompts.
+- Guard: existing `ScriptedPrompter` add-type tests stay green (greeting not on their path).
+
+## Out of scope
+
+- Idle animation during prompts (deprioritised).
+- `set-lifecycle` / `add-gate` greetings (no interactive path).
+
+## Notes
+
+Dictum 2: guard suppresses under `--json`/non-TTY/no-colour — no ESC bytes reach machine-readable output.

--- a/docs/rfcs/RFC-062-interactive-config-wizard-project-bootstrap-and-type-authoring.md
+++ b/docs/rfcs/RFC-062-interactive-config-wizard-project-bootstrap-and-type-authoring.md
@@ -1,0 +1,123 @@
+---
+title: 'Interactive config wizard: project bootstrap and type authoring'
+type: rfc
+status: accepted
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- related-to: RFC-035
+---## Summary
+
+Add an **interactive config wizard** to lazyspec so a human can set up a project — or extend one — without hand-writing `.lazyspec.toml` or memorising the `config` flag grammar. Two entry points:
+
+1. **Project bootstrap** — `lazyspec init` on a TTY walks the user through designing the full type DAG (types, stores, lifecycles, gates, relations) instead of writing a fixed starter config.
+2. **Type authoring** — `lazyspec config add-type` on a TTY walks the user through one new type against an existing config.
+
+The wizard is a **thin interactive front end** over the existing engine writers (`config_write`, `init::starter_config`). It collects the same inputs the current flags accept and produces the same `.lazyspec.toml`; it adds no second config-writing path. Interactivity is a convenience layer, never a requirement — every flow the wizard drives remains fully scriptable via flags, and non-TTY / `--json` invocation keeps today's non-interactive behaviour byte-for-byte.
+
+## Motivation
+
+Today configuring lazyspec means one of:
+
+- `lazyspec init` — writes a fixed `starter_config()` (starter types + default rules). No choice; you take the shipped DAG or hand-edit TOML afterward.
+- `lazyspec config add-type <NAME> <PLURAL> <DIR> <PREFIX> [--flags…]`, then `config set-lifecycle`, then `config add-gate` — three separate one-shot commands whose flag grammar (`--attribute NAME:KIND[:required][:VAL,…]`, store names, numbering strategies) you must already know.
+- The `configure-type` **skill** — an agent interviews you and calls those same CLI writers. This is the *agent* path and works well, but it requires an agent in the loop.
+
+There is no path for a **human without an agent** to design a DAG interactively. They either accept the starter config or learn the flag grammar and the TOML schema. RFC-035 already anticipated this — it named a `lazyspec init` / `lazyspec setup` "interactive wizard with flag overrides" for `git-ref` dirs — but that wizard was never generalised to the full type DAG. This RFC delivers it.
+
+The wizard is the **human analogue of the `configure-type` skill**: same destination, same engine writers, driven by TTY prompts instead of an agent interview.
+
+## Goals
+
+- A human can bootstrap a complete, valid project config — full type DAG (types, lifecycles, gates, relations) — through guided prompts, no TOML knowledge required.
+- A human can add one well-formed type (with lifecycle, gate, attributes, relations) to an existing project through guided prompts.
+- The wizard writes through the **existing** engine writers; there is exactly one config-writing code path.
+- Scriptability is preserved: any flow the wizard drives is reachable non-interactively via flags, and non-TTY / `--json` invocation is unchanged.
+- Prompts validate inputs before they reach the engine (duplicate type names, unknown parent types, malformed attribute specs) and re-prompt rather than aborting.
+
+## Non-goals
+
+- Editing or migrating an **existing** type's lifecycle/gates/relations interactively (this RFC covers *add*, not *edit*). Out of scope; a follow-up.
+- Replacing or deprecating the `configure-type` skill or the non-interactive `config` subcommands. The wizard sits alongside them.
+- A TUI-based config editor. The wizard is line-oriented TTY prompting (stdin/stdout), not a ratatui screen.
+- Remote-store auth flows (`setup github-issues`, `setup clickup`). Those stay in `setup`; the wizard may *offer* to run them but does not reimplement them.
+- Reflowing existing documents when a lifecycle/type changes.
+
+## Design
+
+### Invocation model
+
+Interactivity is inferred, never mandatory:
+
+| Invocation | Behaviour |
+|---|---|
+| `lazyspec init` on a TTY, no flags | **Bootstrap wizard** |
+| `lazyspec init` non-TTY (piped/CI) | Current behaviour: write `starter_config()` |
+| `lazyspec init --non-interactive` | Force current behaviour on a TTY |
+| `lazyspec config add-type` on a TTY, **no positional args** | **Add-type wizard** |
+| `lazyspec config add-type <NAME> <PLURAL> <DIR> <PREFIX> …` | Current behaviour: one-shot from flags (never prompts) |
+| any flow with `--json` | Non-interactive; `--json` implies non-TTY |
+
+The rule: **presence of the disqualifying inputs (positional args, `--non-interactive`, non-TTY, `--json`) suppresses prompting.** A wizard only starts when it has nothing to work from and a human to ask. This keeps CI and scripted callers on exactly today's code path (Convention principle 2: agents consume the same interfaces as humans).
+
+TTY detection uses `std::io::IsTerminal` on stdin and stdout (both must be terminals). No new dependency for detection.
+
+### Layering (Convention principle 3)
+
+```
+CLI (src/cli/init.rs, src/cli/config.rs)
+  └─ wizard prompt module (src/cli/wizard/…)      ← NEW: prompting + validation loop only
+       └─ engine writers (config_write, init::starter_config)   ← unchanged
+```
+
+- The **wizard module lives in the CLI layer**, not the engine. It is I/O (reads stdin, writes prompts) and belongs where I/O formatting lives. The engine stays free of terminal assumptions (Convention principle 3: CLI/TUI depend on engine, never the reverse).
+- The wizard **constructs the same value objects** the flag parsers construct (`TypeDef`, lifecycle edges, gate specs) and hands them to the **same** `config_write` / `starter_config` functions. No engine change is required for the wizard to exist; if a writer needs a new entry point, that is a small, separately-justified engine addition, not a parallel path.
+- A thin **prompt trait** at the CLI seam (`Prompter`: `ask`, `select`, `confirm`, `ask_optional`) lets tests drive the wizard with a scripted fake instead of a real terminal (Convention principle 4: fakes only at trait seams). Real impl reads stdin; the fake replays a queue of answers.
+
+### Bootstrap wizard flow (full DAG designer)
+
+`lazyspec init` on a TTY:
+
+1. **Project basics** — default author (prefaults to git `user.name`), naming pattern (default `{type}-{n:03}-{title}`).
+2. **Types** — repeatedly: name, plural, dir (defaulted to `docs/<plural>`), prefix (defaulted to `NAME` upper), icon, store (`filesystem` / `github-issues` / `git-ref`, default filesystem), numbering, singleton?, authorship ceiling (`human`/`assisted`/`generated`). Each added type is echoed back; user adds another or finishes.
+3. **Lifecycle per type** — offer a standard preset (`draft → review → accepted → in-progress → complete` + `rejected`/`superseded`) accepted by default, or design custom states + edges.
+4. **Relations & DAG edges** — for each type, optionally pick a `parent_type` from already-defined types; define parent-child rules (`child needs parent`, severity warning/error) and `require_parent_status` gates.
+5. **Relation vocabulary** — default to `starter_relationships()`; advanced users can add named relations with inverses.
+6. **Review & confirm** — render the resulting DAG as a summary (types, edges, gates) and confirm before writing.
+7. **Write** — call the existing `init` machinery (create dirs, templates, skeletons, gitignore, gh labels) but seeded from the *designed* `Config` rather than `starter_config()`. Offer "start from the starter DAG and tweak" as the first choice so the blank slate is opt-in.
+
+Ordering matters: types before lifecycles before relations, because later steps reference earlier answers (a gate needs a parent type that already exists). The wizard resolves these dependencies in order and only offers valid targets at each step.
+
+### Add-type wizard flow
+
+`lazyspec config add-type` on a TTY with no positional args walks the single-type subset of the above: name/plural/dir/prefix/icon/store/numbering/singleton/authorship → attributes (`NAME:KIND[:required][:VAL,…]`, one at a time, validated) → optional lifecycle (else inherit the standard preset) → optional parent type + gate + relations. On confirm it calls the same functions `config add-type` + `config set-lifecycle` + `config add-gate` already call. It refuses (re-prompts) on a duplicate type name or unknown parent type.
+
+### Validation & re-prompt
+
+The wizard validates each answer against the engine's own rules *before* accepting it and re-prompts on failure rather than aborting a half-finished session: duplicate type/prefix, unknown parent type, malformed attribute spec, unknown store/numbering/authorship enum, a gate naming a non-existent status. Where the engine already exposes a validator, the wizard calls it; it does not reimplement validation.
+
+### `--json` and machine consumption
+
+`--json` implies non-interactive: it never prompts and preserves the current non-interactive output/behaviour. The wizard emits human-readable prose to stdout; it is not a `--json` producer. Agents continue to use the non-interactive flag interface and the `configure-type` skill (Convention principle 2 holds — the scriptable surface is unchanged and complete).
+
+### Documentation
+
+README updates: document TTY-triggered interactive mode for `init` and `config add-type`, the `--non-interactive` opt-out, and that flags/`--json`/non-TTY remain the canonical scriptable path. Note the wizard is the human counterpart to the `configure-type` skill.
+
+## Alternatives considered
+
+- **A dedicated wizard engine module with its own state machine.** Rejected: it would duplicate config-writing logic and risk a second, drifting path to `.lazyspec.toml`. The thin-front approach keeps one writer (Convention principle 6: indirection only for a second concrete use — there is only one config writer).
+- **An explicit `init --wizard` / `config add-type --interactive` subcommand only.** More predictable, but less discoverable, and it leaves the bare commands as sharp edges (a fixed starter or a flag wall). Auto-on-TTY with a `--non-interactive` escape hatch gives discoverability without breaking scripts.
+- **A ratatui TUI config editor.** Larger scope, and it fights the "line-oriented, pipe-friendly CLI" grain. Deferred; a TUI editor could layer on later over the same engine writers.
+- **Do nothing; rely on the `configure-type` skill.** Leaves humans-without-agents with only the starter config or the flag grammar. The skill is the agent path; this is the human path.
+
+## Open questions
+
+- Should the bootstrap wizard's "start from starter and tweak" vs "blank slate" be a first-screen choice (recommended) or two separate entry commands?
+- Should the add-type wizard offer to immediately create the type's first document, or stop at config? (Lean: stop at config; document creation is a separate verb.)
+- Prompt/validation ergonomics for lifecycle edge entry — free-form `from→to` pairs vs picking from a rendered state list. Resolve during story breakdown.
+
+## Impact on TUI / CLI / web (project constraint)
+
+This is a **CLI-only interactive feature**; the TUI and web view have no interactive-config surface today and gain none here. The wizard writes standard `.lazyspec.toml` that the TUI and web view already consume unchanged. No TUI/web parity work is required — the parity constraint is satisfied because there is no new *viewing* capability, only a new *authoring* entry point that produces the same artifact all three layers already read. README (the CLI's docs) is the only doc surface to update.

--- a/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
+++ b/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
@@ -1,0 +1,109 @@
+---
+title: "Animated spinner and mascot system for CLI and TUI loading states"
+type: rfc
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [tui, cli, ux]
+related: []
+---
+<!-- intent: propose a design and the decisions it forces, before code -->
+
+## Summary
+
+Add an extensible spinner framework at crate root (`src/spinners.rs`) plus a first mascot, **Specy** — a paper/document sprite with a face — driving every loading state across CLI and TUI. Same frame source feeds both layers; each maps colour to its own terminal type. Inspired by Astro `cli-kit`'s Houston, retargeted to lazyspec's doc-tool identity.
+
+## Motivation
+
+- Loading states today are invisible or static. CLI discards engine progress entirely (no-op `on_progress` closures, `main.rs:194,207`); TUI shows plain status text. `indicatif` is declared but unused (`Cargo.toml:45`).
+- Network round-trips block with no feedback: reservation git push, `gh` issue fetch, ClickUp reqwest, remote doc create.
+- A recognisable mascot gives lazyspec identity and makes waits legible. Houston proves the pattern works in a CLI.
+- Now: the interactive init wizard (RFC-062 line of work) already adds greetings/colour; a mascot lands naturally beside it.
+
+## Goals
+
+- One extensible framework: adding a new spinner = implementing one trait, no changes to call sites.
+- Specy renders 4 states — idle, loading, success, error — in a full-box form and a compact one-line form.
+- Cover all loading surfaces: TUI top-right sync/push indicator, TUI create overlay, CLI long-ops (create/fetch/prune), CLI init-wizard greeting.
+- Themed accent colour; dim/bold for state; green success, red error. Respect terminal theme.
+- `--json` and non-TTY emit no animation (dictum 2). Machine output unchanged.
+- Frame logic pure and unit-testable; no ratatui/crossterm in the logic.
+
+## Non-goals
+
+- No full event-expression map (creating vs validating vs thinking). Core states only; richer expressions deferred.
+- No gradient-shimmer colour sweep. Themed accent only.
+- No new async runtime for the CLI. Reuse blocking model + a ticker thread.
+- Not replacing the status-bar component system (RFC-022); Specy plugs into existing zones.
+
+## Design
+
+### Spinner framework (`src/spinners.rs`, crate root)
+
+Layer-agnostic pure module. Neither CLI nor TUI depends on the other; both depend on this. Not under `engine` (engine = doc logic only).
+
+- `enum SpinnerState { Idle, Loading, Success, Error }`
+- `enum FrameColour { Accent, Dim, Success, Error }` — semantic, no terminal type. Each layer maps to its own (`ratatui::Style` / ANSI).
+- `struct Frame { lines: Vec<String>, colour: FrameColour }` — full-box = multi-line; compact = single line.
+- `trait Spinner { fn compact(&self, state: SpinnerState, idx: u64) -> Frame; fn full(&self, state: SpinnerState, idx: u64) -> Frame; }`
+- `idx` = monotonic frame counter; each spinner mods it into its own cycle length. Caller owns the clock.
+- Registry: `fn spinner(name: &str) -> &'static dyn Spinner` (or lookup map), so future spinners register by name. `Specy` is the default.
+
+Extensibility test: a new spinner is a new type implementing `Spinner`, added to the registry — zero call-site edits.
+
+### Specy frames
+
+Full box:
+```
+ idle        loading      success      error
+┌──────┐   ┌──────┐    ┌──────┐    ┌──────┐
+│ - ‿ -│   │ ◔ ◡ ◔│    │ ◠ ◡ ◠│    │ x _ x│
+│≡≡≡   │   │≡≡≡   │    │≡≡≡≡≡ │    │≡≡~~~ │
+│≡≡    │   │≡     │    │≡≡≡≡≡ │    │≡     │
+└──────┘   └──────┘    └──────┘    └──────┘
+```
+Loading animates: eyes dart, doc-lines fill/scroll per frame. Compact one-line:
+```
+idle [·_·]   loading [◐ o··]→[◓ ·o·]→[◑ ··o]→[◒ ·o·]   ok [◠‿◠]   err [x_x]
+```
+
+### TUI wiring
+
+- Clock: existing ~16ms redraw loop (`event_loop.rs:752-799`); reuse `loop_count` (`:751`, currently unused) as `idx`. No new timer.
+- Top-right header (`views.rs:150-180`): replace/augment `right_spans`. Show Loading while `gh_push_in_flight` or poll `refresh_in_flight` active (surface that flag onto `App`); Success briefly after `last_sync`; else Idle.
+- Create overlay (`overlays.rs:131-136`): gate full-box Specy on `form.loading`; drive from `ReservationProgress` → `SpinnerState`.
+
+### CLI wiring
+
+- Wire `indicatif` (already a dep). `ProgressBar` with `enable_steady_tick` + custom `tick_strings` = Specy compact frames — gives ticker thread + TTY detection + clean teardown for free. Blocking create means `on_progress` only fires on state change, so the steady tick supplies motion.
+- Hooks: create closures (`main.rs:194,207`), fetch (`cli/fetch.rs`), prune (`cli/reservations.rs:109-192`). Map progress enums → `SpinnerState`; finish green ✔ / red ✗.
+- Greeting: hand-rolled full-box Specy "say" for the init wizard (Houston `say` equivalent) — talking page-sprite, then resting happy face.
+- All CLI spinners guard on `stdout.is_terminal() && !json`.
+
+## Interfaces
+
+- `@draft src/spinners.rs`: `SpinnerState`, `FrameColour`, `Frame`, `trait Spinner`, `struct Specy`, `fn spinner(name) -> &dyn Spinner`.
+- TUI: extend `App` with `refresh_in_flight: bool` (mirrored from event loop); `views.rs` maps `FrameColour` → `ratatui::Style`.
+- CLI: helper `fn op_spinner(label, json, tty) -> Option<ProgressBar>` mapping `FrameColour` → ANSI; used by create/fetch/prune.
+- No changes to `--json` output shape.
+
+## Decisions (ADRs to emit)
+
+- **ADR: spinner logic lives at crate root, not engine** — cosmetic/layer-agnostic; keeps engine = markdown logic (principle 1, 3).
+- **ADR: reuse `indicatif` for CLI, hand-roll greeting box** — indicatif can't render the multi-line page-sprite; use it for the ticker where it fits, hand-roll where it doesn't.
+- **ADR: caller-owned frame clock** — pure module takes `idx`; TUI feeds render-loop counter, CLI feeds steady-tick. No timer in the logic.
+
+## Stories
+
+1. **Spinner framework + Specy** — `src/spinners.rs`, trait, registry, Specy frames, unit tests. Foundation; blocks the rest.
+2. **TUI loading mascot** — header indicator + create overlay, animation off render loop. Depends on 1.
+3. **CLI operation spinners** — indicatif wiring for create/fetch/prune, TTY/json guards. Depends on 1.
+4. **CLI greeting mascot** — init-wizard "say" talking page-sprite. Depends on 1; pairs with STORY-229 wizard polish.
+
+## Risks and tradeoffs
+
+- **Unicode glyphs** (`◔ ◡ ≡ ◠`) may not render on all terminals → provide ASCII fallback set (mirror Houston `useAscii()`), pick via env/terminal capability.
+- **Redraw cost**: header now animates every 16ms even when idle. Mitigate: only animate in Loading; Idle/Success/Error are static frames.
+- **indicatif teardown** interleaving with normal stdout can smear output — draw to stderr, clear on finish.
+- **Colour on light themes**: use terminal-default accent + dim/bold, avoid hardcoded hex, so both light and dark themes stay legible.
+- Extensible registry is indirection for one concrete spinner today — justified by the explicit goal of pluggable future spinners (accepts principle 6 tension for a stated reason).

--- a/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
+++ b/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
@@ -11,7 +11,7 @@ related: []
 
 ## Summary
 
-Add an extensible spinner framework at crate root (`src/spinners.rs`) plus a first mascot, **Specy** — a paper/document sprite with a face — driving every loading state across CLI and TUI. Same frame source feeds both layers; each maps colour to its own terminal type. Inspired by Astro `cli-kit`'s Houston, retargeted to lazyspec's doc-tool identity.
+Add an extensible spinner framework at crate root (`src/spinners.rs`) plus a first spinner — an **abstract face** (a boxed two-eyes-and-mouth character) — driving every loading state across CLI and TUI. Same frame source feeds both layers; each maps colour to its own terminal type. Inspired by Astro `cli-kit`'s Houston, retargeted to lazyspec's doc-tool identity. No mascot name; it is "the face".
 
 ## Motivation
 
@@ -23,7 +23,7 @@ Add an extensible spinner framework at crate root (`src/spinners.rs`) plus a fir
 ## Goals
 
 - One extensible framework: adding a new spinner = implementing one trait, no changes to call sites.
-- Specy renders 4 states — idle, loading, success, error — in a full-box form and a compact one-line form.
+- The face renders 4 states — idle, loading, success, error — in a full-box form and a compact one-line form.
 - Cover all loading surfaces: TUI top-right sync/push indicator, TUI create overlay, CLI long-ops (create/fetch/prune), CLI init-wizard greeting.
 - Themed accent colour; dim/bold for state; green success, red error. Respect terminal theme.
 - `--json` and non-TTY emit no animation (dictum 2). Machine output unchanged.
@@ -34,7 +34,7 @@ Add an extensible spinner framework at crate root (`src/spinners.rs`) plus a fir
 - No full event-expression map (creating vs validating vs thinking). Core states only; richer expressions deferred.
 - No gradient-shimmer colour sweep. Themed accent only.
 - No new async runtime for the CLI. Reuse blocking model + a ticker thread.
-- Not replacing the status-bar component system (RFC-022); Specy plugs into existing zones.
+- Not replacing the status-bar component system (RFC-022); the face plugs into existing zones.
 
 ## Design
 
@@ -47,42 +47,71 @@ Layer-agnostic pure module. Neither CLI nor TUI depends on the other; both depen
 - `struct Frame { lines: Vec<String>, colour: FrameColour }` — full-box = multi-line; compact = single line.
 - `trait Spinner { fn compact(&self, state: SpinnerState, idx: u64) -> Frame; fn full(&self, state: SpinnerState, idx: u64) -> Frame; }`
 - `idx` = monotonic frame counter; each spinner mods it into its own cycle length. Caller owns the clock.
-- Registry: `fn spinner(name: &str) -> &'static dyn Spinner` (or lookup map), so future spinners register by name. `Specy` is the default.
+- Registry: `fn spinner(name: &str) -> &'static dyn Spinner` (or lookup map), so future spinners register by name. The face is the default.
 
 Extensibility test: a new spinner is a new type implementing `Spinner`, added to the registry — zero call-site edits.
 
-### Specy frames
+### The face — frame catalogue
 
-Full box:
+Full box. Inner width is a fixed 7 columns (`╭───────╮`); every glyph is single-width so all frames align exactly. Layout is `[left-eye] [mouth] [right-eye]`.
+
+**idle** — slow blink, 2 frames, ~600ms each:
 ```
- idle        loading      success      error
-┌──────┐   ┌──────┐    ┌──────┐    ┌──────┐
-│ - ‿ -│   │ ◔ ◡ ◔│    │ ◠ ◡ ◠│    │ x _ x│
-│≡≡≡   │   │≡≡≡   │    │≡≡≡≡≡ │    │≡≡~~~ │
-│≡≡    │   │≡     │    │≡≡≡≡≡ │    │≡     │
-└──────┘   └──────┘    └──────┘    └──────┘
+╭───────╮   ╭───────╮
+│ ● ▪ ● │   │ - ▪ - │
+╰───────╯   ╰───────╯
+  [1]         [2]
 ```
-Loading animates: eyes dart, doc-lines fill/scroll per frame. Compact one-line:
+
+**loading** — eye spin, 4 frames, ~120ms each:
 ```
-idle [·_·]   loading [◐ o··]→[◓ ·o·]→[◑ ··o]→[◒ ·o·]   ok [◠‿◠]   err [x_x]
+╭───────╮   ╭───────╮   ╭───────╮   ╭───────╮
+│ ◐ ○ ◐ │   │ ◓ ○ ◓ │   │ ◑ ○ ◑ │   │ ◒ ○ ◒ │
+╰───────╯   ╰───────╯   ╰───────╯   ╰───────╯
+  [1]         [2]         [3]         [4]
 ```
+
+**success** — 1 held frame:
+```
+╭───────╮
+│ ◠ ◡ ◠ │
+╰───────╯
+```
+
+**error** — 1 held frame:
+```
+╭───────╮
+│ × ▂ × │
+╰───────╯
+```
+
+Compact one-line form (TUI header, CLI inline). Same states, single cluster:
+
+| state    | frames                               |
+|----------|--------------------------------------|
+| idle     | `[·‿·]`                              |
+| loading  | `[◐‿◐]` `[◓‿◓]` `[◑‿◑]` `[◒‿◒]`       |
+| success  | `[◠‿◠]`                              |
+| error    | `[×_×]`                              |
+
+ASCII fallback set (mirrors Houston `useAscii()`), used when the terminal lacks Unicode: corners `+`, walls `-`/`|`, eyes `o`/`O`/`-`, mouths `o`/`_`/`-`, loading eyes cycle `|`/`/`/`-`/`\`.
 
 ### TUI wiring
 
 - Clock: existing ~16ms redraw loop (`event_loop.rs:752-799`); reuse `loop_count` (`:751`, currently unused) as `idx`. No new timer.
 - Top-right header (`views.rs:150-180`): replace/augment `right_spans`. Show Loading while `gh_push_in_flight` or poll `refresh_in_flight` active (surface that flag onto `App`); Success briefly after `last_sync`; else Idle.
-- Create overlay (`overlays.rs:131-136`): gate full-box Specy on `form.loading`; drive from `ReservationProgress` → `SpinnerState`.
+- Create overlay (`overlays.rs:131-136`): gate the full-box face on `form.loading`; drive from `ReservationProgress` → `SpinnerState`.
 
 ### CLI wiring
 
-- Wire `indicatif` (already a dep). `ProgressBar` with `enable_steady_tick` + custom `tick_strings` = Specy compact frames — gives ticker thread + TTY detection + clean teardown for free. Blocking create means `on_progress` only fires on state change, so the steady tick supplies motion.
+- Wire `indicatif` (already a dep). `ProgressBar` with `enable_steady_tick` + custom `tick_strings` = the face's compact frames — gives ticker thread + TTY detection + clean teardown for free. Blocking create means `on_progress` only fires on state change, so the steady tick supplies motion.
 - Hooks: create closures (`main.rs:194,207`), fetch (`cli/fetch.rs`), prune (`cli/reservations.rs:109-192`). Map progress enums → `SpinnerState`; finish green ✔ / red ✗.
-- Greeting: hand-rolled full-box Specy "say" for the init wizard (Houston `say` equivalent) — talking page-sprite, then resting happy face.
+- Greeting: hand-rolled full-box face "say" for the init wizard (Houston `say` equivalent) — talking face (eyes/mouth cycle per word), then resting happy face.
 - All CLI spinners guard on `stdout.is_terminal() && !json`.
 
 ## Interfaces
 
-- `@draft src/spinners.rs`: `SpinnerState`, `FrameColour`, `Frame`, `trait Spinner`, `struct Specy`, `fn spinner(name) -> &dyn Spinner`.
+- `@draft src/spinners.rs`: `SpinnerState`, `FrameColour`, `Frame`, `trait Spinner`, `struct FaceSpinner`, `fn spinner(name) -> &dyn Spinner`.
 - TUI: extend `App` with `refresh_in_flight: bool` (mirrored from event loop); `views.rs` maps `FrameColour` → `ratatui::Style`.
 - CLI: helper `fn op_spinner(label, json, tty) -> Option<ProgressBar>` mapping `FrameColour` → ANSI; used by create/fetch/prune.
 - No changes to `--json` output shape.
@@ -90,19 +119,19 @@ idle [·_·]   loading [◐ o··]→[◓ ·o·]→[◑ ··o]→[◒ ·o·]   o
 ## Decisions (ADRs to emit)
 
 - **ADR: spinner logic lives at crate root, not engine** — cosmetic/layer-agnostic; keeps engine = markdown logic (principle 1, 3).
-- **ADR: reuse `indicatif` for CLI, hand-roll greeting box** — indicatif can't render the multi-line page-sprite; use it for the ticker where it fits, hand-roll where it doesn't.
+- **ADR: reuse `indicatif` for CLI, hand-roll greeting box** — indicatif can't render the multi-line face box; use it for the ticker where it fits, hand-roll where it doesn't.
 - **ADR: caller-owned frame clock** — pure module takes `idx`; TUI feeds render-loop counter, CLI feeds steady-tick. No timer in the logic.
 
 ## Stories
 
-1. **Spinner framework + Specy** — `src/spinners.rs`, trait, registry, Specy frames, unit tests. Foundation; blocks the rest.
+1. **Spinner framework + the face** — `src/spinners.rs`, trait, registry, face frames, unit tests. Foundation; blocks the rest.
 2. **TUI loading mascot** — header indicator + create overlay, animation off render loop. Depends on 1.
 3. **CLI operation spinners** — indicatif wiring for create/fetch/prune, TTY/json guards. Depends on 1.
-4. **CLI greeting mascot** — init-wizard "say" talking page-sprite. Depends on 1; pairs with STORY-229 wizard polish.
+4. **CLI greeting face** — init-wizard "say" talking face. Depends on 1; pairs with STORY-229 wizard polish.
 
 ## Risks and tradeoffs
 
-- **Unicode glyphs** (`◔ ◡ ≡ ◠`) may not render on all terminals → provide ASCII fallback set (mirror Houston `useAscii()`), pick via env/terminal capability.
+- **Unicode glyphs** (`◐ ◓ ◑ ◒ ◠ ◡ ▪ ×`) may not render on all terminals → provide ASCII fallback set (mirror Houston `useAscii()`), pick via env/terminal capability.
 - **Redraw cost**: header now animates every 16ms even when idle. Mitigate: only animate in Loading; Idle/Success/Error are static frames.
 - **indicatif teardown** interleaving with normal stdout can smear output — draw to stderr, clear on finish.
 - **Colour on light themes**: use terminal-default accent + dim/bold, avoid hardcoded hex, so both light and dark themes stay legible.

--- a/docs/stories/STORY-225-add-a-document-type-interactively.md
+++ b/docs/stories/STORY-225-add-a-document-type-interactively.md
@@ -1,7 +1,7 @@
 ---
 title: Add a document type interactively
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-225-add-a-document-type-interactively.md
+++ b/docs/stories/STORY-225-add-a-document-type-interactively.md
@@ -1,0 +1,34 @@
+---
+title: Add a document type interactively
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- implements: RFC-062
+- blocks: STORY-226
+- blocks: STORY-227
+---> As a lazyspec user setting up a project, I want to run `config add-type` with no arguments on a terminal and answer a few prompts to add a document type, so that I don't have to memorise the flag grammar or the `.lazyspec.toml` schema.
+
+This is the **walking skeleton** for the config wizard (RFC-062): the thinnest end-to-end path that proves the whole interactive stack — TTY detection, the CLI-layer prompt seam, and reuse of the existing `config add-type` engine writer — while stubbing every richer flow (attributes, custom lifecycle, gates, relations) for later stories.
+
+## Scope
+
+- `lazyspec config add-type` invoked on a TTY **with no positional arguments** starts an interactive prompt sequence for the core fields: `name`, `plural`, `dir` (defaulted to `docs/<plural>`), `prefix` (defaulted to uppercased name), plus `icon`, `store`, `numbering`, `singleton`, `authorship` as prompts with defaults.
+- The wizard collects answers and calls the **same** engine writer the flag path already calls. No second config-writing path.
+- The new type inherits the standard lifecycle preset; **customising lifecycle/attributes/gates/relations is out of scope** (STORY-226).
+- Resolve RFC-062 open question: interactive prompting is **hand-rolled over stdin** unless a prompt crate is justified during implementation; TTY detection uses `std::io::IsTerminal`.
+
+## Acceptance criteria
+
+- **Given** a project with a config and a terminal, **when** I run `lazyspec config add-type` with no positional args, **then** I am prompted in order for name, plural, dir, prefix (dir/prefix pre-filled with defaults I can accept), and the type is appended to `.lazyspec.toml` identically to the equivalent flag invocation.
+- **Given** I enter a type name or prefix that already exists, **when** the wizard validates it, **then** it reports the clash and re-prompts rather than aborting or writing a duplicate.
+- **Given** stdin/stdout is **not** a terminal (piped, redirected, CI), **when** I run `config add-type` without the required positionals, **then** behaviour is unchanged from today (clap errors on the missing required args) — the wizard never starts.
+- **Given** I pass `--json` or the four positional args, **when** the command runs, **then** it is fully non-interactive and byte-for-byte identical to today.
+- **Given** the wizard completes, **then** the resulting config passes `lazyspec validate` (no malformed type written).
+
+## Non-functional / constraints
+
+- Prompting logic lives in the **CLI layer** (`src/cli/`), not the engine (Convention principle 3). A `Prompter` trait at the CLI seam allows a scripted fake in tests (principle 4); the real impl reads stdin.
+- README: document that `config add-type` prompts interactively on a TTY with no args, and that flags/`--json`/non-TTY remain the canonical scriptable path.

--- a/docs/stories/STORY-225-add-a-document-type-interactively.md
+++ b/docs/stories/STORY-225-add-a-document-type-interactively.md
@@ -1,7 +1,7 @@
 ---
 title: Add a document type interactively
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
+++ b/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
@@ -1,7 +1,7 @@
 ---
 title: 'Interactive add-type: attributes, lifecycle, gates and relations'
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
+++ b/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
@@ -1,7 +1,7 @@
 ---
 title: 'Interactive add-type: attributes, lifecycle, gates and relations'
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
+++ b/docs/stories/STORY-226-interactive-add-type-attributes-lifecycle-gates-and-relations.md
@@ -1,0 +1,33 @@
+---
+title: 'Interactive add-type: attributes, lifecycle, gates and relations'
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- implements: RFC-062
+---> As a lazyspec user adding a type, I want the interactive `config add-type` to also prompt me for attributes, a custom lifecycle, a parent type, a gate, and relations, so that I can author a fully-formed type — not just its core fields — without touching TOML.
+
+Builds on the walking skeleton (STORY-225), which established the prompt seam and core-field flow. This layers the full single-type design surface on top, driving the same `config add-type`, `config set-lifecycle`, and `config add-gate` engine writers the flag paths already use.
+
+## Scope
+
+- Extends the STORY-225 prompt flow with optional sections: **attributes**, **lifecycle**, **parent type + gate**, **relations**.
+- Attributes prompted one at a time in the engine's `NAME:KIND[:required][:VAL,…]` shape, validated per entry.
+- Lifecycle: accept the standard preset by default, or design custom states and `from→to` edges.
+- Parent type chosen only from types that already exist; optional `require_parent_status` gate; optional named relations.
+- Calls the existing `set-lifecycle` / `add-gate` writers — no new engine config path.
+
+## Acceptance criteria
+
+- **Given** the add-type wizard is running, **when** I choose to add an attribute and enter `priority:enum:low,medium,high`, **then** it is validated and written; **and** a malformed spec (unknown kind, enum without values) is rejected with a re-prompt.
+- **Given** I opt into a custom lifecycle, **when** I enter states and edges, **then** an edge naming a non-existent state is rejected and re-prompted; **and** if I decline, the type inherits the standard preset.
+- **Given** I set a parent type, **when** I am offered choices, **then** only already-defined types are offered, and an unknown parent cannot be entered.
+- **Given** I add a `require_parent_status` gate naming a status the parent lifecycle lacks, **then** it is rejected and re-prompted.
+- **Given** I complete the flow, **then** the written config passes `lazyspec validate`, and the same result is reachable non-interactively via `add-type` + `set-lifecycle` + `add-gate` flags.
+
+## Non-functional / constraints
+
+- Reuses the STORY-225 `Prompter` seam; all validation calls existing engine validators, never a reimplementation (principle 6).
+- README: document the extended interactive sections.

--- a/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
+++ b/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
@@ -1,0 +1,32 @@
+---
+title: Interactive project bootstrap from the starter config
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- implements: RFC-062
+- blocks: STORY-228
+---> As a person starting a new lazyspec project, I want to run `init` on a terminal and be walked through customising a config that starts from the shipped starter DAG — setting my author and naming and adding or dropping types — so that I get a config tailored to my project instead of the fixed starter, without editing TOML.
+
+Adds an interactive front to `init`, reusing the add-type prompt flow (STORY-225/226). Seeds prompts from `starter_config()` so the user tweaks a working DAG rather than facing a blank slate (the blank-slate designer is STORY-228).
+
+## Scope
+
+- `lazyspec init` on a TTY with no flags starts the **bootstrap wizard** in "start from starter and tweak" mode.
+- Prompts: default author (pre-filled from git `user.name`), naming pattern (default `{type}-{n:03}-{title}`), then per starter type an add/keep/drop choice, then "add another type" via the STORY-225/226 flow.
+- On confirm, the **existing** `init` machinery (create dirs, templates, skeletons, gitignore, gh labels) runs — but seeded from the *designed* `Config`, not `starter_config()`.
+
+## Acceptance criteria
+
+- **Given** a directory with no `.lazyspec.toml` and a terminal, **when** I run `lazyspec init`, **then** I am prompted for author and naming (defaults offered), shown the starter types to keep/drop, and can add new types before writing.
+- **Given** I accept every default, **then** the written config equals today's `starter_config()` output (parity escape hatch).
+- **Given** stdin/stdout is not a terminal, or I pass `--non-interactive`, **when** I run `init`, **then** it writes `starter_config()` exactly as today — no prompts.
+- **Given** `.lazyspec.toml` already exists, **then** `init` still bails as today (no interactive override).
+- **Given** the wizard completes, **then** the scaffolded project passes `lazyspec validate`, and directories/templates/skeletons match the designed types.
+
+## Non-functional / constraints
+
+- Reuses the STORY-225/226 `Prompter` seam and add-type flow; `init`'s wizard adds no second config writer.
+- README: document TTY-triggered interactive `init` and the `--non-interactive` opt-out.

--- a/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
+++ b/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
@@ -1,7 +1,7 @@
 ---
 title: Interactive project bootstrap from the starter config
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
+++ b/docs/stories/STORY-227-interactive-project-bootstrap-from-the-starter-config.md
@@ -1,7 +1,7 @@
 ---
 title: Interactive project bootstrap from the starter config
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
+++ b/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
@@ -1,0 +1,33 @@
+---
+title: 'Interactive bootstrap: full DAG designer from scratch'
+type: story
+status: accepted
+author: jkaloger
+date: 2026-07-19
+tags: []
+related:
+- implements: RFC-062
+---> As a person setting up a bespoke lazyspec project, I want the `init` wizard to let me design the entire type DAG from scratch — every type, lifecycle, gate, and relation — review it, and confirm before writing, so that I can bootstrap a config that owes nothing to the starter defaults.
+
+The full DAG designer (RFC-062). Layers a blank-slate path onto the STORY-227 bootstrap wizard, resolving the ordering dependencies between DAG design steps (types must exist before lifecycles reference them, before relations/gates reference both).
+
+## Scope
+
+- `init` wizard offers "blank slate" alongside STORY-227's "start from starter". Blank slate walks: **types → per-type lifecycle → parent types / parent-child rules / gates → relation vocabulary → review → write**.
+- Each step only offers targets that earlier steps have defined (a gate's parent, a relation's endpoints).
+- A rendered **DAG summary** (types, edges, gates, relations) is shown for confirmation before anything is written.
+
+## Acceptance criteria
+
+- **Given** the blank-slate path, **when** I add types then design lifecycles, **then** a lifecycle edge or gate can only reference a type/status already defined; invalid references are re-prompted.
+- **Given** I define a parent-child rule, **when** I pick the child and parent, **then** only already-defined types are offered, and I set severity (warning/error).
+- **Given** I finish designing, **when** the wizard renders the DAG summary, **then** it lists every type, its lifecycle, gates, and relations, and asks me to confirm before writing.
+- **Given** I confirm, **then** the written `.lazyspec.toml` passes `lazyspec validate` and the scaffolded dirs/templates match the designed DAG.
+- **Given** I decline at the summary, **then** nothing is written and no directories are created.
+- **Given** non-TTY / `--non-interactive`, **then** the blank-slate path is unreachable (STORY-227's non-interactive rule holds — writes `starter_config()`).
+
+## Non-functional / constraints
+
+- Ordering is enforced by the prompt sequence, not by post-hoc validation; the wizard resolves DAG dependencies as it goes.
+- Reuses the STORY-225/226/227 `Prompter` seam and type-authoring flow; still one config writer.
+- README: document the blank-slate DAG designer.

--- a/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
+++ b/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
@@ -1,7 +1,7 @@
 ---
 title: 'Interactive bootstrap: full DAG designer from scratch'
 type: story
-status: accepted
+status: in-progress
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
+++ b/docs/stories/STORY-228-interactive-bootstrap-full-dag-designer-from-scratch.md
@@ -1,7 +1,7 @@
 ---
 title: 'Interactive bootstrap: full DAG designer from scratch'
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-19
 tags: []

--- a/docs/stories/STORY-229-interactive-init-wizard-ux-polish.md
+++ b/docs/stories/STORY-229-interactive-init-wizard-ux-polish.md
@@ -1,0 +1,58 @@
+---
+title: Interactive init wizard UX polish
+type: story
+status: in-progress
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: RFC-062
+---
+
+> As a lazyspec user bootstrapping a project with the interactive `init` wizard, I want to pick options from a list instead of retyping them, start from a blank DAG by default (opting into the starter with a flag), and read colour-cued prompts, so that the wizard is faster, less error-prone, and easier to follow — without changing anything scripts and CI already rely on.
+
+This story polishes the **already-shipped** interactive `init` wizard (delivered by STORY-225 through STORY-228). It carries no new engine capability: it improves how the existing CLI-layer wizard *presents* choices, what it defaults to, and how it reads. It is deliberately sliced into three cohesive, independently observable UX improvements (which will become three iterations). All three keep RFC-062's one-config-writing-path guarantee and the non-interactive/`--json` byte-for-byte contract.
+
+## Scope
+
+- **Pick-from-list prompts.** Extend the `Prompter` trait (`src/cli/wizard.rs`) so choosing an option is a real chooser rather than typing the option string verbatim, and add a `multi_select` capability for choosing several options at once. Replace the verbatim `select` callsites in the type/rule collectors (store, numbering, authorship, lifecycle states, severity in `collect_type_interactive` and parent-child rule collection).
+- **Blank-by-default + `--template starter`.** Change the interactive wizard's "Start from" first screen (`src/cli/init.rs` `run_init_interactive`) to default to a **blank** DAG, rename the `scratch` option to `blank`, and add a `lazyspec init --template starter` flag to opt into the starter DAG. This resolves RFC-062's open question (first-screen choice vs. separate command) in favour of a flag-selected template.
+- **Wizard colours.** Wire the existing `src/cli/style.rs` helpers (`bold`, `dim`, section headers, success/error prefixes, `colors_enabled()`) into the wizard prompts and the `render_dag_summary` output.
+
+### Out of scope
+
+- The non-interactive `run()` path (`src/cli/init.rs`, which writes `starter_config()`): **unchanged**. Scripts and CI keep today's behaviour exactly.
+- Any engine change; any new document type or rule semantics.
+- TUI and web view: the wizard writes a standard `.lazyspec.toml` that all layers already read, so no parity work is required (CLI-only feature).
+
+## Acceptance criteria
+
+### Multi-select / pick-from-list prompts
+
+- **Given** the wizard reaches a single-choice prompt (store, numbering, authorship, severity), **when** it renders on a TTY, **then** I choose from a presented list rather than typing the option text verbatim, and choosing an out-of-list value is not silently accepted.
+- **Given** a prompt that legitimately accepts several values (e.g. lifecycle states), **when** I use the new `multi_select` capability, **then** I can select more than one option in a single prompt and all selections are captured.
+- **Given** the test suite, **when** it drives the wizard through `ScriptedPrompter`, **then** every new/changed prompt (including `multi_select`) remains fully scriptable via queued answers with no real stdin (Convention principle 4: fakes only at the `Prompter` trait seam).
+
+### Blank-by-default + `--template starter`
+
+- **Given** I run `lazyspec init` on a TTY with no template flag, **when** the wizard shows its first screen, **then** the default is **blank** (the from-scratch designer) and the option is labelled `blank`, not `scratch`.
+- **Given** I run `lazyspec init --template starter` on a TTY, **when** the wizard starts, **then** it seeds the starter DAG (today's `starter_config()` designer path).
+- **Given** I run `init` non-interactively or with `--json` (or on a non-TTY), **when** it writes the config, **then** the output is **byte-for-byte identical to today** — the `run()` path still writes `starter_config()` and never consults `--template` for interactive branching (Convention principle 2).
+
+### Wizard colours
+
+- **Given** a colour-capable TTY, **when** the wizard renders prompts and the DAG summary (`render_dag_summary`), **then** labels/headers/success cues use the `src/cli/style.rs` helpers.
+- **Given** a non-TTY or colours disabled (`colors_enabled()` false, e.g. piped, `NO_COLOR`, `--json`), **when** the same output is produced, **then** it degrades to plain text with no ANSI escape codes.
+
+### Cross-cutting
+
+- **Given** any of the three flows completes and scaffolds a project, **when** I run `lazyspec validate`, **then** the resulting config validates clean.
+- **Given** the change set, **when** reviewed, **then** all prompting/colour/template-branching logic lives in the CLI layer (`src/cli/`) with the engine untouched (Convention principle 3), and there remains exactly one config-writing path shared by interactive and non-interactive `init` (RFC-062).
+
+## Non-functional / constraints
+
+- **Principle 2 (parity):** non-interactive + `--json` paths are byte-for-byte unchanged; every wizard flow remains scriptable via flags (`--template`, positional/flag answers) and via `ScriptedPrompter` in tests.
+- **Principle 3 (layering):** prompting, colour, and template selection stay in `src/cli/`; the engine writers are reused, not modified.
+- **Principle 4 (test seam):** the `Prompter` trait is the only place a fake is introduced; the real impl reads stdin, `ScriptedPrompter` drives tests, and it must stay scriptable through the new `multi_select` addition.
+- **Project constraint:** CLI-only — no TUI/web parity work (the wizard emits a standard `.lazyspec.toml` all layers already read). README is the only documentation surface and must be updated for the blank-default first screen and the new `--template starter` flag.
+

--- a/docs/stories/STORY-229-interactive-init-wizard-ux-polish.md
+++ b/docs/stories/STORY-229-interactive-init-wizard-ux-polish.md
@@ -1,7 +1,7 @@
 ---
 title: Interactive init wizard UX polish
 type: story
-status: in-progress
+status: complete
 author: jkaloger
 date: 2026-07-20
 tags: []

--- a/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
+++ b/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI loading face: create overlay and sync header"
 type: story
-status: draft
+status: in-progress
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [tui, ux]

--- a/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
+++ b/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
@@ -1,0 +1,58 @@
+---
+title: "TUI loading face: create overlay and sync header"
+type: story
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [tui, ux]
+related:
+- implements: RFC-063
+---
+<!-- intent: define a vertical slice of value with testable acceptance criteria -->
+
+## Context
+
+TUI loading states are static text today. The create overlay shows a plain status line (`overlays.rs:131-136`); the top-right header shows static sync text (`views.rs:150-180`). RFC-063 introduces an extensible spinner framework and an animated face. This slice is the walking skeleton: it builds the shared `src/spinners.rs` foundation and proves it end-to-end on the two TUI surfaces, driven by the existing ~16ms render loop (`event_loop.rs:752`, free clock, no new timer).
+
+Value lands for anyone watching the TUI: creating a doc or waiting on a GitHub sync now shows a live animated face instead of frozen text.
+
+## Acceptance Criteria
+
+- **Given** the shared framework is needed by both TUI surfaces
+  **When** `src/spinners.rs` is built
+  **Then** it exposes `SpinnerState {Idle,Loading,Success,Error}`, `FrameColour`, `Frame`, `trait Spinner`, a `FaceSpinner`, and a name→spinner registry, all pure (no ratatui/crossterm), with unit tests covering idx→frame for every state and the ASCII fallback.
+
+- **Given** a create is reserving a remote doc (`form.loading == true`)
+  **When** the create overlay renders
+  **Then** it shows the full-box loading face animating each frame off the render loop.
+
+- **Given** a create finishes
+  **When** it succeeds (`Reserved`) or fails
+  **Then** the overlay shows the success face or the error face respectively before dismissal.
+
+- **Given** a GitHub poll or push is in flight (`refresh_in_flight` / `gh_push_in_flight`)
+  **When** the header renders
+  **Then** the top-right shows the compact loading face; on completion it shows a brief success face, then returns to idle.
+
+- **Given** the face is Idle, Success, or Error (non-animated states)
+  **When** the loop redraws
+  **Then** the frame is static — no per-tick recomputation churn; only Loading animates.
+
+- **Given** `FrameColour`
+  **When** the TUI renders a frame
+  **Then** it maps to a `ratatui::Style` using terminal-default accent + dim/bold (green success, red error), no hardcoded hex.
+
+## Scope
+
+### In Scope
+
+- New `src/spinners.rs` framework + `FaceSpinner` + registry + unit tests (foundation for STORY-231 too).
+- TUI create-overlay hook (`overlays.rs`), gated on `form.loading`, driven by `ReservationProgress`.
+- TUI header hook (`views.rs`); surface `refresh_in_flight` onto `App`.
+- `FrameColour` → `ratatui::Style` mapping.
+
+### Out of Scope
+
+- CLI spinners and the init-wizard greeting (STORY-231).
+- Alternate spinner styles beyond the face (registry supports them; none added here).
+- Richer per-event expressions (RFC non-goal).

--- a/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
+++ b/docs/stories/STORY-230-tui-loading-face-create-overlay-and-sync-header.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI loading face: create overlay and sync header"
 type: story
-status: in-progress
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [tui, ux]

--- a/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
+++ b/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI loading face: operation spinners and init greeting"
 type: story
-status: draft
+status: in-progress
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [cli, ux]

--- a/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
+++ b/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
@@ -1,0 +1,58 @@
+---
+title: "CLI loading face: operation spinners and init greeting"
+type: story
+status: draft
+author: "Jack Kaloger"
+date: 2026-07-20
+tags: [cli, ux]
+related:
+- implements: RFC-063
+---
+<!-- intent: define a vertical slice of value with testable acceptance criteria -->
+
+## Context
+
+The CLI shows nothing during network waits: create passes no-op `on_progress` closures (`main.rs:194,207`), so reservation progress is discarded; fetch and prune block silently or print terse lines. RFC-063's face, built in STORY-230, is reused here for the CLI. `indicatif` is already a dependency (`Cargo.toml:45`) but unused — this slice wires it, using its steady-tick thread to animate the face during blocking ops. The init wizard also gains a talking-face greeting (Houston `say` equivalent).
+
+Value lands for CLI users: long operations show a live face instead of silence, and `init` greets you.
+
+## Acceptance Criteria
+
+- **Given** a TTY and no `--json`
+  **When** `create`/`fetch`/prune runs a network operation
+  **Then** the compact face animates via `indicatif` steady-tick, mapping the progress enum to `SpinnerState`, and finishes with a green ✔ (success) or red ✗ (error) line.
+
+- **Given** `--json` or a non-TTY stdout
+  **When** any of those operations runs
+  **Then** no animation is emitted and the output bytes are byte-for-byte unchanged from today (dictum 2).
+
+- **Given** a blocking op where `on_progress` only fires on state change
+  **When** the op is mid-network
+  **Then** the steady-tick still animates (motion comes from the ticker, not progress events).
+
+- **Given** the spinner is drawn
+  **When** it renders and finishes
+  **Then** it draws to stderr and clears cleanly on completion, not smearing stdout.
+
+- **Given** a user runs `init` on a TTY
+  **When** the wizard greets
+  **Then** a talking full-box face cycles eyes/mouth per word, then rests on the happy face; suppressed under `--json`/non-TTY.
+
+- **Given** `FrameColour`
+  **When** the CLI renders a frame
+  **Then** it maps to ANSI using terminal-default accent + dim/bold, no hardcoded hex.
+
+## Scope
+
+### In Scope
+
+- CLI spinner helper wrapping `indicatif` (steady-tick + `tick_strings` = compact face frames, TTY/json guard, stderr, clean teardown).
+- Hooks at create closures (`main.rs`), `cli/fetch.rs`, and prune (`cli/reservations.rs`).
+- Hand-rolled talking-face greeting for the init wizard.
+- `FrameColour` → ANSI mapping.
+
+### Out of Scope
+
+- The `src/spinners.rs` framework itself (delivered by STORY-230; consumed here).
+- TUI surfaces (STORY-230).
+- New spinner styles; richer expressions (RFC non-goals).

--- a/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
+++ b/docs/stories/STORY-231-cli-loading-face-operation-spinners-and-init-greeting.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI loading face: operation spinners and init greeting"
 type: story
-status: in-progress
+status: complete
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [cli, ux]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,7 @@ pub mod search;
 pub mod setup;
 pub mod show;
 pub mod skills;
+pub mod spinner;
 pub mod status;
 pub mod style;
 pub mod tag;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,8 +71,16 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Initialize lazyspec in the current project
-    Init,
+    /// Initialize lazyspec in the current project. On a TTY with neither flag,
+    /// walks an interactive wizard to tweak the starter config before writing.
+    Init {
+        /// Skip the wizard and write the starter config unchanged
+        #[arg(long)]
+        non_interactive: bool,
+        /// Suppress the wizard (implies --non-interactive) and write the starter config unchanged
+        #[arg(long)]
+        json: bool,
+    },
     /// Create a new document from template
     Create {
         /// Document type (rfc, adr, story, iteration)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,10 @@ pub enum Commands {
         /// Suppress the wizard (implies --non-interactive) and write the starter config unchanged
         #[arg(long)]
         json: bool,
+        /// Pre-select a starter template for the interactive wizard (only `starter`
+        /// is supported; the default is a blank DAG). Ignored on non-interactive runs.
+        #[arg(long, value_parser = ["starter"])]
+        template: Option<String>,
     },
     /// Create a new document from template
     Create {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,7 @@ pub mod style;
 pub mod tag;
 pub mod update;
 pub mod validate;
+pub mod wizard;
 
 use crate::cli::config::ConfigCommand;
 use crate::cli::provenance::ProvenanceCommand;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -134,26 +134,66 @@ pub fn run_add_type(
         bail!("attribute \"{}\" is declared more than once", dup.1.name);
     }
 
-    config.documents.types.push(TypeDef {
+    config.documents.types.push(type_def_from_parts(
+        name,
+        plural,
+        dir,
+        prefix,
+        icon,
+        parent_type,
+        singleton,
+        store.map(parse_store).transpose()?.unwrap_or_default(),
+        numbering
+            .map(parse_numbering)
+            .transpose()?
+            .unwrap_or_default(),
+        intent,
+        authorship
+            .map(parse_authorship)
+            .transpose()?
+            .unwrap_or_default(),
+        clickup_task_type,
+        attributes,
+    ));
+
+    let out = write_config_in_place(&src, &config)?;
+    fs.write(&path, &out)?;
+    Ok(())
+}
+
+/// Assemble a `TypeDef` from already-parsed pieces. Shared by the flag path
+/// (`run_add_type`) and the in-memory init wizard (`apply_collected_type`) so the
+/// full field set is written the same way from both entry points.
+#[allow(clippy::too_many_arguments)]
+fn type_def_from_parts(
+    name: &str,
+    plural: &str,
+    dir: &str,
+    prefix: &str,
+    icon: Option<&str>,
+    parent_type: Option<&str>,
+    singleton: bool,
+    store: StoreBackend,
+    numbering: NumberingStrategy,
+    intent: Option<&str>,
+    authorship: Authorship,
+    clickup_task_type: Option<i64>,
+    attributes: Vec<AttrDef>,
+) -> TypeDef {
+    TypeDef {
         name: name.to_string(),
         plural: plural.to_string(),
         dir: dir.to_string(),
         prefix: prefix.to_string(),
         icon: icon.map(str::to_string),
-        numbering: numbering
-            .map(parse_numbering)
-            .transpose()?
-            .unwrap_or_default(),
+        numbering,
         subdirectory: false,
-        store: store.map(parse_store).transpose()?.unwrap_or_default(),
+        store,
         singleton,
         parent_type: parent_type.map(str::to_string),
         agents: Vec::new(),
         intent: intent.map(str::to_string),
-        authorship: authorship
-            .map(parse_authorship)
-            .transpose()?
-            .unwrap_or_default(),
+        authorship,
         lifecycle: Lifecycle::default(),
         attributes,
         label_override: None,
@@ -162,11 +202,7 @@ pub fn run_add_type(
         clickup_list_id: None,
         clickup_task_type,
         clickup_custom_field_map: None,
-    });
-
-    let out = write_config_in_place(&src, &config)?;
-    fs.write(&path, &out)?;
-    Ok(())
+    }
 }
 
 /// How `config add-type` should proceed given its four positionals: all four
@@ -189,20 +225,34 @@ pub fn classify_add_type_args(positionals: [&Option<String>; 4]) -> Result<AddTy
     }
 }
 
-/// Prompt for a type's fields on a TTY and drive the same writers the flag path
-/// uses. After the core fields it optionally collects attributes and a parent
-/// type (fed to `run_add_type`), a custom lifecycle (`run_set_lifecycle`), and a
-/// gate on an existing parent-child rule (`run_add_gate`). Every optional section
-/// pre-validates prompt-side and re-asks on failure rather than aborting.
-pub fn run_add_type_interactive(
-    root: &Path,
-    fs: &dyn FileSystem,
-    prompter: &mut dyn Prompter,
-) -> Result<()> {
-    let path = root.join(".lazyspec.toml");
-    let src = fs.read_to_string(&path)?;
-    let config = Config::parse(&src)?;
+/// The fields a single interactive type-authoring session collects, before any
+/// disk write. Produced by `collect_type_interactive` and applied either to a
+/// parsed-from-disk config (via `run_add_type` and friends) or to an in-memory
+/// config being designed by `init` (via `apply_collected_type`).
+pub struct CollectedType {
+    pub name: String,
+    pub plural: String,
+    pub dir: String,
+    pub prefix: String,
+    pub icon: Option<String>,
+    pub store: String,
+    pub numbering: String,
+    pub singleton: bool,
+    pub authorship: String,
+    pub attributes: Vec<String>,
+    pub parent_type: Option<String>,
+    pub lifecycle: Option<(Vec<String>, Vec<String>)>,
+    pub gate: Option<(String, String)>,
+}
 
+/// Prompt for a type's fields on a TTY, validating each section against `config`
+/// (an in-memory view of the project as it stands, so name/prefix/parent/gate
+/// checks see prior additions) without touching disk. Every optional section
+/// pre-validates prompt-side and re-asks on failure rather than aborting.
+pub fn collect_type_interactive(
+    config: &Config,
+    prompter: &mut dyn Prompter,
+) -> Result<CollectedType> {
     let default_authorship = match Authorship::default() {
         Authorship::Human => "human",
         Authorship::Assisted => "assisted",
@@ -387,6 +437,112 @@ pub fn run_add_type_interactive(
     } else {
         None
     };
+
+    Ok(CollectedType {
+        name,
+        plural,
+        dir,
+        prefix,
+        icon,
+        store,
+        numbering,
+        singleton,
+        authorship,
+        attributes,
+        parent_type,
+        lifecycle: custom_lifecycle,
+        gate,
+    })
+}
+
+/// Push a collected type onto an in-memory `Config` and apply its optional
+/// lifecycle and gate, without any disk IO. Used by the `init` wizard, which
+/// serializes the whole `Config` at the end rather than editing a file in place.
+pub fn apply_collected_type(config: &mut Config, collected: &CollectedType) -> Result<()> {
+    if config.type_by_name(&collected.name).is_some() {
+        bail!("type \"{}\" already exists", collected.name);
+    }
+
+    let attributes = collected
+        .attributes
+        .iter()
+        .map(|spec| parse_attr_spec(spec))
+        .collect::<Result<Vec<_>>>()?;
+
+    config.documents.types.push(type_def_from_parts(
+        &collected.name,
+        &collected.plural,
+        &collected.dir,
+        &collected.prefix,
+        collected.icon.as_deref(),
+        collected.parent_type.as_deref(),
+        collected.singleton,
+        parse_store(&collected.store)?,
+        parse_numbering(&collected.numbering)?,
+        None,
+        parse_authorship(&collected.authorship)?,
+        None,
+        attributes,
+    ));
+
+    if let Some((states, edges)) = &collected.lifecycle {
+        let parsed_edges = edges.iter().map(|e| parse_edge(e)).collect::<Result<_>>()?;
+        let type_def = config
+            .documents
+            .types
+            .iter_mut()
+            .find(|t| t.name == collected.name)
+            .expect("just-pushed type is present");
+        type_def.lifecycle = Lifecycle {
+            states: states.clone(),
+            edges: parsed_edges,
+        };
+    }
+
+    if let Some((rule, status)) = &collected.gate {
+        match config.rules.iter_mut().find(|r| rule_name(r) == rule) {
+            Some(ValidationRule::ParentChild {
+                require_parent_status,
+                ..
+            }) => {
+                *require_parent_status = Some(status.clone());
+            }
+            _ => bail!("unknown parent-child rule \"{}\"", rule),
+        }
+    }
+
+    Ok(())
+}
+
+/// Prompt for a type's fields on a TTY and drive the same writers the flag path
+/// uses. After the core fields it optionally collects attributes and a parent
+/// type (fed to `run_add_type`), a custom lifecycle (`run_set_lifecycle`), and a
+/// gate on an existing parent-child rule (`run_add_gate`). Every optional section
+/// pre-validates prompt-side and re-asks on failure rather than aborting.
+pub fn run_add_type_interactive(
+    root: &Path,
+    fs: &dyn FileSystem,
+    prompter: &mut dyn Prompter,
+) -> Result<()> {
+    let path = root.join(".lazyspec.toml");
+    let src = fs.read_to_string(&path)?;
+    let config = Config::parse(&src)?;
+
+    let CollectedType {
+        name,
+        plural,
+        dir,
+        prefix,
+        icon,
+        store,
+        numbering,
+        singleton,
+        authorship,
+        attributes,
+        parent_type,
+        lifecycle: custom_lifecycle,
+        gate,
+    } = collect_type_interactive(&config, prompter)?;
 
     run_add_type(
         root,

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,7 +1,7 @@
 use crate::cli::wizard::Prompter;
 use crate::engine::config::{
-    AttrDef, AttrKind, Authorship, Config, Edge, Lifecycle, NumberingStrategy, StoreBackend,
-    TypeDef, ValidationRule,
+    AttrDef, AttrKind, Authorship, Config, Edge, Lifecycle, NumberingStrategy, Severity,
+    StoreBackend, TypeDef, ValidationRule,
 };
 use crate::engine::config_write::write_config_in_place;
 use crate::engine::fs::FileSystem;
@@ -455,6 +455,90 @@ pub fn collect_type_interactive(
     })
 }
 
+/// A stable, dedup-guarded name for the parent-child rule linking `child` to
+/// `parent`, built from their plural forms (e.g. `stories-need-rfcs`). Falls back
+/// to a naive `{name}s` plural when a type is absent, and appends `-2`, `-3`, ...
+/// if the base name already names a rule.
+fn parent_child_rule_name(config: &Config, child: &str, parent: &str) -> String {
+    let plural = |name: &str| {
+        config
+            .type_by_name(name)
+            .map(|t| t.plural.clone())
+            .unwrap_or_else(|| format!("{name}s"))
+    };
+    let base = format!("{}-need-{}", plural(child), plural(parent));
+    if !config.rules.iter().any(|r| rule_name(r) == base) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if !config.rules.iter().any(|r| rule_name(r) == candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Prompt for a single parent-child rule against `config` (an in-memory view of
+/// the project as designed so far). Child and parent are each chosen from the
+/// defined type names -- an unknown answer re-asks rather than aborting. Severity
+/// defaults to `warning`. An optional gate re-asks until the chosen status names
+/// a state in the parent type's effective lifecycle. Pure: no disk IO, fully
+/// driveable by a `ScriptedPrompter`.
+pub fn collect_parent_child_rule(
+    config: &Config,
+    prompter: &mut dyn Prompter,
+) -> Result<ValidationRule> {
+    let type_names: Vec<&str> = config
+        .documents
+        .types
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+
+    let pick = |prompter: &mut dyn Prompter, label: &str| -> Result<String> {
+        loop {
+            let choice = prompter.select(label, &type_names, type_names[0])?;
+            if type_names.contains(&choice.as_str()) {
+                break Ok(choice);
+            }
+            println!("\"{choice}\" is not a defined type; choose one of the listed names");
+        }
+    };
+
+    let child = pick(prompter, "Child type")?;
+    let parent = pick(prompter, "Parent type")?;
+    let name = parent_child_rule_name(config, &child, &parent);
+
+    let severity =
+        parse_severity(&prompter.select("Severity", &["warning", "error"], "warning")?)?;
+
+    let require_parent_status = if prompter.confirm("Gate on a parent status", false)? {
+        let states = config
+            .type_by_name(&parent)
+            .map(|t| t.effective_lifecycle().states.clone())
+            .unwrap_or_default();
+        Some(loop {
+            let answer = prompter.ask("Required parent status", None)?;
+            if states.contains(&answer) {
+                break answer;
+            }
+            println!("\"{answer}\" is not a lifecycle state of \"{parent}\"; choose another");
+        })
+    } else {
+        None
+    };
+
+    Ok(ValidationRule::ParentChild {
+        name,
+        child,
+        parent,
+        severity,
+        require_parent_status,
+    })
+}
+
 /// Push a collected type onto an in-memory `Config` and apply its optional
 /// lifecycle and gate, without any disk IO. Used by the `init` wizard, which
 /// serializes the whole `Config` at the end rather than editing a file in place.
@@ -731,6 +815,14 @@ fn parse_store(value: &str) -> Result<StoreBackend> {
         "git-ref" => Ok(StoreBackend::GitRef),
         "clickup-tasks" => Ok(StoreBackend::ClickupTasks),
         other => bail!("unknown store backend \"{}\"", other),
+    }
+}
+
+pub fn parse_severity(value: &str) -> Result<Severity> {
+    match value {
+        "warning" => Ok(Severity::Warning),
+        "error" => Ok(Severity::Error),
+        other => bail!("unknown severity \"{}\"", other),
     }
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -58,6 +58,15 @@ pub enum ConfigCommand {
         /// Authorship ceiling: human, assisted, or generated
         #[arg(long)]
         authorship: Option<String>,
+        /// GitHub issue tag (label); only valid on store = github-issues
+        #[arg(long)]
+        github_issue_tag: Option<String>,
+        /// GitHub issue type; only valid on store = github-issues
+        #[arg(long)]
+        github_issue_type: Option<String>,
+        /// ClickUp list ID documents are created in; only valid on store = clickup-tasks
+        #[arg(long)]
+        clickup_list_id: Option<String>,
         /// ClickUp custom task type (numeric custom_item_id); only valid on store = clickup-tasks
         #[arg(long)]
         clickup_task_type: Option<i64>,
@@ -111,6 +120,9 @@ pub fn run_add_type(
     numbering: Option<&str>,
     intent: Option<&str>,
     authorship: Option<&str>,
+    github_issue_tag: Option<&str>,
+    github_issue_type: Option<&str>,
+    clickup_list_id: Option<&str>,
     clickup_task_type: Option<i64>,
     attributes: &[String],
 ) -> Result<()> {
@@ -152,6 +164,9 @@ pub fn run_add_type(
             .map(parse_authorship)
             .transpose()?
             .unwrap_or_default(),
+        github_issue_tag,
+        github_issue_type,
+        clickup_list_id,
         clickup_task_type,
         attributes,
     ));
@@ -177,6 +192,9 @@ fn type_def_from_parts(
     numbering: NumberingStrategy,
     intent: Option<&str>,
     authorship: Authorship,
+    github_issue_tag: Option<&str>,
+    github_issue_type: Option<&str>,
+    clickup_list_id: Option<&str>,
     clickup_task_type: Option<i64>,
     attributes: Vec<AttrDef>,
 ) -> TypeDef {
@@ -197,9 +215,9 @@ fn type_def_from_parts(
         lifecycle: Lifecycle::default(),
         attributes,
         label_override: None,
-        github_issue_tag: None,
-        github_issue_type: None,
-        clickup_list_id: None,
+        github_issue_tag: github_issue_tag.map(str::to_string),
+        github_issue_type: github_issue_type.map(str::to_string),
+        clickup_list_id: clickup_list_id.map(str::to_string),
         clickup_task_type,
         clickup_custom_field_map: None,
     }
@@ -243,6 +261,10 @@ pub struct CollectedType {
     pub parent_type: Option<String>,
     pub lifecycle: Option<(Vec<String>, Vec<String>)>,
     pub gate: Option<(String, String)>,
+    pub github_issue_tag: Option<String>,
+    pub github_issue_type: Option<String>,
+    pub clickup_list_id: Option<String>,
+    pub clickup_task_type: Option<i64>,
 }
 
 /// Prompt for a type's fields on a TTY, validating each section against `config`
@@ -292,6 +314,35 @@ pub fn collect_type_interactive(
         ],
         "filesystem",
     )?;
+
+    let mut github_issue_tag = None;
+    let mut github_issue_type = None;
+    let mut clickup_list_id = None;
+    let mut clickup_task_type = None;
+    match store.as_str() {
+        "clickup-tasks" => {
+            let list_id = prompter.ask("ClickUp list ID", None)?;
+            clickup_list_id = (!list_id.is_empty()).then_some(list_id);
+            clickup_task_type = loop {
+                let answer = prompter.ask("ClickUp task type (numeric custom_item_id)", None)?;
+                if answer.is_empty() {
+                    break None;
+                }
+                match answer.parse::<i64>() {
+                    Ok(n) => break Some(n),
+                    Err(_) => println!("\"{answer}\" is not a number; try again"),
+                }
+            };
+        }
+        "github-issues" => {
+            let tag = prompter.ask("GitHub issue tag", None)?;
+            github_issue_tag = (!tag.is_empty()).then_some(tag);
+            let issue_type = prompter.ask("GitHub issue type", None)?;
+            github_issue_type = (!issue_type.is_empty()).then_some(issue_type);
+        }
+        _ => {}
+    }
+
     let numbering = prompter.select(
         "Numbering",
         &["incremental", "sqids", "reserved"],
@@ -448,6 +499,10 @@ pub fn collect_type_interactive(
         parent_type,
         lifecycle: custom_lifecycle,
         gate,
+        github_issue_tag,
+        github_issue_type,
+        clickup_list_id,
+        clickup_task_type,
     })
 }
 
@@ -561,7 +616,10 @@ pub fn apply_collected_type(config: &mut Config, collected: &CollectedType) -> R
         parse_numbering(&collected.numbering)?,
         None,
         parse_authorship(&collected.authorship)?,
-        None,
+        collected.github_issue_tag.as_deref(),
+        collected.github_issue_type.as_deref(),
+        collected.clickup_list_id.as_deref(),
+        collected.clickup_task_type,
         attributes,
     ));
 
@@ -622,6 +680,10 @@ pub fn run_add_type_interactive(
         parent_type,
         lifecycle: custom_lifecycle,
         gate,
+        github_issue_tag,
+        github_issue_type,
+        clickup_list_id,
+        clickup_task_type,
     } = collect_type_interactive(&config, prompter)?;
 
     run_add_type(
@@ -638,7 +700,10 @@ pub fn run_add_type_interactive(
         Some(&numbering),
         None,
         Some(&authorship),
-        None,
+        github_issue_tag.as_deref(),
+        github_issue_type.as_deref(),
+        clickup_list_id.as_deref(),
+        clickup_task_type,
         &attributes,
     )?;
 
@@ -1005,6 +1070,9 @@ require_parent_status = "accepted"
             Some("throwaway exploration"),
             Some("generated"),
             None,
+            None,
+            None,
+            None,
             &[],
         )
         .unwrap();
@@ -1041,6 +1109,9 @@ require_parent_status = "accepted"
             None,
             None,
             false,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -1142,6 +1213,9 @@ require_parent_status = "accepted"
             None,
             None,
             None,
+            None,
+            None,
+            None,
             &["estimate:int".to_string(), "estimate:bool".to_string()],
         )
         .unwrap_err();
@@ -1168,6 +1242,9 @@ require_parent_status = "accepted"
             None,
             None,
             None,
+            None,
+            None,
+            None,
             Some(1001),
             &[],
         )
@@ -1176,6 +1253,40 @@ require_parent_status = "accepted"
         let after = std::fs::read_to_string(&path).unwrap();
         let json = show(&after);
         assert_eq!(type_named(&json, "task")["clickup_task_type"], 1001);
+    }
+
+    // The GitHub tag/type and ClickUp list-id string flags supplied to add-type
+    // are written onto the TypeDef and surface in `config --json` after a reload.
+    #[test]
+    fn add_type_writes_remote_string_fields() {
+        let (_dir, path, fs) = fixture(SRC);
+        run_add_type(
+            path.parent().unwrap(),
+            &fs,
+            "issue",
+            "issues",
+            "docs/issues",
+            "ISSUE",
+            None,
+            None,
+            false,
+            None, // default store; the remote fields are written regardless
+            None,
+            None,
+            None,
+            Some("Bug"),     // github_issue_tag
+            Some("Defect"),  // github_issue_type
+            Some("list-42"), // clickup_list_id
+            None,
+            &[],
+        )
+        .unwrap();
+
+        let json = show(&std::fs::read_to_string(&path).unwrap());
+        let issue = type_named(&json, "issue");
+        assert_eq!(issue["github_issue_tag"], "Bug");
+        assert_eq!(issue["github_issue_type"], "Defect");
+        assert_eq!(issue["clickup_list_id"], "list-42");
     }
 
     #[test]
@@ -1192,6 +1303,9 @@ require_parent_status = "accepted"
             None,
             None,
             false,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -1249,6 +1363,9 @@ require_parent_status = "accepted"
             Some("incremental"),
             None,
             Some("generated"),
+            None,
+            None,
+            None,
             None,
             &[],
         )
@@ -1427,6 +1544,9 @@ require_parent_status = "accepted"
             None,
             None,
             false,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -1649,6 +1769,189 @@ require_parent_status = "accepted"
         assert!(edges.is_empty());
     }
 
+    // ITERATION-338: choosing clickup-tasks prompts for the store's defaults right
+    // after the store select; both land on the collected type.
+    #[test]
+    fn collect_type_clickup_captures_list_id_and_task_type() {
+        let config = Config::parse(SRC).unwrap();
+        let mut prompter = scripted(&[
+            "task",
+            "tasks",
+            "",
+            "",
+            "",              // name/plural/dir/prefix/icon
+            "clickup-tasks", // store
+            "list123",       // clickup list id
+            "1001",          // clickup task type
+            "",
+            "",
+            "", // numbering/singleton/authorship
+            "n",
+            "n",
+            "n",
+            "n", // attributes / parent / lifecycle / gate declined
+        ]);
+        let collected = collect_type_interactive(&config, &mut prompter).unwrap();
+        assert_eq!(collected.clickup_list_id.as_deref(), Some("list123"));
+        assert_eq!(collected.clickup_task_type, Some(1001));
+        assert_eq!(collected.github_issue_tag, None);
+        assert_eq!(collected.github_issue_type, None);
+    }
+
+    // ITERATION-338: a non-numeric clickup task type is rejected and re-asked in
+    // place; a blank leaves it None.
+    #[test]
+    fn collect_type_clickup_task_type_reasks_on_non_numeric() {
+        let config = Config::parse(SRC).unwrap();
+        let mut prompter = scripted(&[
+            "task",
+            "tasks",
+            "",
+            "",
+            "",
+            "clickup-tasks",
+            "",     // clickup list id (blank -> None)
+            "nope", // not a number -> re-ask
+            "42",   // valid
+            "",
+            "",
+            "",
+            "n",
+            "n",
+            "n",
+            "n",
+        ]);
+        let collected = collect_type_interactive(&config, &mut prompter).unwrap();
+        assert_eq!(collected.clickup_list_id, None);
+        assert_eq!(collected.clickup_task_type, Some(42));
+    }
+
+    // ITERATION-338: choosing github-issues prompts for tag and issue type.
+    #[test]
+    fn collect_type_github_captures_tag_and_issue_type() {
+        let config = Config::parse(SRC).unwrap();
+        let mut prompter = scripted(&[
+            "issue",
+            "issues",
+            "",
+            "",
+            "",
+            "github-issues", // store
+            "Bug",           // github issue tag
+            "Bug",           // github issue type
+            "",
+            "",
+            "",
+            "n",
+            "n",
+            "n",
+            "n",
+        ]);
+        let collected = collect_type_interactive(&config, &mut prompter).unwrap();
+        assert_eq!(collected.github_issue_tag.as_deref(), Some("Bug"));
+        assert_eq!(collected.github_issue_type.as_deref(), Some("Bug"));
+        assert_eq!(collected.clickup_list_id, None);
+        assert_eq!(collected.clickup_task_type, None);
+    }
+
+    // ITERATION-338: a filesystem type prompts for NONE of the remote defaults.
+    // No answers are queued for them: a spurious remote prompt would consume a
+    // later answer and the run would end short, so a clean run proves they skip.
+    #[test]
+    fn collect_type_filesystem_prompts_for_no_remote_fields() {
+        let config = Config::parse(SRC).unwrap();
+        let mut prompter = scripted(&[
+            "doc",
+            "docs",
+            "",
+            "",
+            "",
+            "filesystem", // store
+            "",
+            "",
+            "", // numbering/singleton/authorship
+            "n",
+            "n",
+            "n",
+            "n",
+        ]);
+        let collected = collect_type_interactive(&config, &mut prompter).unwrap();
+        assert_eq!(collected.github_issue_tag, None);
+        assert_eq!(collected.github_issue_type, None);
+        assert_eq!(collected.clickup_list_id, None);
+        assert_eq!(collected.clickup_task_type, None);
+    }
+
+    // ITERATION-338: the interactive add-type path persists the GitHub remote
+    // fields it collects, rather than discarding them before the disk write.
+    #[test]
+    fn interactive_add_type_persists_github_fields() {
+        // A github-issues type reparses only with a [github] section present.
+        let src = format!("[github]\nrepo = \"owner/repo\"\n\n{SRC}");
+        let (_dir, path, fs) = fixture(&src);
+        let mut prompter = scripted(&[
+            "issue",
+            "issues",
+            "",
+            "",
+            "",              // name/plural/dir/prefix/icon
+            "github-issues", // store
+            "Bug",           // github issue tag
+            "Defect",        // github issue type
+            "",
+            "",
+            "", // numbering/singleton/authorship
+            "n",
+            "n",
+            "n",
+            "n", // attributes / parent / lifecycle / gate declined
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let issue = Config::parse(&after)
+            .unwrap()
+            .type_by_name("issue")
+            .unwrap()
+            .clone();
+        assert_eq!(issue.github_issue_tag.as_deref(), Some("Bug"));
+        assert_eq!(issue.github_issue_type.as_deref(), Some("Defect"));
+    }
+
+    // ITERATION-338: the interactive add-type path persists both ClickUp remote
+    // fields, including clickup_task_type (which the pre-fix path dropped).
+    #[test]
+    fn interactive_add_type_persists_clickup_fields() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "task",
+            "tasks",
+            "",
+            "",
+            "",              // name/plural/dir/prefix/icon
+            "clickup-tasks", // store
+            "list-7",        // clickup list id
+            "2002",          // clickup task type
+            "",
+            "",
+            "", // numbering/singleton/authorship
+            "n",
+            "n",
+            "n",
+            "n", // attributes / parent / lifecycle / gate declined
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let task = Config::parse(&after)
+            .unwrap()
+            .type_by_name("task")
+            .unwrap()
+            .clone();
+        assert_eq!(task.clickup_list_id.as_deref(), Some("list-7"));
+        assert_eq!(task.clickup_task_type, Some(2002));
+    }
+
     // STORY-226 AC2: declining the custom-lifecycle prompt leaves the lifecycle
     // empty, so the type inherits the store preset via effective_lifecycle.
     #[test]
@@ -1776,6 +2079,9 @@ require_parent_status = "accepted"
             Some("incremental"),
             None,
             Some("assisted"),
+            None,
+            None,
+            None,
             None,
             &["priority:enum:low,medium,high".to_string()],
         )

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -356,18 +356,14 @@ pub fn collect_type_interactive(
     // store preset via `effective_lifecycle`. When designing one, an edge naming a
     // state outside the collected set (source `*` excepted) re-asks in place.
     let custom_lifecycle = if prompter.confirm("Design a custom lifecycle", false)? {
-        let mut states: Vec<String> = Vec::new();
-        loop {
-            let state = prompter.ask("Lifecycle state (blank to finish)", None)?;
-            if state.is_empty() {
-                if states.is_empty() {
-                    println!("at least one state is required");
-                    continue;
-                }
-                break;
+        let states = loop {
+            let states = prompter.multi_select("Lifecycle states", &[], &[])?;
+            if states.is_empty() {
+                println!("at least one state is required");
+                continue;
             }
-            states.push(state);
-        }
+            break states;
+        };
         let mut edges: Vec<String> = Vec::new();
         loop {
             let spec = prompter.ask("Edge FROM:TO (blank to finish)", None)?;
@@ -1590,13 +1586,11 @@ require_parent_status = "accepted"
             "",
             "",
             "",
-            "",  // core fields
-            "n", // no attributes
-            "n", // no parent
-            "y", // design a custom lifecycle
-            "draft",
-            "done",
-            "",           // states, then blank to finish
+            "",           // core fields
+            "n",          // no attributes
+            "n",          // no parent
+            "y",          // design a custom lifecycle
+            "draft,done", // lifecycle states (comma-separated)
             "draft:nope", // `nope` isn't a state -> re-ask
             "draft:done", // valid
             "",           // blank to finish edges
@@ -1614,6 +1608,45 @@ require_parent_status = "accepted"
         assert_eq!(widget.lifecycle.edges.len(), 1);
         assert_eq!(widget.lifecycle.edges[0].from, "draft");
         assert_eq!(widget.lifecycle.edges[0].to, "done");
+    }
+
+    // ITERATION-329: lifecycle states are collected in one `multi_select` prompt.
+    // A comma-separated answer becomes the full state list, and a blank answer
+    // trips the empty-guard re-ask before a valid answer is accepted.
+    #[test]
+    fn collect_type_multi_select_states_reasks_on_blank() {
+        let config = Config::parse(SRC).unwrap();
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "", // core identity
+            "",
+            "",
+            "",
+            "",
+            "",                  // icon/store/numbering/singleton/authorship
+            "n",                 // no attribute
+            "n",                 // no parent
+            "y",                 // design a custom lifecycle
+            "",                  // blank states -> empty-guard re-ask
+            "draft,review,done", // valid states
+            "",                  // blank to finish edges
+            "n",                 // no gate
+        ]);
+        let collected = collect_type_interactive(&config, &mut prompter).unwrap();
+        let (states, edges) = collected
+            .lifecycle
+            .expect("a custom lifecycle was designed");
+        assert_eq!(
+            states,
+            vec![
+                "draft".to_string(),
+                "review".to_string(),
+                "done".to_string()
+            ]
+        );
+        assert!(edges.is_empty());
     }
 
     // STORY-226 AC2: declining the custom-lifecycle prompt leaves the lifecycle
@@ -1717,9 +1750,7 @@ require_parent_status = "accepted"
             "y",
             "rfc", // parent = rfc
             "y",
-            "draft",
-            "done",
-            "",
+            "draft,done",
             "draft:done",
             "", // custom lifecycle
             "y",

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -189,9 +189,11 @@ pub fn classify_add_type_args(positionals: [&Option<String>; 4]) -> Result<AddTy
     }
 }
 
-/// Prompt for a type's core fields on a TTY and delegate to `run_add_type`.
-/// Only the fields the spec calls out are prompted; lifecycle, attributes,
-/// gates, and relations are left to their defaults / the flag path.
+/// Prompt for a type's fields on a TTY and drive the same writers the flag path
+/// uses. After the core fields it optionally collects attributes and a parent
+/// type (fed to `run_add_type`), a custom lifecycle (`run_set_lifecycle`), and a
+/// gate on an existing parent-child rule (`run_add_gate`). Every optional section
+/// pre-validates prompt-side and re-asks on failure rather than aborting.
 pub fn run_add_type_interactive(
     root: &Path,
     fs: &dyn FileSystem,
@@ -252,6 +254,140 @@ pub fn run_add_type_interactive(
         default_authorship,
     )?;
 
+    // Attributes: keep offering to add one until declined. A malformed spec or a
+    // name already collected re-asks in place (no fresh "add another?" prompt) so
+    // a typo never costs the value or ends the session.
+    let mut attributes: Vec<String> = Vec::new();
+    let mut attribute_names: Vec<String> = Vec::new();
+    while prompter.confirm("Add an attribute", false)? {
+        loop {
+            let spec = prompter.ask("Attribute (NAME:KIND[:required][:VALUES])", None)?;
+            let def = match parse_attr_spec(&spec) {
+                Ok(def) => def,
+                Err(e) => {
+                    println!("{e}; try again");
+                    continue;
+                }
+            };
+            if attribute_names.contains(&def.name) {
+                println!(
+                    "attribute \"{}\" was already added; choose another",
+                    def.name
+                );
+                continue;
+            }
+            attribute_names.push(def.name);
+            attributes.push(spec);
+            break;
+        }
+    }
+
+    // Parent: only an already-defined type may be chosen. Skip entirely when the
+    // project has no types to point at.
+    let type_names: Vec<&str> = config
+        .documents
+        .types
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    let parent_type = if !type_names.is_empty() && prompter.confirm("Set a parent type", false)? {
+        Some(loop {
+            let choice = prompter.select("Parent", &type_names, type_names[0])?;
+            if type_names.contains(&choice.as_str()) {
+                break choice;
+            }
+            println!("\"{choice}\" is not a defined type; choose one of the listed names");
+        })
+    } else {
+        None
+    };
+
+    // Lifecycle: declining leaves the type's lifecycle empty so it inherits the
+    // store preset via `effective_lifecycle`. When designing one, an edge naming a
+    // state outside the collected set (source `*` excepted) re-asks in place.
+    let custom_lifecycle = if prompter.confirm("Design a custom lifecycle", false)? {
+        let mut states: Vec<String> = Vec::new();
+        loop {
+            let state = prompter.ask("Lifecycle state (blank to finish)", None)?;
+            if state.is_empty() {
+                if states.is_empty() {
+                    println!("at least one state is required");
+                    continue;
+                }
+                break;
+            }
+            states.push(state);
+        }
+        let mut edges: Vec<String> = Vec::new();
+        loop {
+            let spec = prompter.ask("Edge FROM:TO (blank to finish)", None)?;
+            if spec.is_empty() {
+                break;
+            }
+            let edge = match parse_edge(&spec) {
+                Ok(edge) => edge,
+                Err(e) => {
+                    println!("{e}; try again");
+                    continue;
+                }
+            };
+            let to_ok = states.contains(&edge.to);
+            let from_ok = edge.from == "*" || states.contains(&edge.from);
+            if !to_ok || !from_ok {
+                println!("edge \"{spec}\" names a state that isn't in the lifecycle; try again");
+                continue;
+            }
+            edges.push(spec);
+        }
+        Some((states, edges))
+    } else {
+        None
+    };
+
+    // Gate: attach `require_parent_status` to an existing parent-child rule. Only
+    // a status the parent type's effective lifecycle carries is accepted.
+    let parent_child_rules: Vec<(String, String)> = config
+        .rules
+        .iter()
+        .filter_map(|r| match r {
+            ValidationRule::ParentChild { name, parent, .. } => {
+                Some((name.clone(), parent.clone()))
+            }
+            ValidationRule::RelationExistence { .. } => None,
+        })
+        .collect();
+    let gate = if !parent_child_rules.is_empty()
+        && prompter.confirm("Gate a parent-child rule", false)?
+    {
+        let rule_names: Vec<&str> = parent_child_rules.iter().map(|(n, _)| n.as_str()).collect();
+        let rule = loop {
+            let choice = prompter.select("Rule", &rule_names, rule_names[0])?;
+            if rule_names.contains(&choice.as_str()) {
+                break choice;
+            }
+            println!("\"{choice}\" is not a parent-child rule; choose one of the listed names");
+        };
+        let parent_name = &parent_child_rules
+            .iter()
+            .find(|(n, _)| *n == rule)
+            .expect("selected rule came from this list")
+            .1;
+        let states = config
+            .type_by_name(parent_name)
+            .map(|t| t.effective_lifecycle().states.clone())
+            .unwrap_or_default();
+        let status = loop {
+            let answer = prompter.ask("Required parent status", None)?;
+            if states.contains(&answer) {
+                break answer;
+            }
+            println!("\"{answer}\" is not a lifecycle state of \"{parent_name}\"; choose another");
+        };
+        Some((rule, status))
+    } else {
+        None
+    };
+
     run_add_type(
         root,
         fs,
@@ -260,15 +396,23 @@ pub fn run_add_type_interactive(
         &dir,
         &prefix,
         icon.as_deref(),
-        None,
+        parent_type.as_deref(),
         singleton,
         Some(&store),
         Some(&numbering),
         None,
         Some(&authorship),
         None,
-        &[],
-    )
+        &attributes,
+    )?;
+
+    if let Some((states, edges)) = custom_lifecycle {
+        run_set_lifecycle(root, fs, &name, &states, &edges)?;
+    }
+    if let Some((rule, status)) = gate {
+        run_add_gate(root, fs, &rule, &status)?;
+    }
+    Ok(())
 }
 
 pub fn run_set_lifecycle(
@@ -834,6 +978,10 @@ require_parent_status = "accepted"
                 "incremental", // numbering
                 "y",           // singleton -> true
                 "generated",   // authorship
+                "n",           // add an attribute? no
+                "n",           // set a parent type? no
+                "n",           // design a custom lifecycle? no
+                "n",           // gate a parent-child rule? no
             ]
             .iter()
             .map(|s| s.to_string())
@@ -880,6 +1028,7 @@ require_parent_status = "accepted"
                 "", // numbering -> incremental
                 "", // singleton -> false
                 "", // authorship -> default
+                "n", "n", "n", "n", // attributes / parent / lifecycle / gate declined
             ]
             .iter()
             .map(|s| s.to_string())
@@ -909,7 +1058,8 @@ require_parent_status = "accepted"
         let mut prompter = ScriptedPrompter::new(
             [
                 "task", "tasks", "", "", // dir and prefix blank -> defaults
-                "", "", "", "", "",
+                "", "", "", "", "", // icon / store / numbering / singleton / authorship
+                "n", "n", "n", "n", // attributes / parent / lifecycle / gate declined
             ]
             .iter()
             .map(|s| s.to_string())
@@ -1095,5 +1245,274 @@ require_parent_status = "accepted"
         // The relation-existence rule is untouched.
         assert!(after.contains(r#"require = "any-relation""#));
         Config::parse(&after).unwrap();
+    }
+
+    fn scripted(answers: &[&str]) -> ScriptedPrompter {
+        ScriptedPrompter::new(answers.iter().map(|s| s.to_string()).collect())
+    }
+
+    // STORY-226 AC1: an interactively entered attribute spec is validated and
+    // written into the new type's frontmatter definition.
+    #[test]
+    fn interactive_add_type_collects_attributes() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "", // core fields (dir/prefix default)
+            "",
+            "",
+            "",
+            "",
+            "", // icon/store/numbering/singleton/authorship
+            "y",
+            "priority:enum:low,medium,high", // add one attribute
+            "n",                             // add another? no
+            "n",                             // parent? no
+            "n",                             // custom lifecycle? no
+            "n",                             // gate? no
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        let widget = config.type_by_name("widget").unwrap();
+        assert_eq!(
+            widget.attributes,
+            vec![AttrDef {
+                name: "priority".to_string(),
+                kind: AttrKind::Enum,
+                required: false,
+                values: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
+            }]
+        );
+    }
+
+    // STORY-226 AC1: a malformed attribute spec (unknown kind, enum without
+    // values) is rejected and re-asked in place, not aborted, and the eventual
+    // valid spec is written.
+    #[test]
+    fn interactive_add_type_reprompts_bad_attr() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",                       // core fields
+            "y",                      // add an attribute
+            "priority:bogus",         // unknown kind -> re-ask
+            "priority:enum",          // enum without values -> re-ask
+            "priority:enum:low,high", // valid
+            "n",                      // add another? no
+            "n",
+            "n",
+            "n", // parent / lifecycle / gate declined
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        let widget = config.type_by_name("widget").unwrap();
+        assert_eq!(widget.attributes.len(), 1);
+        assert_eq!(widget.attributes[0].name, "priority");
+        assert_eq!(widget.attributes[0].kind, AttrKind::Enum);
+        assert_eq!(
+            widget.attributes[0].values,
+            vec!["low".to_string(), "high".to_string()]
+        );
+    }
+
+    // STORY-226 AC2: while designing a custom lifecycle, an edge naming a state
+    // outside the collected set is rejected and re-asked; the valid edge is kept.
+    #[test]
+    fn interactive_add_type_custom_lifecycle_reprompts_bad_edge() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",  // core fields
+            "n", // no attributes
+            "n", // no parent
+            "y", // design a custom lifecycle
+            "draft",
+            "done",
+            "",           // states, then blank to finish
+            "draft:nope", // `nope` isn't a state -> re-ask
+            "draft:done", // valid
+            "",           // blank to finish edges
+            "n",          // no gate
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        let widget = config.type_by_name("widget").unwrap();
+        assert_eq!(
+            widget.lifecycle.states,
+            vec!["draft".to_string(), "done".to_string()]
+        );
+        assert_eq!(widget.lifecycle.edges.len(), 1);
+        assert_eq!(widget.lifecycle.edges[0].from, "draft");
+        assert_eq!(widget.lifecycle.edges[0].to, "done");
+    }
+
+    // STORY-226 AC2: declining the custom-lifecycle prompt leaves the lifecycle
+    // empty, so the type inherits the store preset via effective_lifecycle.
+    #[test]
+    fn interactive_add_type_declined_lifecycle_inherits_preset() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget", "widgets", "", "", "", "", "", "", "", // core fields
+            "n", "n", "n", "n", // attributes / parent / lifecycle / gate declined
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        let widget = config.type_by_name("widget").unwrap();
+        // Empty lifecycle -> inherits the store preset via effective_lifecycle.
+        assert!(widget.lifecycle.states.is_empty());
+        assert!(widget.lifecycle.edges.is_empty());
+        assert!(widget.effective_lifecycle().states.is_empty());
+    }
+
+    // STORY-226 AC3: only already-defined types are selectable as a parent; an
+    // unknown answer is rejected and re-asked rather than accepted.
+    #[test]
+    fn interactive_add_type_parent_only_from_existing() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget", "widgets", "", "", "", "", "", "", "",      // core fields
+            "n",     // no attributes
+            "y",     // set a parent type
+            "bogus", // not a defined type -> re-ask
+            "rfc",   // valid existing type
+            "n", "n", // lifecycle / gate declined
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        assert_eq!(
+            config
+                .type_by_name("widget")
+                .unwrap()
+                .parent_type
+                .as_deref(),
+            Some("rfc")
+        );
+    }
+
+    // STORY-226 AC4: gating a parent-child rule with a status the parent's
+    // lifecycle lacks is rejected and re-asked; the valid status is written.
+    #[test]
+    fn interactive_add_type_gate_reprompts_unknown_status() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "", // core fields
+            "n",
+            "n",
+            "n",                 // attributes / parent / lifecycle declined
+            "y",                 // gate a parent-child rule
+            "stories-need-rfcs", // the only parent-child rule (parent = rfc)
+            "shipped",           // rfc lifecycle lacks `shipped` -> re-ask
+            "review",            // rfc lifecycle has `review`
+        ]);
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let json = show(&std::fs::read_to_string(&path).unwrap());
+        assert_eq!(
+            rule_named(&json, "stories-need-rfcs")["require_parent_status"],
+            "review"
+        );
+    }
+
+    // STORY-226 AC5: the full interactive flow produces a byte-identical config to
+    // the equivalent add-type(+attrs+parent) -> set-lifecycle -> add-gate flag
+    // chain, and the result reparses cleanly.
+    #[test]
+    fn interactive_full_flow_matches_flag_chain() {
+        let (_dir_a, path_a, fs_a) = fixture(SRC);
+        let mut prompter = scripted(&[
+            "widget",
+            "widgets",
+            "",
+            "", // core fields (dir/prefix default)
+            "",
+            "",
+            "",
+            "",
+            "", // icon/store/numbering/singleton/authorship
+            "y",
+            "priority:enum:low,medium,high",
+            "n", // one attribute
+            "y",
+            "rfc", // parent = rfc
+            "y",
+            "draft",
+            "done",
+            "",
+            "draft:done",
+            "", // custom lifecycle
+            "y",
+            "stories-need-rfcs",
+            "review", // gate
+        ]);
+        run_add_type_interactive(path_a.parent().unwrap(), &fs_a, &mut prompter).unwrap();
+        let interactive_out = std::fs::read_to_string(&path_a).unwrap();
+
+        let (_dir_b, path_b, fs_b) = fixture(SRC);
+        let root_b = path_b.parent().unwrap();
+        run_add_type(
+            root_b,
+            &fs_b,
+            "widget",
+            "widgets",
+            "docs/widgets",
+            "WIDGET",
+            None,
+            Some("rfc"),
+            false,
+            Some("filesystem"),
+            Some("incremental"),
+            None,
+            Some("assisted"),
+            None,
+            &["priority:enum:low,medium,high".to_string()],
+        )
+        .unwrap();
+        run_set_lifecycle(
+            root_b,
+            &fs_b,
+            "widget",
+            &["draft".to_string(), "done".to_string()],
+            &["draft:done".to_string()],
+        )
+        .unwrap();
+        run_add_gate(root_b, &fs_b, "stories-need-rfcs", "review").unwrap();
+        let flag_out = std::fs::read_to_string(&path_b).unwrap();
+
+        assert_eq!(interactive_out, flag_out);
+        Config::parse(&interactive_out).unwrap();
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,3 +1,4 @@
+use crate::cli::wizard::Prompter;
 use crate::engine::config::{
     AttrDef, AttrKind, Authorship, Config, Edge, Lifecycle, NumberingStrategy, StoreBackend,
     TypeDef, ValidationRule,
@@ -25,16 +26,17 @@ pub enum ConfigCommand {
         #[arg(long)]
         json: bool,
     },
-    /// Append a new document type to .lazyspec.toml
+    /// Append a new document type to .lazyspec.toml. With all four positionals
+    /// omitted on a TTY, prompts for the core fields interactively.
     AddType {
         /// Type name (e.g. spike)
-        name: String,
+        name: Option<String>,
         /// Plural form used for directory listings (e.g. spikes)
-        plural: String,
+        plural: Option<String>,
         /// Directory the type's documents live in (e.g. docs/spikes)
-        dir: String,
+        dir: Option<String>,
         /// ID prefix for the type (e.g. SPIKE)
-        prefix: String,
+        prefix: Option<String>,
         /// Icon shown in the TUI
         #[arg(long)]
         icon: Option<String>,
@@ -165,6 +167,108 @@ pub fn run_add_type(
     let out = write_config_in_place(&src, &config)?;
     fs.write(&path, &out)?;
     Ok(())
+}
+
+/// How `config add-type` should proceed given its four positionals: all four
+/// present runs the flag path, all four absent prompts, and any partial mix is
+/// a usage error.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AddTypeInvocation {
+    Positional,
+    Prompt,
+}
+
+pub fn classify_add_type_args(positionals: [&Option<String>; 4]) -> Result<AddTypeInvocation> {
+    let supplied = positionals.iter().filter(|p| p.is_some()).count();
+    match supplied {
+        4 => Ok(AddTypeInvocation::Positional),
+        0 => Ok(AddTypeInvocation::Prompt),
+        _ => bail!(
+            "config add-type needs all four of name, plural, dir, prefix (or none, to prompt interactively)"
+        ),
+    }
+}
+
+/// Prompt for a type's core fields on a TTY and delegate to `run_add_type`.
+/// Only the fields the spec calls out are prompted; lifecycle, attributes,
+/// gates, and relations are left to their defaults / the flag path.
+pub fn run_add_type_interactive(
+    root: &Path,
+    fs: &dyn FileSystem,
+    prompter: &mut dyn Prompter,
+) -> Result<()> {
+    let path = root.join(".lazyspec.toml");
+    let src = fs.read_to_string(&path)?;
+    let config = Config::parse(&src)?;
+
+    let default_authorship = match Authorship::default() {
+        Authorship::Human => "human",
+        Authorship::Assisted => "assisted",
+        Authorship::Generated => "generated",
+    };
+
+    // Re-prompt the identity fields until neither the name nor the prefix
+    // collides with an existing type, rather than aborting the whole session.
+    let (name, plural, dir, prefix) = loop {
+        let name = prompter.ask("Type name", None)?;
+        let plural = prompter.ask("Plural", None)?;
+        let dir = prompter.ask("Directory", Some(&format!("docs/{plural}")))?;
+        let prefix = prompter.ask("ID prefix", Some(&name.to_uppercase()))?;
+
+        if config.type_by_name(&name).is_some() {
+            println!("type \"{name}\" already exists; choose another");
+            continue;
+        }
+        if config.documents.types.iter().any(|t| t.prefix == prefix) {
+            println!("prefix \"{prefix}\" is already in use; choose another");
+            continue;
+        }
+        break (name, plural, dir, prefix);
+    };
+
+    let icon = prompter.ask("Icon", None)?;
+    let icon = if icon.is_empty() { None } else { Some(icon) };
+    let store = prompter.select(
+        "Store",
+        &[
+            "filesystem",
+            "github-issues",
+            "github-milestones",
+            "github-projects",
+            "git-ref",
+            "clickup-tasks",
+        ],
+        "filesystem",
+    )?;
+    let numbering = prompter.select(
+        "Numbering",
+        &["incremental", "sqids", "reserved"],
+        "incremental",
+    )?;
+    let singleton = prompter.confirm("Singleton", false)?;
+    let authorship = prompter.select(
+        "Authorship",
+        &["human", "assisted", "generated"],
+        default_authorship,
+    )?;
+
+    run_add_type(
+        root,
+        fs,
+        &name,
+        &plural,
+        &dir,
+        &prefix,
+        icon.as_deref(),
+        None,
+        singleton,
+        Some(&store),
+        Some(&numbering),
+        None,
+        Some(&authorship),
+        None,
+        &[],
+    )
 }
 
 pub fn run_set_lifecycle(
@@ -342,6 +446,7 @@ fn parse_authorship(value: &str) -> Result<Authorship> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::wizard::ScriptedPrompter;
     use crate::engine::fs::RealFileSystem;
     use serde_json::Value;
     use std::path::PathBuf;
@@ -713,6 +818,130 @@ require_parent_status = "accepted"
 
     // AC4: set-lifecycle replaces the whole lifecycle (not a merge) and is gated
     // by an existing type.
+    // Interactive add-type writes byte-for-byte the same config as the
+    // equivalent flag call: same start config, same delegated TypeDef.
+    #[test]
+    fn interactive_add_type_matches_flag_call() {
+        let (_dir_a, path_a, fs_a) = fixture(SRC);
+        let mut prompter = ScriptedPrompter::new(
+            [
+                "spike",       // name
+                "spikes",      // plural
+                "docs/spikes", // dir
+                "SPIKE",       // prefix
+                "◆",           // icon
+                "filesystem",  // store
+                "incremental", // numbering
+                "y",           // singleton -> true
+                "generated",   // authorship
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        );
+        run_add_type_interactive(path_a.parent().unwrap(), &fs_a, &mut prompter).unwrap();
+        let interactive_out = std::fs::read_to_string(&path_a).unwrap();
+
+        let (_dir_b, path_b, fs_b) = fixture(SRC);
+        run_add_type(
+            path_b.parent().unwrap(),
+            &fs_b,
+            "spike",
+            "spikes",
+            "docs/spikes",
+            "SPIKE",
+            Some("◆"),
+            None,
+            true,
+            Some("filesystem"),
+            Some("incremental"),
+            None,
+            Some("generated"),
+            None,
+            &[],
+        )
+        .unwrap();
+        let flag_out = std::fs::read_to_string(&path_b).unwrap();
+
+        assert_eq!(interactive_out, flag_out);
+    }
+
+    // A duplicate name on the first pass re-prompts (consuming the next queued
+    // identity) rather than aborting, and never writes a duplicate.
+    #[test]
+    fn interactive_add_type_reprompts_on_duplicate_name() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = ScriptedPrompter::new(
+            [
+                "rfc", "rfcs", "", "", // first pass: rfc already exists -> reprompt
+                "spike", "spikes", "", "", // second pass: unique
+                "", // icon
+                "", // store -> filesystem
+                "", // numbering -> incremental
+                "", // singleton -> false
+                "", // authorship -> default
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        );
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        assert_eq!(
+            config
+                .documents
+                .types
+                .iter()
+                .filter(|t| t.name == "rfc")
+                .count(),
+            1,
+            "rfc must not be duplicated"
+        );
+        assert!(config.type_by_name("spike").is_some());
+    }
+
+    // Blank dir and prefix answers fall back to docs/<plural> and UPPERCASE(name).
+    #[test]
+    fn interactive_add_type_applies_default_dir_and_prefix() {
+        let (_dir, path, fs) = fixture(SRC);
+        let mut prompter = ScriptedPrompter::new(
+            [
+                "task", "tasks", "", "", // dir and prefix blank -> defaults
+                "", "", "", "", "",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        );
+        run_add_type_interactive(path.parent().unwrap(), &fs, &mut prompter).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let config = Config::parse(&after).unwrap();
+        let task = config.type_by_name("task").unwrap();
+        assert_eq!(task.dir, "docs/tasks");
+        assert_eq!(task.prefix, "TASK");
+    }
+
+    #[test]
+    fn classify_add_type_args_enforces_all_or_none() {
+        let some = Some("x".to_string());
+        assert_eq!(
+            classify_add_type_args([&some, &some, &some, &some]).unwrap(),
+            AddTypeInvocation::Positional
+        );
+        assert_eq!(
+            classify_add_type_args([&None, &None, &None, &None]).unwrap(),
+            AddTypeInvocation::Prompt
+        );
+        let err = classify_add_type_args([&some, &some, &None, &None]).unwrap_err();
+        assert!(
+            err.to_string().contains("all four"),
+            "partial positionals should error: {err}"
+        );
+    }
+
     #[test]
     fn set_lifecycle_replaces_states_and_edges() {
         let (_dir, path, fs) = fixture(SRC);

--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -147,6 +147,7 @@ pub fn run(
         None
     };
 
+    let pb = crate::cli::spinner::op_spinner("fetching from remotes", json);
     let outcomes = {
         let mut ctx = SyncContext {
             gh: issue_map.as_mut().map(|m| GhMaps { issue_map: m }),
@@ -195,6 +196,12 @@ pub fn run(
 
         sync_all(root, config, &mut ctx, &mut syncers, type_filter)
     };
+
+    if outcomes.iter().any(|o| o.error.is_some()) {
+        crate::cli::spinner::finish_err(pb, "fetch completed with errors");
+    } else {
+        crate::cli::spinner::finish_ok(pb, "fetch complete");
+    }
 
     for o in &outcomes {
         for w in &o.warnings {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,3 +1,5 @@
+use crate::cli::config::{apply_collected_type, collect_type_interactive};
+use crate::cli::wizard::Prompter;
 use crate::engine::config::{
     default_rules, starter_relationships, starter_types, CertificationConfig, Config,
     DocumentConfig, FilesystemConfig, Naming, Templates, UiConfig,
@@ -8,6 +10,7 @@ use crate::engine::github::resolve_repo;
 use anyhow::{bail, Result};
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 /// The starter config `init` writes into a fresh project. Per ADR-011 this is the
 /// sole home for default types and rules; the engine load path carries none.
@@ -39,13 +42,35 @@ pub fn starter_config() -> Config {
     }
 }
 
-pub fn run(root: &Path) -> Result<()> {
-    let config_path = root.join(".lazyspec.toml");
-    if config_path.exists() {
+/// Whether `init` should run the interactive wizard: neither opt-out flag set
+/// and both stdin and stdout are TTYs. `--json` implies `--non-interactive`.
+pub fn init_is_interactive(
+    non_interactive: bool,
+    json: bool,
+    stdin_tty: bool,
+    stdout_tty: bool,
+) -> bool {
+    !non_interactive && !json && stdin_tty && stdout_tty
+}
+
+fn ensure_no_config(root: &Path) -> Result<()> {
+    if root.join(".lazyspec.toml").exists() {
         bail!(".lazyspec.toml already exists");
     }
+    Ok(())
+}
 
-    let config = starter_config();
+pub fn run(root: &Path) -> Result<()> {
+    ensure_no_config(root)?;
+    write_project(root, &starter_config())
+}
+
+/// Scaffold a fresh project from `config`: per-type directories, the templates
+/// dir and default template, type skeletons, the serialized `.lazyspec.toml`,
+/// and (for github-issues types) labels and gitignore entries. The single write
+/// path shared by both the non-interactive and interactive `init` entry points.
+pub fn write_project(root: &Path, config: &Config) -> Result<()> {
+    let config_path = root.join(".lazyspec.toml");
 
     for type_def in &config.documents.types {
         fs::create_dir_all(root.join(&type_def.dir))?;
@@ -54,15 +79,79 @@ pub fn run(root: &Path) -> Result<()> {
     fs::create_dir_all(&templates_dir)?;
     write_if_absent(&templates_dir.join("template.md"), default_template())?;
 
-    scaffold_skeleton_files(root, &config)?;
+    scaffold_skeleton_files(root, config)?;
 
     fs::write(&config_path, config.to_toml()?)?;
 
-    ensure_github_labels(&config, root);
-    ensure_gitignore(&config, root)?;
+    ensure_github_labels(config, root);
+    ensure_gitignore(config, root)?;
 
     println!("Initialized lazyspec in {}", root.display());
     Ok(())
+}
+
+/// Interactive `init`: bail if a config already exists (before prompting), then
+/// walk the starter-config wizard and scaffold the designed config.
+pub fn run_init_interactive(root: &Path, prompter: &mut dyn Prompter) -> Result<()> {
+    ensure_no_config(root)?;
+    let config = design_config_interactive(starter_config(), prompter)?;
+    write_project(root, &config)
+}
+
+/// Read `git config user.name` as the author prompt's default, or `None` when
+/// git is unavailable or unconfigured. Purely cosmetic: this slice prompts for
+/// an author but does not persist it (Config has no author field).
+fn git_user_name() -> Option<String> {
+    let output = Command::new("git")
+        .args(["config", "user.name"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+/// Walk the starter config with the user: prompt author (not persisted), naming
+/// pattern, keep/drop each starter type, then an add-type loop. Pure -- no disk
+/// IO -- so it is fully driveable by a `ScriptedPrompter`. Accepting every
+/// default returns `base` unchanged (byte-for-byte parity with `init`). A `no`
+/// at the final write confirmation discards the session and starts over.
+pub fn design_config_interactive(base: Config, prompter: &mut dyn Prompter) -> Result<Config> {
+    let author_default = git_user_name();
+    loop {
+        let mut config = base.clone();
+
+        // Prompted for the wizard's sake but intentionally discarded: there is
+        // no author field to persist it to in this slice.
+        let _author = prompter.ask("Author", author_default.as_deref())?;
+
+        let pattern = prompter.ask("Naming pattern", Some(&base.documents.naming.pattern))?;
+        config.documents.naming.pattern = pattern;
+
+        let mut kept = Vec::new();
+        for type_def in &base.documents.types {
+            if prompter.confirm(&format!("Keep type {}", type_def.name), true)? {
+                kept.push(type_def.clone());
+            }
+        }
+        config.documents.types = kept;
+
+        while prompter.confirm("Add another type", false)? {
+            let collected = collect_type_interactive(&config, prompter)?;
+            apply_collected_type(&mut config, &collected)?;
+        }
+
+        if prompter.confirm("Write this config", true)? {
+            return Ok(config);
+        }
+        println!("discarded; starting over");
+    }
 }
 
 fn ensure_github_labels(config: &Config, root: &Path) {
@@ -218,7 +307,205 @@ by agent skills. For example, a dictum about testing philosophy would have
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::wizard::ScriptedPrompter;
     use crate::engine::config::{StoreBackend, TypeDef};
+    use crate::engine::fs::RealFileSystem;
+    use crate::engine::store::Store;
+    use crate::engine::validation::validate_full;
+
+    fn scripted(answers: &[&str]) -> ScriptedPrompter {
+        ScriptedPrompter::new(answers.iter().map(|s| s.to_string()).collect())
+    }
+
+    // Enough blank answers to accept every default in the wizard: author, naming,
+    // one keep-confirm per starter type, the add-another decline, and the final
+    // write confirmation.
+    fn all_default_answers() -> Vec<String> {
+        let n = starter_config().documents.types.len();
+        vec![String::new(); n + 4]
+    }
+
+    // AC1: the wizard prompts author then naming then keep/drop, so a queued
+    // non-blank naming pattern lands on the config and every starter type
+    // survives a keep-all walk. (Misaligning the author prompt would divert the
+    // pattern answer and fail the assertion.)
+    #[test]
+    fn design_prompts_author_naming_types() {
+        let mut answers = vec![
+            "Ada Lovelace".to_string(), // author (prompted, discarded)
+            "custom-{type}-{n:03}-{title}.md".to_string(), // naming pattern
+        ];
+        let starter = starter_config();
+        for _ in &starter.documents.types {
+            answers.push("y".to_string()); // keep each starter type
+        }
+        answers.push("n".to_string()); // add another? no
+        answers.push("y".to_string()); // write? yes
+
+        let mut prompter = ScriptedPrompter::new(answers);
+        let config = design_config_interactive(starter_config(), &mut prompter).unwrap();
+
+        assert_eq!(
+            config.documents.naming.pattern,
+            "custom-{type}-{n:03}-{title}.md"
+        );
+        for type_def in &starter.documents.types {
+            assert!(
+                config.type_by_name(&type_def.name).is_some(),
+                "starter type {} should survive keep-all",
+                type_def.name
+            );
+        }
+    }
+
+    // AC2: accepting every default returns the starter config byte-for-byte, so a
+    // non-interactive `init` and an accept-all interactive `init` are identical.
+    #[test]
+    fn design_all_defaults_equals_starter() {
+        let mut prompter = ScriptedPrompter::new(all_default_answers());
+        let config = design_config_interactive(starter_config(), &mut prompter).unwrap();
+        assert_eq!(
+            config.to_toml().unwrap(),
+            starter_config().to_toml().unwrap()
+        );
+    }
+
+    // AC3: the non-interactive scaffold writer emits exactly the starter config.
+    #[test]
+    fn init_noninteractive_writes_starter() {
+        let dir = tempfile::tempdir().unwrap();
+        write_project(dir.path(), &starter_config()).unwrap();
+        let written = fs::read_to_string(dir.path().join(".lazyspec.toml")).unwrap();
+        assert_eq!(written, starter_config().to_toml().unwrap());
+    }
+
+    // AC3: `--json` and `--non-interactive` and a non-TTY each suppress the wizard;
+    // only a plain TTY invocation runs it.
+    #[test]
+    fn json_suppresses_interactive() {
+        assert!(!init_is_interactive(false, true, true, true), "--json");
+        assert!(
+            !init_is_interactive(true, false, true, true),
+            "--non-interactive"
+        );
+        assert!(
+            !init_is_interactive(false, false, false, true),
+            "no stdin tty"
+        );
+        assert!(
+            !init_is_interactive(false, false, true, false),
+            "no stdout tty"
+        );
+        assert!(init_is_interactive(false, false, true, true), "plain tty");
+    }
+
+    // AC4: an existing .lazyspec.toml bails both paths, and the interactive path
+    // bails before consuming any prompt answer (empty queue never errors).
+    #[test]
+    fn init_bails_when_config_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".lazyspec.toml"), "existing").unwrap();
+
+        let non_interactive = run(dir.path());
+        assert!(non_interactive.is_err(), "run should bail");
+
+        let mut prompter = scripted(&[]);
+        let interactive = run_init_interactive(dir.path(), &mut prompter);
+        assert!(interactive.is_err(), "interactive run should bail");
+        assert!(
+            interactive
+                .unwrap_err()
+                .to_string()
+                .contains("already exists"),
+            "bail message names the conflict"
+        );
+    }
+
+    // Drop one starter type and add a new one; the designed config reflects both.
+    fn drop_spec_add_spike_answers() -> Vec<String> {
+        [
+            "",       // author
+            "",       // naming (default)
+            "y",      // keep rfc
+            "y",      // keep story
+            "y",      // keep iteration
+            "y",      // keep adr
+            "n",      // DROP spec
+            "y",      // keep convention
+            "y",      // keep dictum
+            "y",      // add another type? yes
+            "spike",  // name
+            "spikes", // plural
+            "",       // dir -> docs/spikes
+            "",       // prefix -> SPIKE
+            "",       // icon (none)
+            "",       // store -> filesystem
+            "",       // numbering -> incremental
+            "",       // singleton -> false
+            "",       // authorship -> default
+            "n",      // add an attribute? no
+            "n",      // set a parent type? no
+            "n",      // design custom lifecycle? no
+            "n",      // gate a parent-child rule? no
+            "n",      // add another type? no
+            "y",      // write this config? yes
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    // AC5: dropping a starter type removes it and adding a new one appends it.
+    #[test]
+    fn design_drop_and_add() {
+        let mut prompter = ScriptedPrompter::new(drop_spec_add_spike_answers());
+        let config = design_config_interactive(starter_config(), &mut prompter).unwrap();
+
+        assert!(config.type_by_name("spec").is_none(), "dropped type absent");
+        assert!(config.type_by_name("spike").is_some(), "added type present");
+        let spike = config.type_by_name("spike").unwrap();
+        assert_eq!(spike.dir, "docs/spikes");
+        assert_eq!(spike.prefix, "SPIKE");
+    }
+
+    // AC5: scaffolding a designed config round-trips to a project that validates
+    // clean, with per-type dirs, the template, and skeletons matching the design.
+    #[test]
+    fn write_project_scaffold_validates() {
+        let mut prompter = ScriptedPrompter::new(drop_spec_add_spike_answers());
+        let config = design_config_interactive(starter_config(), &mut prompter).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_project(root, &config).unwrap();
+
+        // Per-type directories track the designed set: dropped type absent, new
+        // type present.
+        assert!(root.join("docs/spikes").is_dir(), "new type dir created");
+        assert!(!root.join("docs/specs").exists(), "dropped type dir absent");
+        assert!(root.join("docs/rfcs").is_dir());
+        assert!(
+            root.join(".lazyspec/templates/template.md").is_file(),
+            "default template written"
+        );
+        assert!(
+            root.join("docs/convention/convention/index.md").is_file(),
+            "convention skeleton written"
+        );
+
+        let fs = RealFileSystem;
+        let loaded = Config::load(root, &fs).unwrap();
+        assert!(loaded.type_by_name("spike").is_some());
+        assert!(loaded.type_by_name("spec").is_none());
+
+        let store = Store::load(root, &loaded).unwrap();
+        let result = validate_full(&store, &loaded);
+        assert!(
+            result.errors.is_empty(),
+            "scaffolded project should validate clean: {:?}",
+            result.errors
+        );
+    }
 
     fn gh_issues_config() -> Config {
         let mut config = Config::default();

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,8 +1,10 @@
-use crate::cli::config::{apply_collected_type, collect_type_interactive};
+use crate::cli::config::{
+    apply_collected_type, collect_parent_child_rule, collect_type_interactive,
+};
 use crate::cli::wizard::Prompter;
 use crate::engine::config::{
     default_rules, starter_relationships, starter_types, CertificationConfig, Config,
-    DocumentConfig, FilesystemConfig, Naming, Templates, UiConfig,
+    DocumentConfig, FilesystemConfig, Naming, Templates, UiConfig, ValidationRule,
 };
 use crate::engine::fs_ops::default_template;
 use crate::engine::gh::{deterministic_color, GhCli, GhError, GhIssueWriter};
@@ -91,10 +93,18 @@ pub fn write_project(root: &Path, config: &Config) -> Result<()> {
 }
 
 /// Interactive `init`: bail if a config already exists (before prompting), then
-/// walk the starter-config wizard and scaffold the designed config.
+/// offer the two authoring paths -- tweak the starter DAG (STORY-227) or design a
+/// DAG from scratch (STORY-228) -- and scaffold whichever config the chosen
+/// designer returns. The single interactive dispatch; `--json`/`--non-interactive`
+/// /non-TTY never reach it (they take the `starter_config()` path in `run`).
 pub fn run_init_interactive(root: &Path, prompter: &mut dyn Prompter) -> Result<()> {
     ensure_no_config(root)?;
-    let config = design_config_interactive(starter_config(), prompter)?;
+    let choice = prompter.select("Start from", &["starter", "scratch"], "starter")?;
+    let config = if choice == "scratch" {
+        design_config_from_scratch(prompter)?
+    } else {
+        design_config_interactive(starter_config(), prompter)?
+    };
     write_project(root, &config)
 }
 
@@ -152,6 +162,137 @@ pub fn design_config_interactive(base: Config, prompter: &mut dyn Prompter) -> R
         }
         println!("discarded; starting over");
     }
+}
+
+/// The empty base the from-scratch designer builds on: the starter config's
+/// non-type scaffolding (naming pattern, filesystem, ui, ceiling, certification)
+/// and the type-agnostic starter relationship vocabulary, but with NO types and
+/// NO rules. Rules must start empty so the from-scratch DAG never inherits a rule
+/// referencing a type it does not define (the dangling-rule trap); every rule is
+/// built from the user's own parent-child steps, whose endpoints are types they
+/// just defined. Relationships are safe to keep because they name no types.
+pub fn blank_config() -> Config {
+    Config {
+        documents: DocumentConfig {
+            types: vec![],
+            ..starter_config().documents
+        },
+        rules: vec![],
+        ..starter_config()
+    }
+}
+
+/// Design a whole type DAG from nothing, interactively: author (prompted, not
+/// persisted), naming pattern, a types loop (at least one type required), then --
+/// once two or more types exist -- a parent-child rules loop with severity and an
+/// optional parent-status gate. Renders a DAG summary and asks to write; a `no`
+/// discards the session and starts over. Pure -- no disk IO -- so it is fully
+/// driveable by a `ScriptedPrompter`. The returned `Config` owes nothing to
+/// `starter_config()`'s types or rules and validates clean via `write_project`.
+pub fn design_config_from_scratch(prompter: &mut dyn Prompter) -> Result<Config> {
+    let author_default = git_user_name();
+    let base = blank_config();
+    loop {
+        let mut config = base.clone();
+
+        // Prompted for the wizard's sake but intentionally discarded: there is
+        // no author field to persist it to in this slice.
+        let _author = prompter.ask("Author", author_default.as_deref())?;
+
+        let pattern = prompter.ask("Naming pattern", Some(&base.documents.naming.pattern))?;
+        config.documents.naming.pattern = pattern;
+
+        // Types loop: at least one type is required. The "Add a type" default is
+        // yes while no type exists yet and no afterwards, so accepting defaults
+        // adds one type then stops; declining while still empty re-asks.
+        loop {
+            let want_type = prompter.confirm("Add a type", config.documents.types.is_empty())?;
+            if want_type {
+                let collected = collect_type_interactive(&config, prompter)?;
+                apply_collected_type(&mut config, &collected)?;
+            } else if config.documents.types.is_empty() {
+                println!("at least one type is required");
+            } else {
+                break;
+            }
+        }
+
+        // Parent-child rules only make sense once at least two types exist. Each
+        // rule's endpoints are chosen from the defined types, so no rule can
+        // dangle. Gates attach here (after rules exist), not in the types loop.
+        if config.documents.types.len() >= 2 {
+            while prompter.confirm("Add a parent-child rule", false)? {
+                let rule = collect_parent_child_rule(&config, prompter)?;
+                config.rules.push(rule);
+            }
+        }
+
+        print!("{}", render_dag_summary(&config));
+        if prompter.confirm("Write this config", true)? {
+            return Ok(config);
+        }
+        println!("discarded; starting over");
+    }
+}
+
+/// A human-readable summary of the designed DAG: every type with its plural,
+/// directory, prefix, store, and effective lifecycle (states and edges); every
+/// parent-child rule with its child, parent, severity, and gate status; and the
+/// relation vocabulary. Rendered before the final write confirmation.
+fn render_dag_summary(config: &Config) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    out.push_str("\nTypes:\n");
+    for type_def in &config.documents.types {
+        let _ = writeln!(
+            out,
+            "  {} (plural: {}, dir: {}, prefix: {}, store: {})",
+            type_def.name, type_def.plural, type_def.dir, type_def.prefix, type_def.store,
+        );
+        let lifecycle = type_def.effective_lifecycle();
+        let _ = writeln!(out, "    lifecycle: {}", lifecycle.states.join(", "));
+        for edge in &lifecycle.edges {
+            let _ = writeln!(out, "      edge: {} -> {}", edge.from, edge.to);
+        }
+    }
+
+    out.push_str("Parent-child rules:\n");
+    let mut any_rule = false;
+    for rule in &config.rules {
+        if let ValidationRule::ParentChild {
+            name,
+            child,
+            parent,
+            severity,
+            require_parent_status,
+        } = rule
+        {
+            any_rule = true;
+            let gate = match require_parent_status {
+                Some(status) => format!(", gate: parent status = {status}"),
+                None => String::new(),
+            };
+            let severity = match severity {
+                crate::engine::config::Severity::Error => "error",
+                crate::engine::config::Severity::Warning => "warning",
+            };
+            let _ = writeln!(
+                out,
+                "  {name}: {child} -> {parent} (severity: {severity}{gate})",
+            );
+        }
+    }
+    if !any_rule {
+        out.push_str("  (none)\n");
+    }
+
+    out.push_str("Relation vocabulary:\n");
+    for rel in &config.relationships {
+        let _ = writeln!(out, "  {}", rel.name);
+    }
+
+    out
 }
 
 fn ensure_github_labels(config: &Config, root: &Path) {
@@ -308,7 +449,7 @@ by agent skills. For example, a dictum about testing philosophy would have
 mod tests {
     use super::*;
     use crate::cli::wizard::ScriptedPrompter;
-    use crate::engine::config::{StoreBackend, TypeDef};
+    use crate::engine::config::{Severity, StoreBackend, TypeDef};
     use crate::engine::fs::RealFileSystem;
     use crate::engine::store::Store;
     use crate::engine::validation::validate_full;
@@ -504,6 +645,320 @@ mod tests {
             result.errors.is_empty(),
             "scaffolded project should validate clean: {:?}",
             result.errors
+        );
+    }
+
+    // --- STORY-228: from-scratch (blank slate) DAG designer ---
+
+    // Blank base parity: no types, no rules, but the type-agnostic starter
+    // relationship vocabulary and the `.md`-suffixed starter naming pattern.
+    #[test]
+    fn scratch_blank_config_parity() {
+        let blank = blank_config();
+        assert!(blank.documents.types.is_empty(), "types start empty");
+        assert!(
+            blank.rules.is_empty(),
+            "rules start empty (no dangling rules)"
+        );
+        assert_eq!(
+            blank.relationships,
+            crate::engine::config::starter_relationships()
+        );
+        assert_eq!(
+            blank.documents.naming.pattern, "{type}-{n:03}-{title}.md",
+            "naming default keeps the .md suffix"
+        );
+    }
+
+    // A full from-scratch happy-path script: rfc (custom lifecycle draft ->
+    // accepted), story (inherited lifecycle, parent rfc), and a story -> rfc
+    // parent-child rule with severity=error gated on parent status `accepted`.
+    fn full_scratch_answers() -> Vec<String> {
+        [
+            "",               // author
+            "",               // naming pattern (default)
+            "y",              // add a type? -> rfc
+            "rfc",            // name
+            "rfcs",           // plural
+            "",               // dir -> docs/rfcs
+            "",               // prefix -> RFC
+            "",               // icon (none)
+            "",               // store -> filesystem
+            "",               // numbering -> incremental
+            "",               // singleton -> false
+            "",               // authorship -> default
+            "n",              // add an attribute? no
+            "y",              // design a custom lifecycle? yes
+            "draft",          // state
+            "accepted",       // state
+            "",               // finish states
+            "draft:accepted", // edge
+            "",               // finish edges
+            "y",              // add a type? -> story
+            "story",          // name
+            "stories",        // plural
+            "",               // dir -> docs/stories
+            "",               // prefix -> STORY
+            "",               // icon (none)
+            "",               // store -> filesystem
+            "",               // numbering -> incremental
+            "",               // singleton -> false
+            "",               // authorship -> default
+            "n",              // add an attribute? no
+            "n",              // set a parent type? no (the DAG edge is the rule below)
+            "n",              // design a custom lifecycle? no (inherits preset)
+            "n",              // add another type? no
+            "y",              // add a parent-child rule? yes
+            "story",          // child
+            "rfc",            // parent
+            "error",          // severity
+            "y",              // gate on a parent status? yes
+            "accepted",       // required parent status
+            "n",              // add another rule? no
+            "y",              // write this config? yes
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    // AC1: a custom-lifecycle edge and a rule gate that each name an undefined
+    // state re-prompt (reusing the type collector) rather than aborting; only
+    // defined states/statuses are accepted.
+    #[test]
+    fn scratch_lifecycle_and_gate_reject_unknown_states() {
+        let answers = [
+            "",
+            "",  // author, naming
+            "y", // add a type -> alpha
+            "alpha",
+            "alphas",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",  // core fields
+            "n", // no attribute
+            "y", // custom lifecycle
+            "draft",
+            "done",
+            "",           // states
+            "draft:nope", // edge names an undefined state -> re-ask
+            "draft:done", // valid
+            "",           // finish edges
+            "y",          // add a type -> beta
+            "beta",
+            "betas",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",  // core fields
+            "n", // no attribute
+            "n", // set a parent type? no (the DAG edge is the rule below)
+            "n", // no custom lifecycle
+            "n", // add another type? no
+            "y", // add a parent-child rule
+            "beta",
+            "alpha", // child, parent
+            "",      // severity -> warning
+            "y",     // gate on a parent status
+            "bogus", // not in alpha's lifecycle -> re-ask
+            "done",  // valid
+            "n",     // add another rule? no
+            "y",     // write
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let mut prompter = ScriptedPrompter::new(answers);
+        let config = design_config_from_scratch(&mut prompter).unwrap();
+
+        let alpha = config.type_by_name("alpha").unwrap();
+        assert_eq!(alpha.lifecycle.states, vec!["draft", "done"]);
+        assert_eq!(alpha.lifecycle.edges.len(), 1, "bad edge was not kept");
+        assert_eq!(alpha.lifecycle.edges[0].from, "draft");
+        assert_eq!(alpha.lifecycle.edges[0].to, "done");
+
+        let rule = config
+            .rules
+            .iter()
+            .find_map(|r| match r {
+                ValidationRule::ParentChild {
+                    require_parent_status,
+                    ..
+                } => require_parent_status.clone(),
+                _ => None,
+            })
+            .expect("a gated parent-child rule exists");
+        assert_eq!(rule, "done", "only a defined parent status is accepted");
+    }
+
+    // AC2: a parent-child rule draws child and parent from the defined types
+    // (an unknown child re-asks) and records the chosen severity.
+    #[test]
+    fn scratch_parent_child_rule_defined_types_and_severity() {
+        let answers = [
+            "", "",  // author, naming
+            "y", // add a type -> alpha
+            "alpha", "alphas", "", "", "", "", "", "", "",  // core fields
+            "n", // no attribute
+            "n", // no custom lifecycle
+            "y", // add a type -> beta
+            "beta", "betas", "", "", "", "", "", "", "",      // core fields
+            "n",     // no attribute
+            "n",     // no parent
+            "n",     // no custom lifecycle
+            "n",     // add another type? no
+            "y",     // add a parent-child rule
+            "ghost", // not a defined type -> re-ask child
+            "beta",  // child
+            "alpha", // parent
+            "error", // severity
+            "n",     // no gate
+            "n",     // add another rule? no
+            "y",     // write
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let mut prompter = ScriptedPrompter::new(answers);
+        let config = design_config_from_scratch(&mut prompter).unwrap();
+
+        let rule = config
+            .rules
+            .iter()
+            .find_map(|r| match r {
+                ValidationRule::ParentChild {
+                    child,
+                    parent,
+                    severity,
+                    ..
+                } => Some((child.clone(), parent.clone(), severity.clone())),
+                _ => None,
+            })
+            .expect("a parent-child rule exists");
+        assert_eq!(rule.0, "beta", "child from defined types");
+        assert_eq!(rule.1, "alpha", "parent from defined types");
+        assert_eq!(rule.2, Severity::Error, "chosen severity recorded");
+    }
+
+    // AC3: the DAG summary names every type, its lifecycle, every rule and gate,
+    // and the relation vocabulary. (The write confirmation is exercised by the
+    // decline test below and by every happy-path script ending in `write? yes`.)
+    #[test]
+    fn scratch_summary_lists_dag() {
+        let mut prompter = ScriptedPrompter::new(full_scratch_answers());
+        let config = design_config_from_scratch(&mut prompter).unwrap();
+
+        let summary = render_dag_summary(&config);
+        assert!(summary.contains("rfc"), "type rfc: {summary}");
+        assert!(summary.contains("story"), "type story: {summary}");
+        assert!(
+            summary.contains("draft -> accepted"),
+            "rfc lifecycle edge: {summary}"
+        );
+        assert!(
+            summary.contains("stories-need-rfcs"),
+            "rule name: {summary}"
+        );
+        assert!(
+            summary.contains("story -> rfc"),
+            "rule endpoints: {summary}"
+        );
+        assert!(
+            summary.contains("parent status = accepted"),
+            "gate: {summary}"
+        );
+        assert!(summary.contains("implements"), "relation vocab: {summary}");
+    }
+
+    // AC4: a full from-scratch design scaffolds into a temp dir that loads and
+    // validates with zero errors -- including no dangling rule (every rule
+    // endpoint is a defined type).
+    #[test]
+    fn scratch_scaffold_validates_clean() {
+        let mut prompter = ScriptedPrompter::new(full_scratch_answers());
+        let config = design_config_from_scratch(&mut prompter).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_project(root, &config).unwrap();
+
+        assert!(root.join("docs/rfcs").is_dir(), "rfc dir created");
+        assert!(root.join("docs/stories").is_dir(), "story dir created");
+        assert!(
+            root.join(".lazyspec/templates/template.md").is_file(),
+            "template written"
+        );
+
+        let fs = RealFileSystem;
+        let loaded = Config::load(root, &fs).unwrap();
+
+        // Explicit no-dangling-rule check: every rule endpoint is a defined type.
+        let defined: Vec<&str> = loaded
+            .documents
+            .types
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect();
+        for rule in &loaded.rules {
+            if let ValidationRule::ParentChild { child, parent, .. } = rule {
+                assert!(defined.contains(&child.as_str()), "child {child} defined");
+                assert!(
+                    defined.contains(&parent.as_str()),
+                    "parent {parent} defined"
+                );
+            }
+        }
+
+        let store = Store::load(root, &loaded).unwrap();
+        let result = validate_full(&store, &loaded);
+        assert!(
+            result.errors.is_empty(),
+            "scaffolded from-scratch project should validate clean: {:?}",
+            result.errors
+        );
+    }
+
+    // AC5: declining at the write confirmation on the scratch path (then aborting
+    // the reloop) writes nothing -- no config file, no per-type directories.
+    #[test]
+    fn scratch_decline_writes_nothing() {
+        let answers = [
+            "scratch", // first-screen select
+            "", "",  // author, naming
+            "y", // add a type -> solo
+            "solo", "solos", "", "", "", "", "", "", "",  // core fields
+            "n", // no attribute
+            "n", // no custom lifecycle
+            "n", // add another type? no (one type is enough; no rule loop)
+            "n", // write this config? no -> discard and reloop
+                 // reloop asks for author again; the queue is empty -> Err (abort)
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut prompter = ScriptedPrompter::new(answers);
+        let result = run_init_interactive(root, &mut prompter);
+
+        assert!(result.is_err(), "aborting the reloop propagates an error");
+        assert!(
+            !root.join(".lazyspec.toml").exists(),
+            "no config written on decline"
+        );
+        assert!(
+            !root.join("docs/solos").exists(),
+            "no per-type dir written on decline"
         );
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -115,7 +115,7 @@ pub fn run_init_interactive(
     // This path is only reached interactively (main.rs routes `--json`/non-TTY to
     // `run`), so json is false here; the guard still honours colours-off / non-TTY.
     if crate::cli::spinner::should_greet(false, std::io::stdout().is_terminal(), colors_enabled()) {
-        crate::cli::spinner::say("hi there, let's set up your project");
+        crate::cli::spinner::say("a new project begins......");
     }
     let config = if template == Some("starter") {
         design_config_interactive(starter_config(), prompter)?

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -93,17 +93,28 @@ pub fn write_project(root: &Path, config: &Config) -> Result<()> {
 }
 
 /// Interactive `init`: bail if a config already exists (before prompting), then
-/// offer the two authoring paths -- tweak the starter DAG (STORY-227) or design a
-/// DAG from scratch (STORY-228) -- and scaffold whichever config the chosen
-/// designer returns. The single interactive dispatch; `--json`/`--non-interactive`
-/// /non-TTY never reach it (they take the `starter_config()` path in `run`).
-pub fn run_init_interactive(root: &Path, prompter: &mut dyn Prompter) -> Result<()> {
+/// scaffold whichever config the chosen designer returns. The wizard defaults to a
+/// blank DAG (STORY-228); passing `template == Some("starter")` pre-selects the
+/// starter designer (STORY-227) and skips the first "Start from" screen entirely.
+/// With no template the first screen offers `blank`/`starter`, defaulting to
+/// `blank`. The single interactive dispatch; `--json`/`--non-interactive`/non-TTY
+/// never reach it (they take the `starter_config()` path in `run`, which never
+/// consults `template`).
+pub fn run_init_interactive(
+    root: &Path,
+    prompter: &mut dyn Prompter,
+    template: Option<&str>,
+) -> Result<()> {
     ensure_no_config(root)?;
-    let choice = prompter.select("Start from", &["starter", "scratch"], "starter")?;
-    let config = if choice == "scratch" {
-        design_config_from_scratch(prompter)?
-    } else {
+    let config = if template == Some("starter") {
         design_config_interactive(starter_config(), prompter)?
+    } else {
+        let choice = prompter.select("Start from", &["blank", "starter"], "blank")?;
+        if choice == "starter" {
+            design_config_interactive(starter_config(), prompter)?
+        } else {
+            design_config_from_scratch(prompter)?
+        }
     };
     write_project(root, &config)
 }
@@ -551,7 +562,7 @@ mod tests {
         assert!(non_interactive.is_err(), "run should bail");
 
         let mut prompter = scripted(&[]);
-        let interactive = run_init_interactive(dir.path(), &mut prompter);
+        let interactive = run_init_interactive(dir.path(), &mut prompter, None);
         assert!(interactive.is_err(), "interactive run should bail");
         assert!(
             interactive
@@ -928,7 +939,7 @@ mod tests {
     #[test]
     fn scratch_decline_writes_nothing() {
         let answers = [
-            "scratch", // first-screen select
+            "blank", // first-screen select
             "", "",  // author, naming
             "y", // add a type -> solo
             "solo", "solos", "", "", "", "", "", "", "",  // core fields
@@ -945,7 +956,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let mut prompter = ScriptedPrompter::new(answers);
-        let result = run_init_interactive(root, &mut prompter);
+        let result = run_init_interactive(root, &mut prompter, None);
 
         assert!(result.is_err(), "aborting the reloop propagates an error");
         assert!(
@@ -955,6 +966,65 @@ mod tests {
         assert!(
             !root.join("docs/solos").exists(),
             "no per-type dir written on decline"
+        );
+    }
+
+    // ITERATION-330: `--template starter` pre-selects the starter designer and
+    // SKIPS the first-screen select. The script starts at the author prompt (no
+    // queued "Start from" answer); accepting every default yields the starter
+    // config, proving no first-screen answer was consumed (a consumed answer would
+    // divert the author prompt and desync the keep-all walk).
+    #[test]
+    fn template_starter_skips_first_screen() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut prompter = ScriptedPrompter::new(all_default_answers());
+
+        run_init_interactive(root, &mut prompter, Some("starter")).unwrap();
+
+        let written = fs::read_to_string(root.join(".lazyspec.toml")).unwrap();
+        assert_eq!(
+            written,
+            starter_config().to_toml().unwrap(),
+            "starter template routes straight to the starter designer"
+        );
+    }
+
+    // ITERATION-330: with no template the first-screen default is `blank`, so a
+    // blank first answer routes to the from-scratch designer. A minimal scratch
+    // script (one type, no rule loop) then produces a config with only that type
+    // and none of the starter types.
+    #[test]
+    fn no_template_default_routes_to_scratch() {
+        let answers = [
+            "", // first-screen select -> default "blank"
+            "", "",  // author, naming
+            "y", // add a type -> solo
+            "solo", "solos", "", "", "", "", "", "", "",  // core fields
+            "n", // no attribute
+            "n", // no custom lifecycle
+            "n", // add another type? no
+            "y", // write this config? yes
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut prompter = ScriptedPrompter::new(answers);
+
+        run_init_interactive(root, &mut prompter, None).unwrap();
+
+        let fs = RealFileSystem;
+        let loaded = Config::load(root, &fs).unwrap();
+        assert!(
+            loaded.type_by_name("solo").is_some(),
+            "from-scratch type present"
+        );
+        assert!(
+            loaded.type_by_name("rfc").is_none(),
+            "no starter types on the from-scratch path"
         );
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,7 @@
 use crate::cli::config::{
     apply_collected_type, collect_parent_child_rule, collect_type_interactive,
 };
+use crate::cli::style::{bold, dim, section_header, success_line, warning_prefix};
 use crate::cli::wizard::Prompter;
 use crate::engine::config::{
     default_rules, starter_relationships, starter_types, CertificationConfig, Config,
@@ -88,7 +89,10 @@ pub fn write_project(root: &Path, config: &Config) -> Result<()> {
     ensure_github_labels(config, root);
     ensure_gitignore(config, root)?;
 
-    println!("Initialized lazyspec in {}", root.display());
+    println!(
+        "{}",
+        success_line(&format!("Initialized lazyspec in {}", root.display()))
+    );
     Ok(())
 }
 
@@ -109,6 +113,7 @@ pub fn run_init_interactive(
     let config = if template == Some("starter") {
         design_config_interactive(starter_config(), prompter)?
     } else {
+        println!("{}", section_header("Start from"));
         let choice = prompter.select("Start from", &["blank", "starter"], "blank")?;
         if choice == "starter" {
             design_config_interactive(starter_config(), prompter)?
@@ -171,7 +176,7 @@ pub fn design_config_interactive(base: Config, prompter: &mut dyn Prompter) -> R
         if prompter.confirm("Write this config", true)? {
             return Ok(config);
         }
-        println!("discarded; starting over");
+        println!("{} {}", warning_prefix(), dim("discarded; starting over"));
     }
 }
 
@@ -222,7 +227,7 @@ pub fn design_config_from_scratch(prompter: &mut dyn Prompter) -> Result<Config>
                 let collected = collect_type_interactive(&config, prompter)?;
                 apply_collected_type(&mut config, &collected)?;
             } else if config.documents.types.is_empty() {
-                println!("at least one type is required");
+                println!("{} at least one type is required", warning_prefix());
             } else {
                 break;
             }
@@ -242,7 +247,7 @@ pub fn design_config_from_scratch(prompter: &mut dyn Prompter) -> Result<Config>
         if prompter.confirm("Write this config", true)? {
             return Ok(config);
         }
-        println!("discarded; starting over");
+        println!("{} {}", warning_prefix(), dim("discarded; starting over"));
     }
 }
 
@@ -254,21 +259,29 @@ fn render_dag_summary(config: &Config) -> String {
     use std::fmt::Write;
     let mut out = String::new();
 
-    out.push_str("\nTypes:\n");
+    let _ = writeln!(out, "\n{}", section_header("Types:"));
     for type_def in &config.documents.types {
         let _ = writeln!(
             out,
             "  {} (plural: {}, dir: {}, prefix: {}, store: {})",
-            type_def.name, type_def.plural, type_def.dir, type_def.prefix, type_def.store,
+            bold(&type_def.name),
+            type_def.plural,
+            dim(&type_def.dir),
+            dim(&type_def.prefix),
+            type_def.store,
         );
         let lifecycle = type_def.effective_lifecycle();
         let _ = writeln!(out, "    lifecycle: {}", lifecycle.states.join(", "));
         for edge in &lifecycle.edges {
-            let _ = writeln!(out, "      edge: {} -> {}", edge.from, edge.to);
+            let _ = writeln!(
+                out,
+                "      edge: {}",
+                dim(&format!("{} -> {}", edge.from, edge.to))
+            );
         }
     }
 
-    out.push_str("Parent-child rules:\n");
+    let _ = writeln!(out, "{}", section_header("Parent-child rules:"));
     let mut any_rule = false;
     for rule in &config.rules {
         if let ValidationRule::ParentChild {
@@ -281,7 +294,7 @@ fn render_dag_summary(config: &Config) -> String {
         {
             any_rule = true;
             let gate = match require_parent_status {
-                Some(status) => format!(", gate: parent status = {status}"),
+                Some(status) => dim(&format!(", gate: parent status = {status}")),
                 None => String::new(),
             };
             let severity = match severity {
@@ -290,7 +303,10 @@ fn render_dag_summary(config: &Config) -> String {
             };
             let _ = writeln!(
                 out,
-                "  {name}: {child} -> {parent} (severity: {severity}{gate})",
+                "  {}: {} (severity: {}{gate})",
+                bold(name),
+                dim(&format!("{child} -> {parent}")),
+                dim(severity),
             );
         }
     }
@@ -298,7 +314,7 @@ fn render_dag_summary(config: &Config) -> String {
         out.push_str("  (none)\n");
     }
 
-    out.push_str("Relation vocabulary:\n");
+    let _ = writeln!(out, "{}", section_header("Relation vocabulary:"));
     for rel in &config.relationships {
         let _ = writeln!(out, "  {}", rel.name);
     }
@@ -884,6 +900,43 @@ mod tests {
             "gate: {summary}"
         );
         assert!(summary.contains("implements"), "relation vocab: {summary}");
+    }
+
+    // ITERATION-331: colour parity. With colours forced off the summary carries
+    // zero ANSI escapes; with them forced on it does, yet every load-bearing
+    // substring survives because styling wraps whole tokens (never splits them).
+    #[test]
+    fn dag_summary_colour_parity() {
+        let mut prompter = ScriptedPrompter::new(full_scratch_answers());
+        let config = design_config_from_scratch(&mut prompter).unwrap();
+
+        console::set_colors_enabled(false);
+        let plain = render_dag_summary(&config);
+        assert!(
+            !plain.contains('\u{1b}'),
+            "colours-off summary must be free of ANSI: {plain:?}"
+        );
+
+        console::set_colors_enabled(true);
+        let colored = render_dag_summary(&config);
+        console::set_colors_enabled(false);
+
+        assert!(
+            colored.contains('\u{1b}'),
+            "colours-on summary should carry ANSI"
+        );
+        for needle in [
+            "rfc",
+            "draft -> accepted",
+            "story -> rfc",
+            "parent status = accepted",
+            "implements",
+        ] {
+            assert!(
+                colored.contains(needle),
+                "styled summary lost contiguous substring {needle:?}: {colored:?}"
+            );
+        }
     }
 
     // AC4: a full from-scratch design scaffolds into a temp dir that loads and

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -689,9 +689,7 @@ mod tests {
             "",               // authorship -> default
             "n",              // add an attribute? no
             "y",              // design a custom lifecycle? yes
-            "draft",          // state
-            "accepted",       // state
-            "",               // finish states
+            "draft,accepted", // lifecycle states (comma-separated)
             "draft:accepted", // edge
             "",               // finish edges
             "y",              // add a type? -> story
@@ -739,12 +737,10 @@ mod tests {
             "",
             "",
             "",
-            "",  // core fields
-            "n", // no attribute
-            "y", // custom lifecycle
-            "draft",
-            "done",
-            "",           // states
+            "",           // core fields
+            "n",          // no attribute
+            "y",          // custom lifecycle
+            "draft,done", // lifecycle states (comma-separated)
             "draft:nope", // edge names an undefined state -> re-ask
             "draft:done", // valid
             "",           // finish edges

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -11,7 +11,9 @@ use crate::engine::fs_ops::default_template;
 use crate::engine::gh::{deterministic_color, GhCli, GhError, GhIssueWriter};
 use crate::engine::github::resolve_repo;
 use anyhow::{bail, Result};
+use console::colors_enabled;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::Command;
 
@@ -110,6 +112,11 @@ pub fn run_init_interactive(
     template: Option<&str>,
 ) -> Result<()> {
     ensure_no_config(root)?;
+    // This path is only reached interactively (main.rs routes `--json`/non-TTY to
+    // `run`), so json is false here; the guard still honours colours-off / non-TTY.
+    if crate::cli::spinner::should_greet(false, std::io::stdout().is_terminal(), colors_enabled()) {
+        crate::cli::spinner::say("hi there, let's set up your project");
+    }
     let config = if template == Some("starter") {
         design_config_interactive(starter_config(), prompter)?
     } else {

--- a/src/cli/reservations.rs
+++ b/src/cli/reservations.rs
@@ -1,9 +1,10 @@
 use crate::engine::config::{Config, ReservedFormat};
-use crate::engine::reservation::{self, PruneProgress, Reservation};
+use crate::engine::reservation::{self, Reservation};
 use crate::engine::store::Store;
 use crate::engine::template::shuffle_alphabet;
 use anyhow::{bail, Result};
 use clap::Subcommand;
+use indicatif::ProgressBar;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::path::Path;
@@ -106,13 +107,22 @@ pub fn run_prune(
     store: &Store,
     dry_run: bool,
     json: bool,
-    on_progress: impl Fn(PruneProgress),
+    spinner: Option<&ProgressBar>,
 ) -> Result<()> {
     let Some(reserved_config) = config.documents.reserved.as_ref() else {
         bail!("reserved numbering is not configured");
     };
 
-    on_progress(PruneProgress::QueryingRemote);
+    // Print a result line, suspending the spinner so its stderr redraw never
+    // smears the stdout output.
+    let emit = |line: String| match spinner {
+        Some(pb) => pb.suspend(|| println!("{line}")),
+        None => println!("{line}"),
+    };
+
+    if let Some(pb) = spinner {
+        pb.set_message("querying remote reservations");
+    }
     let reservations = reservation::list_reservations(repo_root, &reserved_config.remote, |_| {})?;
 
     let prunable: Vec<_> = reservations
@@ -137,15 +147,21 @@ pub fn run_prune(
         if has_local_document(store, &r.prefix, &formatted) {
             if dry_run {
                 if !json {
-                    println!("would prune\t{}\t{}\t{}", r.prefix, r.number, r.ref_path);
+                    emit(format!(
+                        "would prune\t{}\t{}\t{}",
+                        r.prefix, r.number, r.ref_path
+                    ));
                 }
                 pruned.push(PruneEntry::from(r));
             } else {
-                on_progress(PruneProgress::Deleting {
-                    current: pruned.len() + errors.len() + 1,
-                    total,
-                    ref_path: r.ref_path.clone(),
-                });
+                if let Some(pb) = spinner {
+                    pb.set_message(format!(
+                        "deleting {}/{} {}",
+                        pruned.len() + errors.len() + 1,
+                        total,
+                        r.ref_path
+                    ));
+                }
                 match reservation::delete_remote_ref(
                     repo_root,
                     &reserved_config.remote,
@@ -153,13 +169,19 @@ pub fn run_prune(
                 ) {
                     Ok(()) => {
                         if !json {
-                            println!("pruned\t{}\t{}\t{}", r.prefix, r.number, r.ref_path);
+                            emit(format!(
+                                "pruned\t{}\t{}\t{}",
+                                r.prefix, r.number, r.ref_path
+                            ));
                         }
                         pruned.push(PruneEntry::from(r));
                     }
                     Err(e) => {
                         if !json {
-                            println!("error\t{}\t{}\t{}\t{}", r.prefix, r.number, r.ref_path, e);
+                            emit(format!(
+                                "error\t{}\t{}\t{}\t{}",
+                                r.prefix, r.number, r.ref_path, e
+                            ));
                         }
                         errors.push(PruneError {
                             prefix: r.prefix.clone(),
@@ -172,16 +194,14 @@ pub fn run_prune(
             }
         } else {
             if !json {
-                println!("orphan\t{}\t{}\t{}", r.prefix, r.number, r.ref_path);
+                emit(format!(
+                    "orphan\t{}\t{}\t{}",
+                    r.prefix, r.number, r.ref_path
+                ));
             }
             orphaned.push(PruneEntry::from(r));
         }
     }
-
-    on_progress(PruneProgress::Done {
-        pruned: pruned.len(),
-        orphaned: orphaned.len(),
-    });
 
     if json {
         let output = PruneOutput {

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -1,13 +1,19 @@
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
+use std::thread::sleep;
 use std::time::Duration;
 
 use console::Style;
+use crossterm::{cursor, execute, terminal};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 
 use crate::engine::reservation::ReservationProgress;
 use crate::spinners::{spinner, FrameColour, SpinnerState};
 
 const TICK: Duration = Duration::from_millis(120);
+
+/// Delay between spoken words in the greeting animation. Within the RFC's
+/// 75-200ms window: slow enough to read the mouth cycle, brisk enough to finish.
+const WORD_TICK: Duration = Duration::from_millis(110);
 
 /// Map a semantic [`FrameColour`] to a `console` style, mirroring the TUI's
 /// `frame_style`: Accent is the terminal default so both light and dark themes
@@ -87,6 +93,58 @@ pub fn finish_err(pb: Option<ProgressBar>, msg: &str) {
     }
 }
 
+/// Whether the interactive `init` wizard should play its animated greeting: only
+/// on a colour-capable TTY that is not emitting machine-readable output. Pure so
+/// the guard is testable without a terminal; the `say` animation itself assumes
+/// the caller has already cleared this gate (dictum 2).
+pub fn should_greet(json: bool, is_tty: bool, colors: bool) -> bool {
+    !json && is_tty && colors
+}
+
+/// Hand-rolled talking-face greeting for the interactive init wizard -- the
+/// Houston `say` equivalent. Draws the full-box face and speaks `msg` word by
+/// word, cycling the loading eyes/mouth on each word, then settles on the happy
+/// success face. This is a bespoke per-word animation, distinct from the
+/// steady-tick op spinner. Callers must gate on [`should_greet`]; this always
+/// draws (and emits ESC bytes), so it must never run under `--json`/non-TTY.
+pub fn say(msg: &str) {
+    let face = spinner("face");
+    let words: Vec<&str> = msg.split_whitespace().collect();
+    let mut out = std::io::stdout();
+
+    let draw = |out: &mut std::io::Stdout, state: SpinnerState, idx: u64, spoken: &str| {
+        let frame = face.full(state, idx);
+        let style = frame_style(frame.colour);
+        let _ = writeln!(out, "{}", style.apply_to(&frame.lines[0]));
+        let _ = writeln!(out, "{}  {}", style.apply_to(&frame.lines[1]), spoken);
+        let _ = writeln!(out, "{}", style.apply_to(&frame.lines[2]));
+        let _ = out.flush();
+    };
+
+    let redraw = |out: &mut std::io::Stdout, state: SpinnerState, idx: u64, spoken: &str| {
+        let _ = execute!(
+            out,
+            cursor::MoveToPreviousLine(3),
+            terminal::Clear(terminal::ClearType::FromCursorDown)
+        );
+        draw(out, state, idx, spoken);
+    };
+
+    let mut spoken = String::new();
+    draw(&mut out, SpinnerState::Loading, 0, &spoken);
+    for (i, word) in words.iter().enumerate() {
+        sleep(WORD_TICK);
+        if !spoken.is_empty() {
+            spoken.push(' ');
+        }
+        spoken.push_str(word);
+        redraw(&mut out, SpinnerState::Loading, i as u64 + 1, &spoken);
+    }
+
+    sleep(WORD_TICK);
+    redraw(&mut out, SpinnerState::Success, 0, &spoken);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,6 +159,17 @@ mod tests {
         // The test harness captures stderr, so it is never a TTY here; the guard
         // must suppress the spinner even when json is false.
         assert!(op_spinner("working", false).is_none());
+    }
+
+    // Dictum 2: the greeting plays only on a colour TTY without `--json`; every
+    // suppressing condition (json, non-TTY, colours off) gates it out so no ESC
+    // bytes reach machine-readable or piped output.
+    #[test]
+    fn should_greet_only_on_colour_tty_without_json() {
+        assert!(should_greet(false, true, true), "colour tty, no json");
+        assert!(!should_greet(true, true, true), "json suppresses");
+        assert!(!should_greet(false, false, true), "non-tty suppresses");
+        assert!(!should_greet(false, true, false), "colours off suppresses");
     }
 
     #[test]

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -36,9 +36,9 @@ pub fn op_spinner(msg: impl Into<String>, json: bool) -> Option<ProgressBar> {
     }
 
     let face = spinner("face");
-    // indicatif treats the trailing tick as the finished frame; the loop cycles
-    // the four loading frames before it.
-    let mut ticks: Vec<String> = (0..4)
+    // The four loading frames cycle while the op runs; the terminal frame is
+    // drawn by finish_ok/finish_err, not by indicatif's finished tick.
+    let ticks: Vec<String> = (0..4)
         .map(|i| {
             let frame = face.compact(SpinnerState::Loading, i);
             frame_style(frame.colour)
@@ -46,7 +46,6 @@ pub fn op_spinner(msg: impl Into<String>, json: bool) -> Option<ProgressBar> {
                 .to_string()
         })
         .collect();
-    ticks.push(face.compact(SpinnerState::Success, 0).lines[0].clone());
     let tick_refs: Vec<&str> = ticks.iter().map(String::as_str).collect();
 
     let style = ProgressStyle::with_template("{spinner} {msg}")
@@ -75,22 +74,31 @@ pub fn reservation_message(progress: &ReservationProgress) -> String {
     }
 }
 
-/// Clear the spinner and print a green check completion line to stderr. A no-op
-/// when the spinner was suppressed, keeping non-interactive output untouched.
+/// Clear the animation and settle on the happy success face with `msg` to
+/// stderr. A no-op when the spinner was suppressed, keeping non-interactive
+/// output untouched.
 pub fn finish_ok(pb: Option<ProgressBar>, msg: &str) {
     if let Some(pb) = pb {
         pb.finish_and_clear();
-        eprintln!("{}", crate::cli::style::success_line(msg));
+        eprintln!("{}", terminal_face(SpinnerState::Success, msg));
     }
 }
 
-/// Clear the spinner and print a red cross failure line to stderr. A no-op when
-/// the spinner was suppressed.
+/// Clear the animation and settle on the error face with `msg` to stderr. A
+/// no-op when the spinner was suppressed.
 pub fn finish_err(pb: Option<ProgressBar>, msg: &str) {
     if let Some(pb) = pb {
         pb.finish_and_clear();
-        eprintln!("{} {}", crate::cli::style::error_prefix(), msg);
+        eprintln!("{}", terminal_face(SpinnerState::Error, msg));
     }
+}
+
+/// Render the compact terminal face for `state`, styled by its semantic colour,
+/// followed by `msg` -- the line that replaces the cleared spinner animation.
+fn terminal_face(state: SpinnerState, msg: &str) -> String {
+    let frame = spinner("face").compact(state, 0);
+    let style = frame_style(frame.colour);
+    format!("{} {}", style.apply_to(&frame.lines[0]), msg)
 }
 
 /// Whether the interactive `init` wizard should play its animated greeting: only

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -1,0 +1,162 @@
+use std::io::IsTerminal;
+use std::time::Duration;
+
+use console::Style;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+
+use crate::engine::reservation::ReservationProgress;
+use crate::spinners::{spinner, FrameColour, SpinnerState};
+
+const TICK: Duration = Duration::from_millis(120);
+
+/// Map a semantic [`FrameColour`] to a `console` style, mirroring the TUI's
+/// `frame_style`: Accent is the terminal default so both light and dark themes
+/// stay legible, with dim/bold and green/red carrying the remaining cues.
+pub fn frame_style(colour: FrameColour) -> Style {
+    match colour {
+        FrameColour::Accent => Style::new(),
+        FrameColour::Dim => Style::new().dim(),
+        FrameColour::Success => Style::new().green(),
+        FrameColour::Error => Style::new().red(),
+    }
+}
+
+/// A stderr spinner animating the compact loading face, or `None` when output
+/// must stay machine-readable (`--json`) or stderr is not a terminal. `None` is
+/// the signal for callers to stay silent, so stdout parity is preserved.
+pub fn op_spinner(msg: impl Into<String>, json: bool) -> Option<ProgressBar> {
+    if json || !std::io::stderr().is_terminal() {
+        return None;
+    }
+
+    let face = spinner("face");
+    // indicatif treats the trailing tick as the finished frame; the loop cycles
+    // the four loading frames before it.
+    let mut ticks: Vec<String> = (0..4)
+        .map(|i| {
+            let frame = face.compact(SpinnerState::Loading, i);
+            frame_style(frame.colour)
+                .apply_to(&frame.lines[0])
+                .to_string()
+        })
+        .collect();
+    ticks.push(face.compact(SpinnerState::Success, 0).lines[0].clone());
+    let tick_refs: Vec<&str> = ticks.iter().map(String::as_str).collect();
+
+    let style = ProgressStyle::with_template("{spinner} {msg}")
+        .expect("static spinner template is valid")
+        .tick_strings(&tick_refs);
+
+    let pb = ProgressBar::new_spinner().with_message(msg.into());
+    pb.set_style(style);
+    pb.set_draw_target(ProgressDrawTarget::stderr());
+    pb.enable_steady_tick(TICK);
+    Some(pb)
+}
+
+/// A human-readable message for each reservation progress point, fed to the
+/// spinner as the underlying op advances.
+pub fn reservation_message(progress: &ReservationProgress) -> String {
+    match progress {
+        ReservationProgress::QueryingRemote => "querying remote for reserved ids".to_string(),
+        ReservationProgress::PushAttempt {
+            attempt,
+            max,
+            candidate,
+        } => format!("reserving {candidate} (attempt {attempt}/{max})"),
+        ReservationProgress::PushRejected { candidate } => format!("{candidate} taken, retrying"),
+        ReservationProgress::Reserved { number } => format!("reserved {number}"),
+    }
+}
+
+/// Clear the spinner and print a green check completion line to stderr. A no-op
+/// when the spinner was suppressed, keeping non-interactive output untouched.
+pub fn finish_ok(pb: Option<ProgressBar>, msg: &str) {
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
+        eprintln!("{}", crate::cli::style::success_line(msg));
+    }
+}
+
+/// Clear the spinner and print a red cross failure line to stderr. A no-op when
+/// the spinner was suppressed.
+pub fn finish_err(pb: Option<ProgressBar>, msg: &str) {
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
+        eprintln!("{} {}", crate::cli::style::error_prefix(), msg);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_spinner_none_under_json() {
+        assert!(op_spinner("working", true).is_none());
+    }
+
+    #[test]
+    fn op_spinner_none_when_stderr_not_a_terminal() {
+        // The test harness captures stderr, so it is never a TTY here; the guard
+        // must suppress the spinner even when json is false.
+        assert!(op_spinner("working", false).is_none());
+    }
+
+    #[test]
+    fn frame_style_maps_each_colour() {
+        assert_eq!(frame_style(FrameColour::Accent), Style::new());
+        assert_eq!(frame_style(FrameColour::Dim), Style::new().dim());
+        assert_eq!(frame_style(FrameColour::Success), Style::new().green());
+        assert_eq!(frame_style(FrameColour::Error), Style::new().red());
+    }
+
+    #[test]
+    fn reservation_progress_maps_to_spinner_state() {
+        assert_eq!(
+            ReservationProgress::QueryingRemote.spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::PushAttempt {
+                attempt: 1,
+                max: 3,
+                candidate: 7
+            }
+            .spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::PushRejected { candidate: 7 }.spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::Reserved { number: 7 }.spinner_state(),
+            SpinnerState::Success
+        );
+    }
+
+    #[test]
+    fn reservation_message_describes_each_point() {
+        assert_eq!(
+            reservation_message(&ReservationProgress::QueryingRemote),
+            "querying remote for reserved ids"
+        );
+        assert_eq!(
+            reservation_message(&ReservationProgress::PushAttempt {
+                attempt: 2,
+                max: 5,
+                candidate: 9
+            }),
+            "reserving 9 (attempt 2/5)"
+        );
+        assert_eq!(
+            reservation_message(&ReservationProgress::PushRejected { candidate: 9 }),
+            "9 taken, retrying"
+        );
+        assert_eq!(
+            reservation_message(&ReservationProgress::Reserved { number: 9 }),
+            "reserved 9"
+        );
+    }
+}

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -162,13 +162,6 @@ mod tests {
         assert!(op_spinner("working", true).is_none());
     }
 
-    #[test]
-    fn op_spinner_none_when_stderr_not_a_terminal() {
-        // The test harness captures stderr, so it is never a TTY here; the guard
-        // must suppress the spinner even when json is false.
-        assert!(op_spinner("working", false).is_none());
-    }
-
     // Dictum 2: the greeting plays only on a colour TTY without `--json`; every
     // suppressing condition (json, non-TTY, colours off) gates it out so no ESC
     // bytes reach machine-readable or piped output.

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -149,6 +149,31 @@ pub fn warning_prefix() -> String {
     }
 }
 
+/// A section divider for wizard flow transitions and DAG-summary headers. Bold +
+/// underlined when colours are on; the bare text otherwise, so callers that embed
+/// it in a returned string keep byte-for-byte parity with the plain form.
+pub fn section_header(text: &str) -> String {
+    if colors_enabled() {
+        Style::new().bold().underlined().apply_to(text).to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+/// A success cue, mirroring `error_prefix`/`warning_prefix` but returning the
+/// whole line: a green check prefix when colours are on, the bare text otherwise.
+pub fn success_line(text: &str) -> String {
+    if colors_enabled() {
+        format!(
+            "{} {}",
+            Style::new().green().bold().apply_to("\u{2713}"),
+            text
+        )
+    } else {
+        text.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/wizard.rs
+++ b/src/cli/wizard.rs
@@ -1,6 +1,6 @@
-use crate::cli::style::{bold, dim};
 use anyhow::{bail, Result};
-use std::io::{BufRead, Write};
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Input, MultiSelect, Select};
 
 /// The test seam for interactive prompts: the real terminal implementation and
 /// the scripted test fake both satisfy it, so `run_add_type_interactive` never
@@ -11,19 +11,18 @@ pub trait Prompter {
     fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String>;
     /// Ask a yes/no question. Blank yields `default`.
     fn confirm(&mut self, label: &str, default: bool) -> Result<bool>;
-    /// Ask to choose one of `options` as a numbered chooser. A blank answer
-    /// yields `default`; otherwise a 1-based number resolves into `options` or an
-    /// exact option string is matched. The real (`StdinPrompter`) impl rejects an
-    /// out-of-list answer and re-asks; the scripted fake returns the queued answer
-    /// verbatim (validation lives at the callsite, not the fake).
+    /// Ask to choose one of `options`. The real (`StdinPrompter`) impl renders an
+    /// arrow-key chooser (Enter picks) with the item equal to `default`
+    /// pre-selected; the scripted fake returns the queued answer verbatim (a blank
+    /// falls back to `default`; validation lives at the callsite, not the fake).
     fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String>;
     /// Ask to choose several values in one prompt. When `options` is empty the
     /// answer is freeform: the single input line is split on `,`, each token
     /// trimmed and empties dropped (used for user-invented lifecycle states). When
-    /// `options` is non-empty it is a numbered multi-chooser accepting a
-    /// comma-separated mix of 1-based numbers and exact option strings; the real
-    /// impl rejects any unknown token and re-asks. A blank answer yields
-    /// `defaults`. Selections are returned in input order, de-duplicated.
+    /// `options` is non-empty the real impl renders an arrow-key multi-chooser
+    /// (Space toggles, Enter confirms) with the items in `defaults` pre-checked;
+    /// the scripted fake splits its queued line on `,`. A blank/empty selection
+    /// yields `defaults`. Selections are returned in option order, de-duplicated.
     fn multi_select(
         &mut self,
         label: &str,
@@ -32,92 +31,60 @@ pub trait Prompter {
     ) -> Result<Vec<String>>;
 }
 
-/// Real prompter: renders the label (and any default) to a writer and reads one
-/// line from a reader. Generic over the streams so it stays testable, though in
-/// practice it wraps stdin/stdout.
-pub struct StdinPrompter<R: BufRead, W: Write> {
-    reader: R,
-    writer: W,
-}
+/// Real prompter: drives interactive `dialoguer` widgets styled with
+/// `ColorfulTheme`, which shares `console`'s colour state so `NO_COLOR`/`CLICOLOR`
+/// are honoured. `dialoguer` owns the terminal, navigation, and validation.
+pub struct StdinPrompter;
 
-impl StdinPrompter<std::io::BufReader<std::io::Stdin>, std::io::Stdout> {
+impl StdinPrompter {
     pub fn new() -> Self {
-        StdinPrompter {
-            reader: std::io::BufReader::new(std::io::stdin()),
-            writer: std::io::stdout(),
-        }
+        StdinPrompter
     }
 }
 
-impl Default for StdinPrompter<std::io::BufReader<std::io::Stdin>, std::io::Stdout> {
+impl Default for StdinPrompter {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R: BufRead, W: Write> StdinPrompter<R, W> {
-    fn read_line(&mut self, prompt: &str) -> Result<String> {
-        write!(self.writer, "{prompt}")?;
-        self.writer.flush()?;
-        let mut line = String::new();
-        let n = self.reader.read_line(&mut line)?;
-        if n == 0 {
-            bail!("unexpected end of input while prompting");
-        }
-        Ok(line.trim_end_matches(['\r', '\n']).to_string())
-    }
-}
-
-impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
+impl Prompter for StdinPrompter {
     fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String> {
-        let prompt = match default {
-            Some(d) if !d.is_empty() => {
-                format!("{} {}: ", bold(label), dim(&format!("[{d}]")))
-            }
-            _ => format!("{}: ", bold(label)),
+        let theme = ColorfulTheme::default();
+        let value: String = match default {
+            Some(d) if !d.is_empty() => Input::with_theme(&theme)
+                .with_prompt(label)
+                .allow_empty(true)
+                .default(d.to_string())
+                .interact_text()?,
+            _ => Input::with_theme(&theme)
+                .with_prompt(label)
+                .allow_empty(true)
+                .interact_text()?,
         };
-        let input = self.read_line(&prompt)?;
-        if input.is_empty() {
+        if value.is_empty() {
             if let Some(d) = default {
                 return Ok(d.to_string());
             }
         }
-        Ok(input)
+        Ok(value)
     }
 
     fn confirm(&mut self, label: &str, default: bool) -> Result<bool> {
-        let hint = if default { "Y/n" } else { "y/N" };
-        let input = self.read_line(&format!("{} {}: ", bold(label), dim(&format!("[{hint}]"))))?;
-        Ok(match input.to_ascii_lowercase().as_str() {
-            "" => default,
-            "y" | "yes" => true,
-            _ => false,
-        })
+        Ok(Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(label)
+            .default(default)
+            .interact()?)
     }
 
     fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String> {
-        loop {
-            writeln!(self.writer, "{}:", bold(label))?;
-            for (i, opt) in options.iter().enumerate() {
-                let cue = if *opt == default {
-                    format!(" {}", dim("[default]"))
-                } else {
-                    String::new()
-                };
-                writeln!(self.writer, "  {}) {opt}{cue}", i + 1)?;
-            }
-            let input = self.read_line(&format!("Choose {}: ", dim(&format!("[{default}]"))))?;
-            if input.is_empty() {
-                return Ok(default.to_string());
-            }
-            if let Some(opt) = resolve_choice(&input, options) {
-                return Ok(opt);
-            }
-            writeln!(
-                self.writer,
-                "\"{input}\" is not one of the options; choose a number or an exact name"
-            )?;
-        }
+        let index = options.iter().position(|o| *o == default).unwrap_or(0);
+        let chosen = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt(label)
+            .items(options)
+            .default(index)
+            .interact()?;
+        Ok(options[chosen].to_string())
     }
 
     fn multi_select(
@@ -127,54 +94,28 @@ impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
         defaults: &[&str],
     ) -> Result<Vec<String>> {
         if options.is_empty() {
-            let input = self.read_line(&format!("{label} (comma-separated): "))?;
+            let input: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!("{label} (comma-separated)"))
+                .allow_empty(true)
+                .interact_text()?;
             if input.trim().is_empty() {
                 return Ok(defaults.iter().map(|s| s.to_string()).collect());
             }
             return Ok(dedup(split_csv(&input)));
         }
-        loop {
-            writeln!(self.writer, "{label} (comma-separated):")?;
-            for (i, opt) in options.iter().enumerate() {
-                writeln!(self.writer, "  {}) {opt}", i + 1)?;
-            }
-            let hint = defaults.join(", ");
-            let input = self.read_line(&format!("Choose [{hint}]: "))?;
-            if input.trim().is_empty() {
-                return Ok(defaults.iter().map(|s| s.to_string()).collect());
-            }
-            let mut chosen: Vec<String> = Vec::new();
-            let mut bad: Option<String> = None;
-            for token in input.split(',').map(str::trim).filter(|t| !t.is_empty()) {
-                match resolve_choice(token, options) {
-                    Some(opt) => chosen.push(opt),
-                    None => {
-                        bad = Some(token.to_string());
-                        break;
-                    }
-                }
-            }
-            if let Some(token) = bad {
-                writeln!(
-                    self.writer,
-                    "\"{token}\" is not one of the options; choose numbers or exact names"
-                )?;
-                continue;
-            }
-            return Ok(dedup(chosen));
+        let checked: Vec<bool> = options.iter().map(|o| defaults.contains(o)).collect();
+        let selected = MultiSelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(label)
+            .items(options)
+            .defaults(&checked)
+            .interact()?;
+        if selected.is_empty() {
+            return Ok(defaults.iter().map(|s| s.to_string()).collect());
         }
+        Ok(dedup(
+            selected.iter().map(|&i| options[i].to_string()).collect(),
+        ))
     }
-}
-
-/// Resolve a single token to an option: a 1-based index into `options`, or an
-/// exact option string. Returns the canonical option text.
-fn resolve_choice(token: &str, options: &[&str]) -> Option<String> {
-    if let Ok(n) = token.parse::<usize>() {
-        if n >= 1 && n <= options.len() {
-            return Some(options[n - 1].to_string());
-        }
-    }
-    options.iter().find(|o| **o == token).map(|o| o.to_string())
 }
 
 fn split_csv(input: &str) -> Vec<String> {
@@ -268,81 +209,6 @@ impl Prompter for ScriptedPrompter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
-
-    fn stdin(input: &str) -> StdinPrompter<Cursor<Vec<u8>>, Vec<u8>> {
-        StdinPrompter {
-            reader: Cursor::new(input.as_bytes().to_vec()),
-            writer: Vec::new(),
-        }
-    }
-
-    fn written(p: &StdinPrompter<Cursor<Vec<u8>>, Vec<u8>>) -> String {
-        String::from_utf8(p.writer.clone()).unwrap()
-    }
-
-    // Real select rejects an out-of-list answer and re-asks, accepting the valid
-    // one on the next line; a rejection cue is emitted.
-    #[test]
-    fn real_select_rejects_out_of_list_then_accepts() {
-        let mut p = stdin("bogus\nfilesystem\n");
-        let choice = p
-            .select("Store", &["filesystem", "git-ref"], "filesystem")
-            .unwrap();
-        assert_eq!(choice, "filesystem");
-        assert!(
-            written(&p).contains("is not one of the options"),
-            "expected a rejection cue, got: {}",
-            written(&p)
-        );
-    }
-
-    // Real select resolves a 1-based number to the matching option.
-    #[test]
-    fn real_select_resolves_number() {
-        let mut p = stdin("2\n");
-        let choice = p
-            .select("Store", &["filesystem", "git-ref"], "filesystem")
-            .unwrap();
-        assert_eq!(choice, "git-ref");
-    }
-
-    // Real select: a blank line yields the default.
-    #[test]
-    fn real_select_blank_yields_default() {
-        let mut p = stdin("\n");
-        let choice = p
-            .select("Store", &["filesystem", "git-ref"], "filesystem")
-            .unwrap();
-        assert_eq!(choice, "filesystem");
-    }
-
-    // Real multi_select over a fixed option set captures several by number and
-    // returns them in input order.
-    #[test]
-    fn real_multi_select_numbers_capture_several() {
-        let mut p = stdin("1,3\n");
-        let chosen = p.multi_select("Pick", &["a", "b", "c"], &[]).unwrap();
-        assert_eq!(chosen, vec!["a".to_string(), "c".to_string()]);
-    }
-
-    // Real multi_select rejects an unknown token (number out of range or unknown
-    // name) and re-asks.
-    #[test]
-    fn real_multi_select_rejects_unknown_token() {
-        let mut p = stdin("9\nnope\n1\n");
-        let chosen = p.multi_select("Pick", &["a", "b", "c"], &[]).unwrap();
-        assert_eq!(chosen, vec!["a".to_string()]);
-        assert!(written(&p).contains("is not one of the options"));
-    }
-
-    // Real multi_select with empty options is freeform: split on commas, trim.
-    #[test]
-    fn real_multi_select_freeform_splits_and_trims() {
-        let mut p = stdin("draft, accepted\n");
-        let chosen = p.multi_select("Lifecycle states", &[], &[]).unwrap();
-        assert_eq!(chosen, vec!["draft".to_string(), "accepted".to_string()]);
-    }
 
     // Scripted multi_select splits a queued answer; a blank falls back to defaults.
     #[test]

--- a/src/cli/wizard.rs
+++ b/src/cli/wizard.rs
@@ -1,3 +1,4 @@
+use crate::cli::style::{bold, dim};
 use anyhow::{bail, Result};
 use std::io::{BufRead, Write};
 
@@ -70,8 +71,10 @@ impl<R: BufRead, W: Write> StdinPrompter<R, W> {
 impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
     fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String> {
         let prompt = match default {
-            Some(d) if !d.is_empty() => format!("{label} [{d}]: "),
-            _ => format!("{label}: "),
+            Some(d) if !d.is_empty() => {
+                format!("{} {}: ", bold(label), dim(&format!("[{d}]")))
+            }
+            _ => format!("{}: ", bold(label)),
         };
         let input = self.read_line(&prompt)?;
         if input.is_empty() {
@@ -84,7 +87,7 @@ impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
 
     fn confirm(&mut self, label: &str, default: bool) -> Result<bool> {
         let hint = if default { "Y/n" } else { "y/N" };
-        let input = self.read_line(&format!("{label} [{hint}]: "))?;
+        let input = self.read_line(&format!("{} {}: ", bold(label), dim(&format!("[{hint}]"))))?;
         Ok(match input.to_ascii_lowercase().as_str() {
             "" => default,
             "y" | "yes" => true,
@@ -94,12 +97,16 @@ impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
 
     fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String> {
         loop {
-            writeln!(self.writer, "{label}:")?;
+            writeln!(self.writer, "{}:", bold(label))?;
             for (i, opt) in options.iter().enumerate() {
-                let cue = if *opt == default { " [default]" } else { "" };
+                let cue = if *opt == default {
+                    format!(" {}", dim("[default]"))
+                } else {
+                    String::new()
+                };
                 writeln!(self.writer, "  {}) {opt}{cue}", i + 1)?;
             }
-            let input = self.read_line(&format!("Choose [{default}]: "))?;
+            let input = self.read_line(&format!("Choose {}: ", dim(&format!("[{default}]"))))?;
             if input.is_empty() {
                 return Ok(default.to_string());
             }

--- a/src/cli/wizard.rs
+++ b/src/cli/wizard.rs
@@ -10,8 +10,25 @@ pub trait Prompter {
     fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String>;
     /// Ask a yes/no question. Blank yields `default`.
     fn confirm(&mut self, label: &str, default: bool) -> Result<bool>;
-    /// Ask to choose one of `options`. Blank yields `default`.
+    /// Ask to choose one of `options` as a numbered chooser. A blank answer
+    /// yields `default`; otherwise a 1-based number resolves into `options` or an
+    /// exact option string is matched. The real (`StdinPrompter`) impl rejects an
+    /// out-of-list answer and re-asks; the scripted fake returns the queued answer
+    /// verbatim (validation lives at the callsite, not the fake).
     fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String>;
+    /// Ask to choose several values in one prompt. When `options` is empty the
+    /// answer is freeform: the single input line is split on `,`, each token
+    /// trimmed and empties dropped (used for user-invented lifecycle states). When
+    /// `options` is non-empty it is a numbered multi-chooser accepting a
+    /// comma-separated mix of 1-based numbers and exact option strings; the real
+    /// impl rejects any unknown token and re-asks. A blank answer yields
+    /// `defaults`. Selections are returned in input order, de-duplicated.
+    fn multi_select(
+        &mut self,
+        label: &str,
+        options: &[&str],
+        defaults: &[&str],
+    ) -> Result<Vec<String>>;
 }
 
 /// Real prompter: renders the label (and any default) to a writer and reads one
@@ -76,19 +93,109 @@ impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
     }
 
     fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String> {
-        let joined = options.join(", ");
-        let input = self.read_line(&format!("{label} ({joined}) [{default}]: "))?;
-        Ok(if input.is_empty() {
-            default.to_string()
-        } else {
-            input
-        })
+        loop {
+            writeln!(self.writer, "{label}:")?;
+            for (i, opt) in options.iter().enumerate() {
+                let cue = if *opt == default { " [default]" } else { "" };
+                writeln!(self.writer, "  {}) {opt}{cue}", i + 1)?;
+            }
+            let input = self.read_line(&format!("Choose [{default}]: "))?;
+            if input.is_empty() {
+                return Ok(default.to_string());
+            }
+            if let Some(opt) = resolve_choice(&input, options) {
+                return Ok(opt);
+            }
+            writeln!(
+                self.writer,
+                "\"{input}\" is not one of the options; choose a number or an exact name"
+            )?;
+        }
     }
+
+    fn multi_select(
+        &mut self,
+        label: &str,
+        options: &[&str],
+        defaults: &[&str],
+    ) -> Result<Vec<String>> {
+        if options.is_empty() {
+            let input = self.read_line(&format!("{label} (comma-separated): "))?;
+            if input.trim().is_empty() {
+                return Ok(defaults.iter().map(|s| s.to_string()).collect());
+            }
+            return Ok(dedup(split_csv(&input)));
+        }
+        loop {
+            writeln!(self.writer, "{label} (comma-separated):")?;
+            for (i, opt) in options.iter().enumerate() {
+                writeln!(self.writer, "  {}) {opt}", i + 1)?;
+            }
+            let hint = defaults.join(", ");
+            let input = self.read_line(&format!("Choose [{hint}]: "))?;
+            if input.trim().is_empty() {
+                return Ok(defaults.iter().map(|s| s.to_string()).collect());
+            }
+            let mut chosen: Vec<String> = Vec::new();
+            let mut bad: Option<String> = None;
+            for token in input.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+                match resolve_choice(token, options) {
+                    Some(opt) => chosen.push(opt),
+                    None => {
+                        bad = Some(token.to_string());
+                        break;
+                    }
+                }
+            }
+            if let Some(token) = bad {
+                writeln!(
+                    self.writer,
+                    "\"{token}\" is not one of the options; choose numbers or exact names"
+                )?;
+                continue;
+            }
+            return Ok(dedup(chosen));
+        }
+    }
+}
+
+/// Resolve a single token to an option: a 1-based index into `options`, or an
+/// exact option string. Returns the canonical option text.
+fn resolve_choice(token: &str, options: &[&str]) -> Option<String> {
+    if let Ok(n) = token.parse::<usize>() {
+        if n >= 1 && n <= options.len() {
+            return Some(options[n - 1].to_string());
+        }
+    }
+    options.iter().find(|o| **o == token).map(|o| o.to_string())
+}
+
+fn split_csv(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn dedup(items: Vec<String>) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for item in items {
+        if !seen.contains(&item) {
+            seen.push(item);
+        }
+    }
+    seen
 }
 
 /// Test fake: answers are dequeued in order from a queue. `confirm` reads a
 /// `y`/`yes` (case-insensitive) as true, anything else as false; `select`
 /// returns the queued answer verbatim (blank falls back to the default).
+/// `multi_select` pops one queued answer: blank falls back to `defaults`,
+/// otherwise the line is split on `,` (each token trimmed, empties dropped) into
+/// the selection list. No validation happens in the fake -- it stays verbatim so
+/// callsite re-ask loops remain the only test seam.
 pub struct ScriptedPrompter {
     answers: std::collections::VecDeque<String>,
 }
@@ -135,5 +242,114 @@ impl Prompter for ScriptedPrompter {
         } else {
             input
         })
+    }
+
+    fn multi_select(
+        &mut self,
+        label: &str,
+        _options: &[&str],
+        defaults: &[&str],
+    ) -> Result<Vec<String>> {
+        let input = self.pop(label)?;
+        if input.is_empty() {
+            return Ok(defaults.iter().map(|s| s.to_string()).collect());
+        }
+        Ok(split_csv(&input))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn stdin(input: &str) -> StdinPrompter<Cursor<Vec<u8>>, Vec<u8>> {
+        StdinPrompter {
+            reader: Cursor::new(input.as_bytes().to_vec()),
+            writer: Vec::new(),
+        }
+    }
+
+    fn written(p: &StdinPrompter<Cursor<Vec<u8>>, Vec<u8>>) -> String {
+        String::from_utf8(p.writer.clone()).unwrap()
+    }
+
+    // Real select rejects an out-of-list answer and re-asks, accepting the valid
+    // one on the next line; a rejection cue is emitted.
+    #[test]
+    fn real_select_rejects_out_of_list_then_accepts() {
+        let mut p = stdin("bogus\nfilesystem\n");
+        let choice = p
+            .select("Store", &["filesystem", "git-ref"], "filesystem")
+            .unwrap();
+        assert_eq!(choice, "filesystem");
+        assert!(
+            written(&p).contains("is not one of the options"),
+            "expected a rejection cue, got: {}",
+            written(&p)
+        );
+    }
+
+    // Real select resolves a 1-based number to the matching option.
+    #[test]
+    fn real_select_resolves_number() {
+        let mut p = stdin("2\n");
+        let choice = p
+            .select("Store", &["filesystem", "git-ref"], "filesystem")
+            .unwrap();
+        assert_eq!(choice, "git-ref");
+    }
+
+    // Real select: a blank line yields the default.
+    #[test]
+    fn real_select_blank_yields_default() {
+        let mut p = stdin("\n");
+        let choice = p
+            .select("Store", &["filesystem", "git-ref"], "filesystem")
+            .unwrap();
+        assert_eq!(choice, "filesystem");
+    }
+
+    // Real multi_select over a fixed option set captures several by number and
+    // returns them in input order.
+    #[test]
+    fn real_multi_select_numbers_capture_several() {
+        let mut p = stdin("1,3\n");
+        let chosen = p.multi_select("Pick", &["a", "b", "c"], &[]).unwrap();
+        assert_eq!(chosen, vec!["a".to_string(), "c".to_string()]);
+    }
+
+    // Real multi_select rejects an unknown token (number out of range or unknown
+    // name) and re-asks.
+    #[test]
+    fn real_multi_select_rejects_unknown_token() {
+        let mut p = stdin("9\nnope\n1\n");
+        let chosen = p.multi_select("Pick", &["a", "b", "c"], &[]).unwrap();
+        assert_eq!(chosen, vec!["a".to_string()]);
+        assert!(written(&p).contains("is not one of the options"));
+    }
+
+    // Real multi_select with empty options is freeform: split on commas, trim.
+    #[test]
+    fn real_multi_select_freeform_splits_and_trims() {
+        let mut p = stdin("draft, accepted\n");
+        let chosen = p.multi_select("Lifecycle states", &[], &[]).unwrap();
+        assert_eq!(chosen, vec!["draft".to_string(), "accepted".to_string()]);
+    }
+
+    // Scripted multi_select splits a queued answer; a blank falls back to defaults.
+    #[test]
+    fn scripted_multi_select_splits_and_defaults() {
+        let mut p = ScriptedPrompter::new(vec!["a,b,c".to_string()]);
+        assert_eq!(
+            p.multi_select("Pick", &[], &[]).unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+
+        let mut p = ScriptedPrompter::new(vec![String::new()]);
+        assert_eq!(
+            p.multi_select("Pick", &[], &["x", "y"]).unwrap(),
+            vec!["x".to_string(), "y".to_string()]
+        );
     }
 }

--- a/src/cli/wizard.rs
+++ b/src/cli/wizard.rs
@@ -1,0 +1,139 @@
+use anyhow::{bail, Result};
+use std::io::{BufRead, Write};
+
+/// The test seam for interactive prompts: the real terminal implementation and
+/// the scripted test fake both satisfy it, so `run_add_type_interactive` never
+/// touches stdin/stdout directly.
+pub trait Prompter {
+    /// Ask for a free-text value. A blank answer yields `default` when one is
+    /// given, otherwise the raw (empty) input.
+    fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String>;
+    /// Ask a yes/no question. Blank yields `default`.
+    fn confirm(&mut self, label: &str, default: bool) -> Result<bool>;
+    /// Ask to choose one of `options`. Blank yields `default`.
+    fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String>;
+}
+
+/// Real prompter: renders the label (and any default) to a writer and reads one
+/// line from a reader. Generic over the streams so it stays testable, though in
+/// practice it wraps stdin/stdout.
+pub struct StdinPrompter<R: BufRead, W: Write> {
+    reader: R,
+    writer: W,
+}
+
+impl StdinPrompter<std::io::BufReader<std::io::Stdin>, std::io::Stdout> {
+    pub fn new() -> Self {
+        StdinPrompter {
+            reader: std::io::BufReader::new(std::io::stdin()),
+            writer: std::io::stdout(),
+        }
+    }
+}
+
+impl Default for StdinPrompter<std::io::BufReader<std::io::Stdin>, std::io::Stdout> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R: BufRead, W: Write> StdinPrompter<R, W> {
+    fn read_line(&mut self, prompt: &str) -> Result<String> {
+        write!(self.writer, "{prompt}")?;
+        self.writer.flush()?;
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line)?;
+        if n == 0 {
+            bail!("unexpected end of input while prompting");
+        }
+        Ok(line.trim_end_matches(['\r', '\n']).to_string())
+    }
+}
+
+impl<R: BufRead, W: Write> Prompter for StdinPrompter<R, W> {
+    fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String> {
+        let prompt = match default {
+            Some(d) if !d.is_empty() => format!("{label} [{d}]: "),
+            _ => format!("{label}: "),
+        };
+        let input = self.read_line(&prompt)?;
+        if input.is_empty() {
+            if let Some(d) = default {
+                return Ok(d.to_string());
+            }
+        }
+        Ok(input)
+    }
+
+    fn confirm(&mut self, label: &str, default: bool) -> Result<bool> {
+        let hint = if default { "Y/n" } else { "y/N" };
+        let input = self.read_line(&format!("{label} [{hint}]: "))?;
+        Ok(match input.to_ascii_lowercase().as_str() {
+            "" => default,
+            "y" | "yes" => true,
+            _ => false,
+        })
+    }
+
+    fn select(&mut self, label: &str, options: &[&str], default: &str) -> Result<String> {
+        let joined = options.join(", ");
+        let input = self.read_line(&format!("{label} ({joined}) [{default}]: "))?;
+        Ok(if input.is_empty() {
+            default.to_string()
+        } else {
+            input
+        })
+    }
+}
+
+/// Test fake: answers are dequeued in order from a queue. `confirm` reads a
+/// `y`/`yes` (case-insensitive) as true, anything else as false; `select`
+/// returns the queued answer verbatim (blank falls back to the default).
+pub struct ScriptedPrompter {
+    answers: std::collections::VecDeque<String>,
+}
+
+impl ScriptedPrompter {
+    pub fn new(answers: Vec<String>) -> Self {
+        ScriptedPrompter {
+            answers: answers.into(),
+        }
+    }
+
+    fn pop(&mut self, label: &str) -> Result<String> {
+        match self.answers.pop_front() {
+            Some(a) => Ok(a),
+            None => bail!("scripted prompter ran out of answers at \"{label}\""),
+        }
+    }
+}
+
+impl Prompter for ScriptedPrompter {
+    fn ask(&mut self, label: &str, default: Option<&str>) -> Result<String> {
+        let input = self.pop(label)?;
+        if input.is_empty() {
+            if let Some(d) = default {
+                return Ok(d.to_string());
+            }
+        }
+        Ok(input)
+    }
+
+    fn confirm(&mut self, label: &str, default: bool) -> Result<bool> {
+        let input = self.pop(label)?;
+        Ok(match input.to_ascii_lowercase().as_str() {
+            "" => default,
+            "y" | "yes" => true,
+            _ => false,
+        })
+    }
+
+    fn select(&mut self, label: &str, _options: &[&str], default: &str) -> Result<String> {
+        let input = self.pop(label)?;
+        Ok(if input.is_empty() {
+            default.to_string()
+        } else {
+            input
+        })
+    }
+}

--- a/src/engine/config_write.rs
+++ b/src/engine/config_write.rs
@@ -94,6 +94,9 @@ fn update_type_table(entry: &mut Table, def: &TypeDef) {
         authorship_str(&def.authorship),
         "assisted",
     );
+    set_opt_str(entry, "github_issue_tag", def.github_issue_tag.as_deref());
+    set_opt_str(entry, "github_issue_type", def.github_issue_type.as_deref());
+    set_opt_str(entry, "clickup_list_id", def.clickup_list_id.as_deref());
     set_opt_int(entry, "clickup_task_type", def.clickup_task_type);
     set_lifecycle(entry, &def.lifecycle);
     set_attributes(entry, &def.attributes);

--- a/src/engine/reservation.rs
+++ b/src/engine/reservation.rs
@@ -27,6 +27,18 @@ pub enum ReservationProgress {
     },
 }
 
+impl ReservationProgress {
+    pub fn spinner_state(&self) -> crate::spinners::SpinnerState {
+        use crate::spinners::SpinnerState;
+        match self {
+            ReservationProgress::QueryingRemote
+            | ReservationProgress::PushAttempt { .. }
+            | ReservationProgress::PushRejected { .. } => SpinnerState::Loading,
+            ReservationProgress::Reserved { .. } => SpinnerState::Success,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum PruneProgress {
     QueryingRemote,
@@ -263,4 +275,35 @@ pub fn reserve_next(
         base + 1,
         base + max_retries as u32
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spinners::SpinnerState;
+
+    #[test]
+    fn progress_maps_to_spinner_state() {
+        assert_eq!(
+            ReservationProgress::QueryingRemote.spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::PushAttempt {
+                attempt: 1,
+                max: 3,
+                candidate: 7,
+            }
+            .spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::PushRejected { candidate: 7 }.spinner_state(),
+            SpinnerState::Loading
+        );
+        assert_eq!(
+            ReservationProgress::Reserved { number: 8 }.spinner_state(),
+            SpinnerState::Success
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod app;
 pub mod cli;
 pub mod engine;
+pub mod spinners;
 pub mod tui;
 #[cfg(feature = "web")]
 pub mod web;

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,6 +638,9 @@ fn main() -> anyhow::Result<()> {
                     numbering,
                     intent,
                     authorship,
+                    github_issue_tag,
+                    github_issue_type,
+                    clickup_list_id,
                     clickup_task_type,
                     attributes,
                 }) => {
@@ -659,6 +662,9 @@ fn main() -> anyhow::Result<()> {
                                 numbering.as_deref(),
                                 intent.as_deref(),
                                 authorship.as_deref(),
+                                github_issue_tag.as_deref(),
+                                github_issue_type.as_deref(),
+                                clickup_list_id.as_deref(),
                                 clickup_task_type,
                                 &attributes,
                             )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(Commands::Init {
         non_interactive,
         json,
+        template,
     }) = &cli.command
     {
         use std::io::IsTerminal;
@@ -36,7 +37,7 @@ fn main() -> anyhow::Result<()> {
         );
         if interactive {
             let mut prompter = lazyspec::cli::wizard::StdinPrompter::new();
-            lazyspec::cli::init::run_init_interactive(&cwd, &mut prompter)?;
+            lazyspec::cli::init::run_init_interactive(&cwd, &mut prompter, template.as_deref())?;
         } else {
             lazyspec::cli::init::run(&cwd)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,10 +683,15 @@ fn main() -> anyhow::Result<()> {
                     use std::io::IsTerminal;
                     match classify_add_type_args([&name, &plural, &dir, &prefix])? {
                         AddTypeInvocation::Positional => {
-                            lazyspec::cli::config::run_add_type(
+                            let type_name = name.as_deref().unwrap();
+                            let pb = lazyspec::cli::spinner::op_spinner(
+                                format!("adding type {type_name}"),
+                                json,
+                            );
+                            let result = lazyspec::cli::config::run_add_type(
                                 &cwd,
                                 &fs,
-                                name.as_deref().unwrap(),
+                                type_name,
                                 plural.as_deref().unwrap(),
                                 dir.as_deref().unwrap(),
                                 prefix.as_deref().unwrap(),
@@ -702,7 +707,14 @@ fn main() -> anyhow::Result<()> {
                                 clickup_list_id.as_deref(),
                                 clickup_task_type,
                                 &attributes,
-                            )?;
+                            );
+                            match result {
+                                Ok(()) => lazyspec::cli::spinner::finish_ok(pb, "type added"),
+                                Err(e) => {
+                                    lazyspec::cli::spinner::finish_err(pb, "add-type failed");
+                                    return Err(e);
+                                }
+                            }
                         }
                         AddTypeInvocation::Prompt => {
                             let interactive = !json
@@ -719,6 +731,10 @@ fn main() -> anyhow::Result<()> {
                                 &fs,
                                 &mut prompter,
                             )?;
+                            // The wizard's prompts are the feedback while it runs;
+                            // settle on the happy face once the write lands.
+                            let pb = lazyspec::cli::spinner::op_spinner("type added", json);
+                            lazyspec::cli::spinner::finish_ok(pb, "type added");
                         }
                     }
                 }
@@ -727,10 +743,30 @@ fn main() -> anyhow::Result<()> {
                     states,
                     edges,
                 }) => {
-                    lazyspec::cli::config::run_set_lifecycle(&cwd, &fs, &name, &states, &edges)?;
+                    let pb = lazyspec::cli::spinner::op_spinner(
+                        format!("setting lifecycle on {name}"),
+                        json,
+                    );
+                    match lazyspec::cli::config::run_set_lifecycle(
+                        &cwd, &fs, &name, &states, &edges,
+                    ) {
+                        Ok(()) => lazyspec::cli::spinner::finish_ok(pb, "lifecycle set"),
+                        Err(e) => {
+                            lazyspec::cli::spinner::finish_err(pb, "set-lifecycle failed");
+                            return Err(e);
+                        }
+                    }
                 }
                 Some(ConfigCommand::AddGate { name, status }) => {
-                    lazyspec::cli::config::run_add_gate(&cwd, &fs, &name, &status)?;
+                    let pb =
+                        lazyspec::cli::spinner::op_spinner(format!("gating rule {name}"), json);
+                    match lazyspec::cli::config::run_add_gate(&cwd, &fs, &name, &status) {
+                        Ok(()) => lazyspec::cli::spinner::finish_ok(pb, "gate added"),
+                        Err(e) => {
+                            lazyspec::cli::spinner::finish_err(pb, "add-gate failed");
+                            return Err(e);
+                        }
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -599,7 +599,7 @@ fn main() -> anyhow::Result<()> {
                 )?;
             }
         },
-        Some(Commands::Config { command, json: _ }) => {
+        Some(Commands::Config { command, json }) => {
             use lazyspec::cli::config::ConfigCommand;
             match command {
                 None | Some(ConfigCommand::Show { .. }) => {
@@ -624,23 +624,45 @@ fn main() -> anyhow::Result<()> {
                     clickup_task_type,
                     attributes,
                 }) => {
-                    lazyspec::cli::config::run_add_type(
-                        &cwd,
-                        &fs,
-                        &name,
-                        &plural,
-                        &dir,
-                        &prefix,
-                        icon.as_deref(),
-                        parent_type.as_deref(),
-                        singleton,
-                        store.as_deref(),
-                        numbering.as_deref(),
-                        intent.as_deref(),
-                        authorship.as_deref(),
-                        clickup_task_type,
-                        &attributes,
-                    )?;
+                    use lazyspec::cli::config::{classify_add_type_args, AddTypeInvocation};
+                    use std::io::IsTerminal;
+                    match classify_add_type_args([&name, &plural, &dir, &prefix])? {
+                        AddTypeInvocation::Positional => {
+                            lazyspec::cli::config::run_add_type(
+                                &cwd,
+                                &fs,
+                                name.as_deref().unwrap(),
+                                plural.as_deref().unwrap(),
+                                dir.as_deref().unwrap(),
+                                prefix.as_deref().unwrap(),
+                                icon.as_deref(),
+                                parent_type.as_deref(),
+                                singleton,
+                                store.as_deref(),
+                                numbering.as_deref(),
+                                intent.as_deref(),
+                                authorship.as_deref(),
+                                clickup_task_type,
+                                &attributes,
+                            )?;
+                        }
+                        AddTypeInvocation::Prompt => {
+                            let interactive = !json
+                                && std::io::stdin().is_terminal()
+                                && std::io::stdout().is_terminal();
+                            if !interactive {
+                                anyhow::bail!(
+                                    "config add-type requires name, plural, dir, and prefix (or run interactively on a TTY)"
+                                );
+                            }
+                            let mut prompter = lazyspec::cli::wizard::StdinPrompter::new();
+                            lazyspec::cli::config::run_add_type_interactive(
+                                &cwd,
+                                &fs,
+                                &mut prompter,
+                            )?;
+                        }
+                    }
                 }
                 Some(ConfigCommand::SetLifecycle {
                     name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,8 +181,9 @@ fn main() -> anyhow::Result<()> {
         }) => {
             let body_content = lazyspec::cli::resolve_body(&body, &body_file)?;
             let store = Store::load(&cwd, &config)?;
+            let pb = lazyspec::cli::spinner::op_spinner(format!("creating {}", doc_type), json);
             if json {
-                let output = lazyspec::cli::create::run_json_with_body(
+                let result = lazyspec::cli::create::run_json_with_body(
                     &cwd,
                     &config,
                     &store,
@@ -191,11 +192,24 @@ fn main() -> anyhow::Result<()> {
                     &author,
                     parent.as_deref(),
                     body_content.as_deref(),
-                    |_| {},
-                )?;
-                println!("{}", output);
+                    |p| {
+                        if let Some(pb) = &pb {
+                            pb.set_message(lazyspec::cli::spinner::reservation_message(&p));
+                        }
+                    },
+                );
+                match result {
+                    Ok(output) => {
+                        lazyspec::cli::spinner::finish_ok(pb, "created");
+                        println!("{}", output);
+                    }
+                    Err(e) => {
+                        lazyspec::cli::spinner::finish_err(pb, "create failed");
+                        return Err(e);
+                    }
+                }
             } else {
-                let (path, push_outcome) = lazyspec::cli::create::run_with_body(
+                let result = lazyspec::cli::create::run_with_body(
                     &cwd,
                     &config,
                     &store,
@@ -204,11 +218,24 @@ fn main() -> anyhow::Result<()> {
                     &author,
                     parent.as_deref(),
                     body_content.as_deref(),
-                    |_| {},
-                )?;
-                println!("{}", path.display());
-                if let Some(warning) = push_outcome.warning() {
-                    eprintln!("{}", warning);
+                    |p| {
+                        if let Some(pb) = &pb {
+                            pb.set_message(lazyspec::cli::spinner::reservation_message(&p));
+                        }
+                    },
+                );
+                match result {
+                    Ok((path, push_outcome)) => {
+                        lazyspec::cli::spinner::finish_ok(pb, "created");
+                        println!("{}", path.display());
+                        if let Some(warning) = push_outcome.warning() {
+                            eprintln!("{}", warning);
+                        }
+                    }
+                    Err(e) => {
+                        lazyspec::cli::spinner::finish_err(pb, "create failed");
+                        return Err(e);
+                    }
                 }
             }
         }
@@ -606,14 +633,22 @@ fn main() -> anyhow::Result<()> {
             }
             ReservationsCommand::Prune { dry_run, json } => {
                 let store = Store::load(&cwd, &config)?;
-                lazyspec::cli::reservations::run_prune(
+                let pb = lazyspec::cli::spinner::op_spinner("pruning reservations", json);
+                let result = lazyspec::cli::reservations::run_prune(
                     &cwd,
                     &config,
                     &store,
                     dry_run,
                     json,
-                    |_| {},
-                )?;
+                    pb.as_ref(),
+                );
+                match result {
+                    Ok(()) => lazyspec::cli::spinner::finish_ok(pb, "prune complete"),
+                    Err(e) => {
+                        lazyspec::cli::spinner::finish_err(pb, "prune failed");
+                        return Err(e);
+                    }
+                }
             }
         },
         Some(Commands::Config { command, json }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -725,6 +725,13 @@ fn main() -> anyhow::Result<()> {
                                     "config add-type requires name, plural, dir, and prefix (or run interactively on a TTY)"
                                 );
                             }
+                            if lazyspec::cli::spinner::should_greet(
+                                json,
+                                std::io::stdout().is_terminal(),
+                                console::colors_enabled(),
+                            ) {
+                                lazyspec::cli::spinner::say("let's add a new document type");
+                            }
                             let mut prompter = lazyspec::cli::wizard::StdinPrompter::new();
                             lazyspec::cli::config::run_add_type_interactive(
                                 &cwd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,24 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let cwd = std::env::current_dir()?;
 
-    if matches!(cli.command, Some(Commands::Init)) {
-        lazyspec::cli::init::run(&cwd)?;
+    if let Some(Commands::Init {
+        non_interactive,
+        json,
+    }) = &cli.command
+    {
+        use std::io::IsTerminal;
+        let interactive = lazyspec::cli::init::init_is_interactive(
+            *non_interactive,
+            *json,
+            std::io::stdin().is_terminal(),
+            std::io::stdout().is_terminal(),
+        );
+        if interactive {
+            let mut prompter = lazyspec::cli::wizard::StdinPrompter::new();
+            lazyspec::cli::init::run_init_interactive(&cwd, &mut prompter)?;
+        } else {
+            lazyspec::cli::init::run(&cwd)?;
+        }
         return Ok(());
     }
 
@@ -106,7 +122,7 @@ fn main() -> anyhow::Result<()> {
     let config = Config::load(&cwd, &fs)?;
 
     match cli.command {
-        Some(Commands::Init)
+        Some(Commands::Init { .. })
         | Some(Commands::Completions { .. })
         | Some(Commands::Skills { .. }) => {
             unreachable!()

--- a/src/spinners.rs
+++ b/src/spinners.rs
@@ -64,12 +64,16 @@ impl FaceSpinner {
 
     fn compact_frames(&self, state: SpinnerState) -> (&'static [&'static str], FrameColour) {
         match (self.ascii, state) {
-            (false, SpinnerState::Idle) => (&["[·‿·]"], FrameColour::Accent),
-            (false, SpinnerState::Loading) => {
-                (&["[◐‿◐]", "[◓‿◓]", "[◑‿◑]", "[◒‿◒]"], FrameColour::Accent)
-            }
-            (false, SpinnerState::Success) => (&["[◠‿◠]"], FrameColour::Success),
-            (false, SpinnerState::Error) => (&["[×_×]"], FrameColour::Error),
+            // Spaces around each glyph: the circle glyphs render wider than one
+            // cell in some fonts and bleed over an adjacent glyph. The box frames
+            // are already space-padded; compact needs the same clearance.
+            (false, SpinnerState::Idle) => (&["[· ‿ ·]"], FrameColour::Accent),
+            (false, SpinnerState::Loading) => (
+                &["[◐ ‿ ◐ ]", "[◓ ‿ ◓ ]", "[◑ ‿ ◑ ]", "[◒ ‿ ◒ ]"],
+                FrameColour::Accent,
+            ),
+            (false, SpinnerState::Success) => (&["[◠ ‿ ◠ ]"], FrameColour::Success),
+            (false, SpinnerState::Error) => (&["[× _ ×]"], FrameColour::Error),
             (true, SpinnerState::Idle) => (&["[o_o]"], FrameColour::Accent),
             (true, SpinnerState::Loading) => {
                 (&["[|_|]", "[/_/]", "[-_-]", "[\\_\\]"], FrameColour::Accent)
@@ -164,28 +168,28 @@ mod tests {
     fn compact_frame_catalogue_and_wrap() {
         let s = FaceSpinner { ascii: false };
 
-        assert_eq!(s.compact(SpinnerState::Idle, 0).lines[0], "[·‿·]");
+        assert_eq!(s.compact(SpinnerState::Idle, 0).lines[0], "[· ‿ ·]");
         assert_eq!(
             s.compact(SpinnerState::Idle, 1),
             s.compact(SpinnerState::Idle, 0)
         );
 
-        assert_eq!(s.compact(SpinnerState::Loading, 0).lines[0], "[◐‿◐]");
-        assert_eq!(s.compact(SpinnerState::Loading, 1).lines[0], "[◓‿◓]");
-        assert_eq!(s.compact(SpinnerState::Loading, 2).lines[0], "[◑‿◑]");
-        assert_eq!(s.compact(SpinnerState::Loading, 3).lines[0], "[◒‿◒]");
+        assert_eq!(s.compact(SpinnerState::Loading, 0).lines[0], "[◐ ‿ ◐ ]");
+        assert_eq!(s.compact(SpinnerState::Loading, 1).lines[0], "[◓ ‿ ◓ ]");
+        assert_eq!(s.compact(SpinnerState::Loading, 2).lines[0], "[◑ ‿ ◑ ]");
+        assert_eq!(s.compact(SpinnerState::Loading, 3).lines[0], "[◒ ‿ ◒ ]");
         assert_eq!(
             s.compact(SpinnerState::Loading, 4),
             s.compact(SpinnerState::Loading, 0)
         );
 
-        assert_eq!(s.compact(SpinnerState::Success, 0).lines[0], "[◠‿◠]");
+        assert_eq!(s.compact(SpinnerState::Success, 0).lines[0], "[◠ ‿ ◠ ]");
         assert_eq!(
             s.compact(SpinnerState::Success, 999),
             s.compact(SpinnerState::Success, 0)
         );
 
-        assert_eq!(s.compact(SpinnerState::Error, 0).lines[0], "[×_×]");
+        assert_eq!(s.compact(SpinnerState::Error, 0).lines[0], "[× _ ×]");
         assert_eq!(
             s.compact(SpinnerState::Error, 999),
             s.compact(SpinnerState::Error, 0)

--- a/src/spinners.rs
+++ b/src/spinners.rs
@@ -1,0 +1,260 @@
+//! Pure spinner framework shared by the TUI and CLI.
+//!
+//! This module carries no terminal dependency: frames are plain strings tagged
+//! with a semantic [`FrameColour`]. Consumers map colour to their own styling.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpinnerState {
+    Idle,
+    Loading,
+    Success,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameColour {
+    Accent,
+    Dim,
+    Success,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    pub lines: Vec<String>,
+    pub colour: FrameColour,
+}
+
+pub trait Spinner {
+    fn compact(&self, state: SpinnerState, idx: u64) -> Frame;
+    fn full(&self, state: SpinnerState, idx: u64) -> Frame;
+}
+
+pub struct FaceSpinner {
+    pub ascii: bool,
+}
+
+impl FaceSpinner {
+    fn borders(&self) -> (&'static str, &'static str) {
+        if self.ascii {
+            ("+-------+", "+-------+")
+        } else {
+            ("╭───────╮", "╰───────╯")
+        }
+    }
+
+    fn full_frames(&self, state: SpinnerState) -> (&'static [&'static str], FrameColour) {
+        match (self.ascii, state) {
+            (false, SpinnerState::Idle) => (&["│ ● ▪ ● │", "│ - ▪ - │"], FrameColour::Accent),
+            (false, SpinnerState::Loading) => (
+                &["│ ◐ ○ ◐ │", "│ ◓ ○ ◓ │", "│ ◑ ○ ◑ │", "│ ◒ ○ ◒ │"],
+                FrameColour::Accent,
+            ),
+            (false, SpinnerState::Success) => (&["│ ◠ ◡ ◠ │"], FrameColour::Success),
+            (false, SpinnerState::Error) => (&["│ × ▂ × │"], FrameColour::Error),
+            (true, SpinnerState::Idle) => (&["| o - o |", "| - - - |"], FrameColour::Accent),
+            (true, SpinnerState::Loading) => (
+                &["| | o | |", "| / o / |", "| - o - |", "| \\ o \\ |"],
+                FrameColour::Accent,
+            ),
+            (true, SpinnerState::Success) => (&["| ^ _ ^ |"], FrameColour::Success),
+            (true, SpinnerState::Error) => (&["| x _ x |"], FrameColour::Error),
+        }
+    }
+
+    fn compact_frames(&self, state: SpinnerState) -> (&'static [&'static str], FrameColour) {
+        match (self.ascii, state) {
+            (false, SpinnerState::Idle) => (&["[·‿·]"], FrameColour::Accent),
+            (false, SpinnerState::Loading) => {
+                (&["[◐‿◐]", "[◓‿◓]", "[◑‿◑]", "[◒‿◒]"], FrameColour::Accent)
+            }
+            (false, SpinnerState::Success) => (&["[◠‿◠]"], FrameColour::Success),
+            (false, SpinnerState::Error) => (&["[×_×]"], FrameColour::Error),
+            (true, SpinnerState::Idle) => (&["[o_o]"], FrameColour::Accent),
+            (true, SpinnerState::Loading) => {
+                (&["[|_|]", "[/_/]", "[-_-]", "[\\_\\]"], FrameColour::Accent)
+            }
+            (true, SpinnerState::Success) => (&["[^_^]"], FrameColour::Success),
+            (true, SpinnerState::Error) => (&["[x_x]"], FrameColour::Error),
+        }
+    }
+}
+
+fn pick<'a>(frames: &'a [&'a str], idx: u64) -> &'a str {
+    frames[(idx % frames.len() as u64) as usize]
+}
+
+impl Spinner for FaceSpinner {
+    fn compact(&self, state: SpinnerState, idx: u64) -> Frame {
+        let (frames, colour) = self.compact_frames(state);
+        Frame {
+            lines: vec![pick(frames, idx).to_string()],
+            colour,
+        }
+    }
+
+    fn full(&self, state: SpinnerState, idx: u64) -> Frame {
+        let (frames, colour) = self.full_frames(state);
+        let (top, bottom) = self.borders();
+        Frame {
+            lines: vec![
+                top.to_string(),
+                pick(frames, idx).to_string(),
+                bottom.to_string(),
+            ],
+            colour,
+        }
+    }
+}
+
+static FACE: FaceSpinner = FaceSpinner { ascii: false };
+
+pub fn spinner(_name: &str) -> &'static dyn Spinner {
+    &FACE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_STATES: [SpinnerState; 4] = [
+        SpinnerState::Idle,
+        SpinnerState::Loading,
+        SpinnerState::Success,
+        SpinnerState::Error,
+    ];
+
+    #[test]
+    fn full_frame_catalogue_and_wrap() {
+        let s = FaceSpinner { ascii: false };
+
+        assert_eq!(s.full(SpinnerState::Idle, 0).lines[1], "│ ● ▪ ● │");
+        assert_eq!(s.full(SpinnerState::Idle, 1).lines[1], "│ - ▪ - │");
+        assert_eq!(s.full(SpinnerState::Idle, 2), s.full(SpinnerState::Idle, 0));
+
+        assert_eq!(s.full(SpinnerState::Loading, 0).lines[1], "│ ◐ ○ ◐ │");
+        assert_eq!(s.full(SpinnerState::Loading, 1).lines[1], "│ ◓ ○ ◓ │");
+        assert_eq!(s.full(SpinnerState::Loading, 2).lines[1], "│ ◑ ○ ◑ │");
+        assert_eq!(s.full(SpinnerState::Loading, 3).lines[1], "│ ◒ ○ ◒ │");
+        assert_eq!(
+            s.full(SpinnerState::Loading, 4),
+            s.full(SpinnerState::Loading, 0)
+        );
+
+        assert_eq!(s.full(SpinnerState::Success, 0).lines[1], "│ ◠ ◡ ◠ │");
+        assert_eq!(
+            s.full(SpinnerState::Success, 999),
+            s.full(SpinnerState::Success, 0)
+        );
+
+        assert_eq!(s.full(SpinnerState::Error, 0).lines[1], "│ × ▂ × │");
+        assert_eq!(
+            s.full(SpinnerState::Error, 999),
+            s.full(SpinnerState::Error, 0)
+        );
+
+        for st in ALL_STATES {
+            let f = s.full(st, 0);
+            assert_eq!(f.lines[0], "╭───────╮");
+            assert_eq!(f.lines[2], "╰───────╯");
+        }
+    }
+
+    #[test]
+    fn compact_frame_catalogue_and_wrap() {
+        let s = FaceSpinner { ascii: false };
+
+        assert_eq!(s.compact(SpinnerState::Idle, 0).lines[0], "[·‿·]");
+        assert_eq!(
+            s.compact(SpinnerState::Idle, 1),
+            s.compact(SpinnerState::Idle, 0)
+        );
+
+        assert_eq!(s.compact(SpinnerState::Loading, 0).lines[0], "[◐‿◐]");
+        assert_eq!(s.compact(SpinnerState::Loading, 1).lines[0], "[◓‿◓]");
+        assert_eq!(s.compact(SpinnerState::Loading, 2).lines[0], "[◑‿◑]");
+        assert_eq!(s.compact(SpinnerState::Loading, 3).lines[0], "[◒‿◒]");
+        assert_eq!(
+            s.compact(SpinnerState::Loading, 4),
+            s.compact(SpinnerState::Loading, 0)
+        );
+
+        assert_eq!(s.compact(SpinnerState::Success, 0).lines[0], "[◠‿◠]");
+        assert_eq!(
+            s.compact(SpinnerState::Success, 999),
+            s.compact(SpinnerState::Success, 0)
+        );
+
+        assert_eq!(s.compact(SpinnerState::Error, 0).lines[0], "[×_×]");
+        assert_eq!(
+            s.compact(SpinnerState::Error, 999),
+            s.compact(SpinnerState::Error, 0)
+        );
+    }
+
+    #[test]
+    fn ascii_output_has_no_non_ascii_bytes() {
+        let s = FaceSpinner { ascii: true };
+        for st in ALL_STATES {
+            for idx in 0..8u64 {
+                let full = s.full(st, idx);
+                assert!(
+                    full.lines.iter().all(|l| l.is_ascii()),
+                    "full {st:?} idx {idx} not ascii: {:?}",
+                    full.lines
+                );
+                let compact = s.compact(st, idx);
+                assert!(
+                    compact.lines.iter().all(|l| l.is_ascii()),
+                    "compact {st:?} idx {idx} not ascii: {:?}",
+                    compact.lines
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn full_box_width_invariant() {
+        for ascii in [false, true] {
+            let s = FaceSpinner { ascii };
+            let mut widths = Vec::new();
+            for st in ALL_STATES {
+                for idx in 0..8u64 {
+                    let f = s.full(st, idx);
+                    assert_eq!(f.lines.len(), 3, "{st:?} idx {idx} not 3 lines");
+                    for line in &f.lines {
+                        widths.push(line.chars().count());
+                    }
+                }
+            }
+            assert!(
+                widths.iter().all(|&w| w == widths[0]),
+                "unequal line widths (ascii={ascii}): {widths:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_defaults_to_unicode_face() {
+        let unicode = FaceSpinner { ascii: false };
+        let expected = unicode.full(SpinnerState::Loading, 0);
+        assert_eq!(spinner("face").full(SpinnerState::Loading, 0), expected);
+        assert_eq!(spinner("unknown").full(SpinnerState::Loading, 0), expected);
+    }
+
+    #[test]
+    fn frame_colour_mapping_per_state() {
+        for ascii in [false, true] {
+            let s = FaceSpinner { ascii };
+            for st in ALL_STATES {
+                let expected = match st {
+                    SpinnerState::Idle | SpinnerState::Loading => FrameColour::Accent,
+                    SpinnerState::Success => FrameColour::Success,
+                    SpinnerState::Error => FrameColour::Error,
+                };
+                assert_eq!(s.full(st, 0).colour, expected);
+                assert_eq!(s.compact(st, 0).colour, expected);
+            }
+        }
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,3 +6,59 @@ pub mod state;
 pub mod views;
 
 pub use infra::event_loop::run;
+
+use crate::engine::config::{Config, StoreBackend};
+
+/// Whether the project has any type the background poll refreshes: github
+/// issues/milestones or clickup tasks. Gates the poll loop, the header sync
+/// face + countdown, and the `last_sync` seed so all three agree -- a
+/// milestone-only or clickup-only project polls and shows the tick just like a
+/// github-issues project.
+pub(crate) fn has_pollable_types(config: &Config) -> bool {
+    config.documents.types.iter().any(|t| {
+        t.store == StoreBackend::GithubIssues
+            || t.store == StoreBackend::GithubMilestones
+            || t.store == StoreBackend::ClickupTasks
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::config::TypeDef;
+
+    // Gate: a project whose only GitHub-backed type is github-milestones must
+    // still poll, so a milestone created after launch appears live in the list.
+    #[test]
+    fn milestone_only_project_is_pollable() {
+        let mut config = Config::default();
+        config.documents.types = vec![TypeDef::test_fixture(
+            "milestone",
+            StoreBackend::GithubMilestones,
+        )];
+
+        assert!(has_pollable_types(&config));
+    }
+
+    // Gate: a clickup-only project must poll too, so tasks created after launch
+    // appear live without a manual fetch — same parity as github types.
+    #[test]
+    fn clickup_only_project_is_pollable() {
+        let mut config = Config::default();
+        config.documents.types = vec![TypeDef::test_fixture("task", StoreBackend::ClickupTasks)];
+
+        assert!(has_pollable_types(&config));
+    }
+
+    // Gate: a project with no pollable types must not poll.
+    #[test]
+    fn project_without_gh_types_is_not_pollable() {
+        let mut config = Config::default();
+        config.documents.types = vec![
+            TypeDef::test_fixture("doc", StoreBackend::Filesystem),
+            TypeDef::test_fixture("note", StoreBackend::Filesystem),
+        ];
+
+        assert!(!has_pollable_types(&config));
+    }
+}

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -587,9 +587,10 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
             }
         }
         AppEvent::CreateStarted => {}
-        AppEvent::CreateProgress { message } => {
+        AppEvent::CreateProgress { message, state } => {
             if app.create_form.active && app.create_form.loading {
                 app.create_form.status_message = Some(message);
+                app.create_form.state = state;
             }
         }
         AppEvent::CreateComplete { result } => {
@@ -616,13 +617,20 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
                             app.selected_doc = doc_idx;
                         }
                     }
-                    app.close_create_form();
                     app.refresh_validation(config);
                     app.git_status_cache.invalidate();
                     app.gh_issue_map_stale = true;
+                    // Hold the success face over the updated list for a beat so a
+                    // create that finishes instantly still renders it before the
+                    // overlay is torn down; the run loop dismisses on this deadline.
+                    app.create_form.loading = false;
+                    app.create_form.state = crate::spinners::SpinnerState::Success;
+                    app.create_form.dismiss_at =
+                        Some(std::time::Instant::now() + std::time::Duration::from_millis(600));
                 }
                 Err(msg) => {
                     app.create_form.loading = false;
+                    app.create_form.state = crate::spinners::SpinnerState::Error;
                     app.create_form.error = Some(msg);
                     app.create_form.status_message = None;
                 }
@@ -753,6 +761,7 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
         let loop_start = Instant::now();
 
         let t = Instant::now();
+        app.frame_idx = loop_count;
         terminal.draw(|f| views::draw(f, &mut app, &config))?;
         perf_log::log_duration("draw", t);
 
@@ -795,6 +804,12 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
             }
             Err(_) => {
                 perf_log::log_duration("recv_timeout", t);
+            }
+        }
+
+        if let Some(deadline) = app.create_form.dismiss_at {
+            if Instant::now() >= deadline {
+                app.close_create_form();
             }
         }
 

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -235,18 +235,6 @@ fn try_push_clickup_edit_with<C: ClickupClient + 'static>(
         .map_err(|e| e.to_string())
 }
 
-// Whether the background poll should run for this project: true when any type is
-// backed by a store the poll refreshes (github issues/milestones OR clickup
-// tasks). Milestone-only and clickup-only projects still need the poll so a
-// milestone/task created after launch appears live in the list.
-fn has_pollable_types(config: &Config) -> bool {
-    config.documents.types.iter().any(|t| {
-        t.store == StoreBackend::GithubIssues
-            || t.store == StoreBackend::GithubMilestones
-            || t.store == StoreBackend::ClickupTasks
-    })
-}
-
 // Human-readable summary of a fix run for the warnings panel. The engine op core
 // returns the structured `FixOutput`; each frontend renders its own
 // presentation, so this mirrors the CLI's `fix::output::format_human`
@@ -684,24 +672,25 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
     let (tx, rx) = crossbeam_channel::unbounded();
     app.event_tx = tx.clone();
 
-    let shared_gh_store: Option<Arc<Mutex<GithubIssuesStore>>> = if has_pollable_types(&config) {
-        let gh_config = config.documents.github.as_ref();
-        let repo = gh_config.and_then(|g| g.repo.clone());
-        repo.map(|repo| {
-            let root = app.store.root();
-            Arc::new(Mutex::new(GithubIssuesStore {
-                client: Box::new(GhCli::new()),
-                root: root.to_path_buf(),
-                repo,
-                config: config.clone(),
-                issue_map: IssueMap::load(root)
-                    .unwrap_or_else(|_| serde_json::from_str("{}").unwrap()),
-                issue_cache: IssueCache::new(root),
-            }))
-        })
-    } else {
-        None
-    };
+    let shared_gh_store: Option<Arc<Mutex<GithubIssuesStore>>> =
+        if crate::tui::has_pollable_types(&config) {
+            let gh_config = config.documents.github.as_ref();
+            let repo = gh_config.and_then(|g| g.repo.clone());
+            repo.map(|repo| {
+                let root = app.store.root();
+                Arc::new(Mutex::new(GithubIssuesStore {
+                    client: Box::new(GhCli::new()),
+                    root: root.to_path_buf(),
+                    repo,
+                    config: config.clone(),
+                    issue_map: IssueMap::load(root)
+                        .unwrap_or_else(|_| serde_json::from_str("{}").unwrap()),
+                    issue_cache: IssueCache::new(root),
+                }))
+            })
+        } else {
+            None
+        };
 
     let cache_ttl = config
         .documents
@@ -712,7 +701,7 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
     // Schedule polling whenever the project has any pollable type, independent of
     // whether a github store was built: a clickup-only project has no github repo
     // (shared_gh_store == None) but must still poll to refresh its task cache.
-    let mut next_poll = if has_pollable_types(&config) {
+    let mut next_poll = if crate::tui::has_pollable_types(&config) {
         Some(Instant::now())
     } else {
         None
@@ -1077,41 +1066,6 @@ mod tests {
     use super::*;
     use crate::engine::config::TypeDef;
     use tempfile::TempDir;
-
-    // Gate: a project whose only GitHub-backed type is github-milestones must
-    // still poll, so a milestone created after launch appears live in the list.
-    #[test]
-    fn milestone_only_project_is_pollable() {
-        let mut config = Config::default();
-        config.documents.types = vec![TypeDef::test_fixture(
-            "milestone",
-            StoreBackend::GithubMilestones,
-        )];
-
-        assert!(has_pollable_types(&config));
-    }
-
-    // Gate: a clickup-only project must poll too, so tasks created after launch
-    // appear live without a manual fetch — same parity as github types.
-    #[test]
-    fn clickup_only_project_is_pollable() {
-        let mut config = Config::default();
-        config.documents.types = vec![TypeDef::test_fixture("task", StoreBackend::ClickupTasks)];
-
-        assert!(has_pollable_types(&config));
-    }
-
-    // Gate: a project with no pollable types must not poll.
-    #[test]
-    fn project_without_gh_types_is_not_pollable() {
-        let mut config = Config::default();
-        config.documents.types = vec![
-            TypeDef::test_fixture("doc", StoreBackend::Filesystem),
-            TypeDef::test_fixture("note", StoreBackend::Filesystem),
-        ];
-
-        assert!(!has_pollable_types(&config));
-    }
 
     // Build an App over `root` with the given config, using a deterministic
     // halfblocks picker so no terminal probing happens in tests.

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -762,6 +762,7 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
 
         let t = Instant::now();
         app.frame_idx = loop_count;
+        app.refresh_in_flight = refresh_in_flight.load(Ordering::Relaxed);
         terminal.draw(|f| views::draw(f, &mut app, &config))?;
         perf_log::log_duration("draw", t);
 

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -757,11 +757,15 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
     });
 
     let mut loop_count: u64 = 0;
+    let anim_start = Instant::now();
     loop {
         let loop_start = Instant::now();
 
         let t = Instant::now();
-        app.frame_idx = loop_count;
+        // Spinner cadence: wall-clock seconds, not loop count. The render loop
+        // wakes tens of times/sec for input; binding frame_idx to that spun the
+        // spinner far too fast. One frame per second.
+        app.frame_idx = anim_start.elapsed().as_secs();
         app.refresh_in_flight = refresh_in_flight.load(Ordering::Relaxed);
         terminal.draw(|f| views::draw(f, &mut app, &config))?;
         perf_log::log_duration("draw", t);

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -667,12 +667,6 @@ impl App {
         let (event_tx, _event_rx) = crossbeam_channel::unbounded();
         let git_branch = query_git_branch(store.root());
         let git_status_cache = GitStatusCache::new(store.root());
-        let has_github_issues = config
-            .documents
-            .types
-            .iter()
-            .any(|t| t.store == StoreBackend::GithubIssues);
-
         #[cfg(feature = "agent")]
         let agent_spawner = AgentSpawner::new(store.root());
         // ADR-015 zero-defaults: an absent agents dir yields no prompts; discovery
@@ -772,7 +766,7 @@ impl App {
             gh_conflict_message: None,
             gh_push_in_flight: Arc::new(AtomicBool::new(false)),
             refresh_in_flight: false,
-            last_sync: if has_github_issues {
+            last_sync: if crate::tui::has_pollable_types(config) {
                 Some(Instant::now())
             } else {
                 None

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -596,6 +596,9 @@ pub struct App {
     pub git_status_cache: GitStatusCache,
     pub gh_conflict_message: Option<String>,
     pub gh_push_in_flight: Arc<AtomicBool>,
+    /// Mirror of the event loop's local `refresh_in_flight` atomic, refreshed
+    /// each frame so the header sync face can reflect an in-flight poll.
+    pub refresh_in_flight: bool,
     pub last_sync: Option<Instant>,
     pub gh_issue_map_stale: bool,
     pub status_bar_enabled: bool,
@@ -768,6 +771,7 @@ impl App {
             git_status_cache,
             gh_conflict_message: None,
             gh_push_in_flight: Arc::new(AtomicBool::new(false)),
+            refresh_in_flight: false,
             last_sync: if has_github_issues {
                 Some(Instant::now())
             } else {
@@ -3541,6 +3545,7 @@ pub(crate) mod parity_seed {
             git_status_cache: GitStatusCache::new(tmp.path()),
             gh_conflict_message: None,
             gh_push_in_flight: Arc::new(AtomicBool::new(false)),
+            refresh_in_flight: false,
             last_sync: None,
             gh_issue_map_stale: false,
             status_bar_enabled: true,
@@ -4019,6 +4024,7 @@ mod tests {
             git_status_cache: GitStatusCache::new(Path::new(".")),
             gh_conflict_message: None,
             gh_push_in_flight: Arc::new(AtomicBool::new(false)),
+            refresh_in_flight: false,
             last_sync: None,
             gh_issue_map_stale: false,
             status_bar_enabled: true,

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -265,6 +265,7 @@ pub enum AppEvent {
     CreateStarted,
     CreateProgress {
         message: String,
+        state: crate::spinners::SpinnerState,
     },
     CreateComplete {
         result: Result<CreateResult, String>,
@@ -648,6 +649,9 @@ pub struct App {
     /// `Enter`. `Some` routes keys to the picker; selecting writes the chosen
     /// variant back into `settings_buffer` (RFC-023 / STORY-144).
     pub settings_variant_picker: Option<SettingsVariantPicker>,
+    /// Free-running render-loop counter, set each frame before `terminal.draw`.
+    /// Drives spinner animation phase; shared with the header sync/push face.
+    pub frame_idx: u64,
 }
 
 impl App {
@@ -790,6 +794,7 @@ impl App {
             override_key_prompt: OverrideKeyPrompt::new(),
             settings_zone_editor: None,
             settings_variant_picker: None,
+            frame_idx: 0,
         };
         app.apply_config(config);
         app.rebuild_search_index();
@@ -2442,6 +2447,7 @@ impl App {
             let doc_type = self.create_form.doc_type.clone();
 
             self.create_form.loading = true;
+            self.create_form.state = crate::spinners::SpinnerState::Loading;
             self.create_form.status_message = Some("Reserving...".to_string());
             let _ = self.event_tx.send(AppEvent::CreateStarted);
 
@@ -2482,7 +2488,8 @@ impl App {
                                     format!("Reserved number {}", number)
                                 }
                             };
-                            let _ = progress_tx.send(AppEvent::CreateProgress { message });
+                            let state = p.spinner_state();
+                            let _ = progress_tx.send(AppEvent::CreateProgress { message, state });
                         },
                     )
                     .map_err(|e| e.to_string())?;
@@ -3556,6 +3563,7 @@ pub(crate) mod parity_seed {
             override_key_prompt: OverrideKeyPrompt::new(),
             settings_zone_editor: None,
             settings_variant_picker: None,
+            frame_idx: 0,
         };
         app.apply_config(&config);
         (tmp, app)
@@ -4033,6 +4041,7 @@ mod tests {
             override_key_prompt: OverrideKeyPrompt::new(),
             settings_zone_editor: None,
             settings_variant_picker: None,
+            frame_idx: 0,
         };
         app
     }

--- a/src/tui/state/forms.rs
+++ b/src/tui/state/forms.rs
@@ -54,6 +54,11 @@ pub struct CreateForm {
     pub error: Option<String>,
     pub loading: bool,
     pub status_message: Option<String>,
+    pub state: crate::spinners::SpinnerState,
+    /// When set, the event loop auto-dismisses the overlay once this deadline
+    /// passes. Used to hold the success face on screen briefly before teardown
+    /// so a create that finishes instantly still renders its success frame.
+    pub dismiss_at: Option<std::time::Instant>,
 }
 
 impl Default for CreateForm {
@@ -75,6 +80,8 @@ impl CreateForm {
             error: None,
             loading: false,
             status_message: None,
+            state: crate::spinners::SpinnerState::Idle,
+            dismiss_at: None,
         }
     }
 
@@ -88,6 +95,8 @@ impl CreateForm {
         self.error = None;
         self.loading = false;
         self.status_message = None;
+        self.state = crate::spinners::SpinnerState::Idle;
+        self.dismiss_at = None;
     }
 
     pub(super) fn focused_value_mut(&mut self) -> &mut String {
@@ -703,5 +712,39 @@ mod tests {
         let mut picker = SettingsVariantPicker::new(FieldPath::Unset, NUMBERING, 0);
         picker.cursor_up();
         assert_eq!(picker.selected, 0, "cursor_up saturates at 0");
+    }
+
+    // STORY-230 AC3: a successful create holds the success face -- state is
+    // Success, animation stops, and a dismiss deadline is armed rather than the
+    // overlay being torn down immediately.
+    #[test]
+    fn ac3_success_arms_dismiss_deadline_without_reset() {
+        let mut form = CreateForm::new();
+        form.active = true;
+        form.loading = true;
+        form.state = crate::spinners::SpinnerState::Loading;
+
+        // Mirror the event loop's CreateComplete Ok branch.
+        form.loading = false;
+        form.state = crate::spinners::SpinnerState::Success;
+        form.dismiss_at = Some(std::time::Instant::now() + std::time::Duration::from_millis(600));
+
+        assert_eq!(form.state, crate::spinners::SpinnerState::Success);
+        assert!(!form.loading, "success is a held frame, not animating");
+        assert!(
+            form.dismiss_at.is_some(),
+            "overlay not dismissed immediately"
+        );
+        assert!(form.active, "overlay stays active during the hold");
+    }
+
+    // reset() (via close_create_form) must clear the dismiss deadline so a stale
+    // Instant can never re-trigger a dismiss on the next form.
+    #[test]
+    fn reset_clears_dismiss_at() {
+        let mut form = CreateForm::new();
+        form.dismiss_at = Some(std::time::Instant::now());
+        form.reset();
+        assert!(form.dismiss_at.is_none());
     }
 }

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -19,7 +19,7 @@ use ratatui::{
 
 use std::sync::atomic::Ordering;
 
-use crate::engine::config::{Config, StoreBackend};
+use crate::engine::config::Config;
 use crate::engine::status_colors::StatusColors;
 use crate::tui::state::{App, ViewMode};
 use status_bar::draw_status_bar;
@@ -159,14 +159,8 @@ pub fn draw(f: &mut Frame, app: &mut App, config: &Config) {
     )]);
     f.render_widget(Paragraph::new(title), outer[0]);
 
-    let has_gh_types = config
-        .documents
-        .types
-        .iter()
-        .any(|t| t.store == StoreBackend::GithubIssues);
-
     let mut right_spans: Vec<Span> = Vec::new();
-    if has_gh_types {
+    if crate::tui::has_pollable_types(config) {
         let state = sync_spinner_state(
             app.refresh_in_flight,
             app.gh_push_in_flight.load(Ordering::Relaxed),

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -42,6 +42,24 @@ use panels::{
     render_fullscreen_document,
 };
 
+const SYNC_SUCCESS_WINDOW: std::time::Duration = std::time::Duration::from_secs(2);
+
+fn sync_spinner_state(
+    refresh_in_flight: bool,
+    gh_push_in_flight: bool,
+    last_sync_elapsed: Option<std::time::Duration>,
+    success_window: std::time::Duration,
+) -> crate::spinners::SpinnerState {
+    use crate::spinners::SpinnerState;
+    if refresh_in_flight || gh_push_in_flight {
+        SpinnerState::Loading
+    } else if last_sync_elapsed.is_some_and(|d| d < success_window) {
+        SpinnerState::Success
+    } else {
+        SpinnerState::Idle
+    }
+}
+
 pub fn sync_indicator_text(elapsed_secs: u64, cache_ttl: u64) -> (String, Color) {
     if elapsed_secs >= 2 * cache_ttl {
         return ("stale".to_string(), Color::Red);
@@ -149,6 +167,18 @@ pub fn draw(f: &mut Frame, app: &mut App, config: &Config) {
 
     let mut right_spans: Vec<Span> = Vec::new();
     if has_gh_types {
+        let state = sync_spinner_state(
+            app.refresh_in_flight,
+            app.gh_push_in_flight.load(Ordering::Relaxed),
+            app.last_sync.map(|t| t.elapsed()),
+            SYNC_SUCCESS_WINDOW,
+        );
+        let frame = crate::spinners::spinner("face").compact(state, app.frame_idx);
+        right_spans.push(Span::styled(
+            frame.lines[0].clone(),
+            colors::frame_style(frame.colour),
+        ));
+        right_spans.push(Span::raw(" "));
         if let Some(last_sync) = app.last_sync {
             let cache_ttl = config
                 .documents
@@ -161,12 +191,6 @@ pub fn draw(f: &mut Frame, app: &mut App, config: &Config) {
             right_spans.push(Span::styled(text, Style::default().fg(color)));
             right_spans.push(Span::raw("  "));
         }
-    }
-    if app.gh_push_in_flight.load(Ordering::Relaxed) {
-        right_spans.push(Span::styled(
-            "pushing... ",
-            Style::default().fg(Color::Yellow),
-        ));
     }
     right_spans.push(Span::styled(
         format!("[{}] ` to cycle ", app.view_mode.name()),
@@ -286,7 +310,51 @@ mod tests {
     use std::path::Path;
 
     use super::panels;
-    use super::sync_indicator_text;
+    use super::{sync_indicator_text, sync_spinner_state};
+    use crate::spinners::SpinnerState;
+    use std::time::Duration;
+
+    const WINDOW: Duration = Duration::from_secs(2);
+
+    #[test]
+    fn spinner_loading_when_refresh_in_flight() {
+        assert_eq!(
+            sync_spinner_state(true, false, Some(Duration::from_millis(500)), WINDOW),
+            SpinnerState::Loading
+        );
+    }
+
+    #[test]
+    fn spinner_loading_when_push_in_flight() {
+        assert_eq!(
+            sync_spinner_state(false, true, None, WINDOW),
+            SpinnerState::Loading
+        );
+    }
+
+    #[test]
+    fn spinner_success_within_window() {
+        assert_eq!(
+            sync_spinner_state(false, false, Some(Duration::from_millis(500)), WINDOW),
+            SpinnerState::Success
+        );
+    }
+
+    #[test]
+    fn spinner_idle_after_window() {
+        assert_eq!(
+            sync_spinner_state(false, false, Some(Duration::from_secs(5)), WINDOW),
+            SpinnerState::Idle
+        );
+    }
+
+    #[test]
+    fn spinner_idle_when_never_synced() {
+        assert_eq!(
+            sync_spinner_state(false, false, None, WINDOW),
+            SpinnerState::Idle
+        );
+    }
 
     fn display_name(path: &Path) -> &str {
         let stem = path.file_stem().and_then(|s| s.to_str());

--- a/src/tui/views/colors.rs
+++ b/src/tui/views/colors.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier, Style};
 
 use crate::engine::document::Status;
 use crate::engine::status_colors::StatusColors;
@@ -114,10 +114,41 @@ pub fn tag_color(tag: &str) -> Color {
     hash_palette_color(tag)
 }
 
+/// Map a semantic spinner [`FrameColour`] to a ratatui style. Accent is the
+/// terminal default foreground; success/error carry the conventional
+/// green/red; dim is a modifier so it tracks the terminal's own palette.
+pub fn frame_style(colour: crate::spinners::FrameColour) -> Style {
+    use crate::spinners::FrameColour;
+    match colour {
+        FrameColour::Accent => Style::default(),
+        FrameColour::Dim => Style::default().add_modifier(Modifier::DIM),
+        FrameColour::Success => Style::default().fg(Color::Green),
+        FrameColour::Error => Style::default().fg(Color::Red),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn frame_style_maps_colours() {
+        use crate::spinners::FrameColour;
+        assert_eq!(frame_style(FrameColour::Accent), Style::default());
+        assert_eq!(
+            frame_style(FrameColour::Success),
+            Style::default().fg(Color::Green)
+        );
+        assert_eq!(
+            frame_style(FrameColour::Error),
+            Style::default().fg(Color::Red)
+        );
+        assert_eq!(
+            frame_style(FrameColour::Dim),
+            Style::default().add_modifier(Modifier::DIM)
+        );
+    }
 
     #[test]
     fn hex_to_color_parses_rrggbb() {

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -82,7 +82,12 @@ pub fn draw_create_form(f: &mut Frame, app: &App) {
     let area = f.area();
 
     let popup_width = 60.min(area.width.saturating_sub(4));
-    let popup_height = 14.min(area.height.saturating_sub(4));
+    let base_height = if app.create_form.state == crate::spinners::SpinnerState::Idle {
+        14
+    } else {
+        17
+    };
+    let popup_height = base_height.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(popup_width)) / 2;
     let y = (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
@@ -126,6 +131,14 @@ pub fn draw_create_form(f: &mut Frame, app: &App) {
             Span::styled(format!("{}{}", value, cursor), value_style),
         ]));
         lines.push(Line::from(""));
+    }
+
+    if form.state != crate::spinners::SpinnerState::Idle {
+        let frame = crate::spinners::spinner("face").full(form.state, app.frame_idx);
+        let style = super::colors::frame_style(frame.colour);
+        for face_line in frame.lines {
+            lines.push(Line::from(Span::styled(format!("  {}", face_line), style)));
+        }
     }
 
     if let Some(ref msg) = form.status_message {

--- a/tests/integration/cli_init_greeting_test.rs
+++ b/tests/integration/cli_init_greeting_test.rs
@@ -1,0 +1,58 @@
+use std::process::Command;
+
+// ITERATION-335 / STORY-231 AC5 + dictum 2: the init wizard's talking-face
+// greeting must never reach machine-readable or piped output. Running the binary
+// through captured pipes makes stdout a non-terminal, so `should_greet` gates the
+// animation off and no ESC bytes (nor the face box) appear on stdout.
+
+fn run_init(root: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let mut args = vec!["init"];
+    args.extend_from_slice(extra);
+    Command::new(env!("CARGO_BIN_EXE_lazyspec"))
+        .args(&args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run lazyspec init")
+}
+
+#[test]
+fn init_json_stdout_has_no_greeting_or_escape_codes() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = run_init(dir.path(), &["--json"]);
+    assert!(
+        output.status.success(),
+        "init --json should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "json stdout must contain no ESC bytes"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !stdout.contains('╭') && !stdout.contains('╰'),
+        "json stdout must not render the greeting face box, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn init_piped_stdout_has_no_greeting_or_escape_codes() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = run_init(dir.path(), &[]);
+    assert!(
+        output.status.success(),
+        "init should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "piped stdout must contain no ESC bytes"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !stdout.contains('╭') && !stdout.contains('╰'),
+        "piped stdout must not render the greeting face box, got: {stdout:?}"
+    );
+}

--- a/tests/integration/cli_spinner_parity_test.rs
+++ b/tests/integration/cli_spinner_parity_test.rs
@@ -1,0 +1,74 @@
+use std::process::Command;
+
+// ITERATION-334 / STORY-231 AC2: with `--json` or a non-TTY stdout, the create
+// spinner emits zero animation. Running the binary through captured pipes makes
+// both stdout and stderr non-terminals, so `op_spinner` returns `None` and the
+// bytes match the pre-spinner behaviour exactly.
+
+fn fixture_with_rfc_template() -> crate::common::TestFixture {
+    let fixture = crate::common::TestFixture::new();
+    let templates = fixture.root().join(".lazyspec/templates");
+    std::fs::create_dir_all(&templates).unwrap();
+    std::fs::write(
+        templates.join("rfc.md"),
+        "---\ntitle: \"{title}\"\ntype: rfc\nstatus: draft\nauthor: \"{author}\"\ndate: {date}\ntags: []\n---\n",
+    )
+    .unwrap();
+    fixture
+}
+
+fn run_create(root: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let mut args = vec!["create", "rfc", "Event Sourcing", "--author", "tester"];
+    args.extend_from_slice(extra);
+    Command::new(env!("CARGO_BIN_EXE_lazyspec"))
+        .args(&args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run lazyspec create")
+}
+
+#[test]
+fn create_json_stdout_has_no_escape_codes() {
+    let fixture = fixture_with_rfc_template();
+    let output = run_create(fixture.root(), &["--json"]);
+    assert!(
+        output.status.success(),
+        "create --json should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "json stdout must contain no ESC bytes"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("json stdout must parse");
+    assert_eq!(parsed["type"], "rfc");
+    assert_eq!(parsed["title"], "Event Sourcing");
+}
+
+#[test]
+fn create_piped_stdout_is_the_bare_path_line() {
+    let fixture = fixture_with_rfc_template();
+    let output = run_create(fixture.root(), &[]);
+    assert!(
+        output.status.success(),
+        "create should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "piped stdout must contain no ESC bytes"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let line = stdout.trim_end();
+    assert!(
+        !line.contains('\n'),
+        "piped stdout must be a single path line, got: {line:?}"
+    );
+    assert!(
+        line.ends_with("docs/rfcs/RFC-001-event-sourcing.md"),
+        "piped stdout must be the created path, got: {line:?}"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod cli_git_ref_show_test;
 mod cli_git_ref_status_test;
 mod cli_git_ref_validate_test;
 mod cli_ignore_test;
+mod cli_init_greeting_test;
 mod cli_init_test;
 mod cli_json_test;
 mod cli_lifecycle_seed_test;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -26,6 +26,7 @@ mod cli_link_test;
 mod cli_mutate_test;
 mod cli_no_config_test;
 mod cli_query_test;
+mod cli_spinner_parity_test;
 mod cli_status_test;
 mod cli_template_test;
 mod cli_transition_gate_test;

--- a/tests/integration/reservation_test.rs
+++ b/tests/integration/reservation_test.rs
@@ -268,7 +268,7 @@ fn prune_deletes_refs_with_matching_documents() {
     fixture.write_rfc("RFC-042-some-title.md", "Some Title", "draft");
 
     let store = Store::load(fixture.root(), &config).unwrap();
-    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, false, false, |_| {})
+    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, false, false, None)
         .unwrap();
 
     assert!(
@@ -286,7 +286,7 @@ fn prune_flags_orphans_without_deleting() {
     seed_ref_on_bare(bare.path(), "RFC", 99);
 
     let store = Store::load(fixture.root(), &config).unwrap();
-    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, false, false, |_| {})
+    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, false, false, None)
         .unwrap();
 
     assert!(
@@ -305,7 +305,7 @@ fn prune_dry_run_does_not_delete() {
     fixture.write_rfc("RFC-042-some-title.md", "Some Title", "draft");
 
     let store = Store::load(fixture.root(), &config).unwrap();
-    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, true, false, |_| {})
+    lazyspec::cli::reservations::run_prune(fixture.root(), &config, &store, true, false, None)
         .unwrap();
 
     assert!(


### PR DESCRIPTION
## Why

`init` and `config add-type` were flag-only: setting up a project or adding a
type meant knowing every field name and value up front, with no guided path
and no feedback while an operation ran.

## What this enables

- `init` and `config add-type` now run as interactive TTY wizards (starter
  template, blank-slate DAG designer, type attributes/lifecycle/gates/parent
  relations, arrow-key select, colourised prompts), falling back to the
  existing flag/`--json` path on non-TTY.
- CLI operations (create/fetch/prune) and the wizards show a talking-face
  greeting and operation spinners via a shared `spinners`/`spinner` module,
  reused identically by the TUI header sync/push indicator and create overlay.
- TUI and CLI now share one `has_pollable_types` gate (moved into `tui.rs`)
  so the background poll and sync indicator agree for github-issues,
  github-milestones, and clickup-tasks projects alike, not just github-issues.

## Related

Implements RFC-062, RFC-063. Completes STORY-225, STORY-226, STORY-227,
STORY-228, STORY-229, STORY-231.
