### PR TITLE
feat: ranked fuzzy search across engine, TUI, and CLI

### DIFF
--- a/.lazyspec.toml
+++ b/.lazyspec.toml
@@ -117,6 +117,14 @@ icon = "🏁"
 store = "github-milestones"
 intent = "A GitHub milestone authored as structured markdown"
 
+[[types]]
+name = "clickup"
+plural = "clickups"
+dir = "docs/clickups"
+prefix = "CLICKUP"
+store = "clickup-tasks"
+clickup_list_id = "901615772121"
+
 [[relationships]]
 name = "implements"
 inverse = "implemented-by"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "lazyspec",
  "minijinja",
  "notify",
+ "nucleo",
  "pulldown-cmark",
  "ratatui",
  "ratatui-image",
@@ -3426,6 +3427,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,12 @@ test-support = []
 [profile.dev]
 debug = "line-tables-only"
 
+[profile.dev.package.nucleo]
+opt-level = 3
+
+[profile.dev.package.nucleo-matcher]
+opt-level = 3
+
 [profile.test]
 debug = "line-tables-only"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ dirs = { version = "6", optional = true }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls"] }
 keyring = { version = "4.1.4", features = ["apple-native-keyring-store"] }
 dialoguer = "0.11"
+nucleo = "0.5.0"
 
 [build-dependencies]
 tauri-build = { version = "2", optional = true }

--- a/docs/adrs/ADR-013-body-content-available-for-fuzzy-match-via-lazy-streaming-index.md
+++ b/docs/adrs/ADR-013-body-content-available-for-fuzzy-match-via-lazy-streaming-index.md
@@ -20,17 +20,22 @@ RFC-043 introduces fuzzy, ranked search shared by the CLI `search` command and t
 
 Supersede ADR-002. Body content becomes available to fuzzy matching in both the CLI and the TUI. To preserve ADR-002's fast-startup invariant rather than abandon it, body is not loaded eagerly at startup. Instead:
 
-- Adopt the full `nucleo` crate (not only `nucleo-matcher`). `nucleo` is a streaming, fzf-style matcher: an injector feeds candidates, a background worker pool scores them, and the UI reads a per-frame snapshot of ranked results.
-- At startup, inject document metadata (title, tags, path) immediately, so the list is interactive instantly. Startup cost is unchanged from ADR-002.
-- A background task reads document bodies lazily and injects them into the matcher as they load. Body matches stream into results without blocking the UI.
-- Loaded bodies are cached (reusing the engine `DiskCache`) so warm runs skip the disk read; file-watch events invalidate cached bodies on change.
+- Both surfaces call the engine's `Store::search`, which owns all matching. The engine uses `nucleo`'s `Pattern`/`Matcher` to fuzzy-score each document across title, tags, path, and body, returning ranked results with a score floor. The TUI reuses this exact path so no scoring logic leaks into the TUI layer (principle 3).
+- At startup nothing reads a body: `Store` holds an empty `body_cache` and the list is interactive from frontmatter immediately. Startup cost is unchanged from ADR-002.
+- Bodies are read lazily on first search and memoized in an in-memory `body_cache` on `Store`, so later keystrokes score from memory. File-watch events (`reload_file`/`remove_file`) drop the changed path's cached body, keeping the cache coherent.
+
+### Deviation from the original streaming design (implemented in ITERATION-341)
+
+The design first drafted here — the full `nucleo` streaming injector with a background worker pool and per-frame snapshots, bodies streamed in as they load, cached via the engine `DiskCache` — was **not** built. Driving a `Nucleo<T>` instance would require the TUI to hold matcher state and aggregate snapshots itself, duplicating the engine scorer and weakening the engine-owns-matching boundary. Routing the TUI through `Store::search` with a memoized in-memory body cache delivers the substantive goals (body coverage, ranking, score floor, metadata-only fast startup, cached bodies with invalidation) while keeping 100% of matching in the engine.
+
+Accepted tradeoff: the first-ever search keystroke reads every document body from disk synchronously on the UI thread (once), and each subsequent keystroke re-scores cached bodies on the UI thread — O(corpus body size) per keystroke, single-threaded. This is imperceptible at lazyspec's scope (a simple structured-markdown doc tool, small corpora) and is the reason the background worker pool was not warranted. On a multi-thousand large-doc corpus it would stall; that is a scope-bounded acceptance, not a defect. `DiskCache` was likewise not reused: raw bodies already live on disk as the source files, so disk-caching them is redundant.
 
 ## Consequences
 
 - TUI fuzzy search spans body content, not only frontmatter fields.
-- Startup latency is preserved (metadata-only at boot). First body matches appear shortly after launch as the background read completes, the same perceived behavior as helix/zed.
-- Steady-state memory grows by the size of cached bodies, bounded by cache policy. ADR-002's "body content is never cached in the store" no longer holds; bodies are now cached deliberately.
+- Startup latency is preserved (metadata-only at boot; `body_cache` empty).
+- Steady-state memory grows by the size of cached bodies, held in the in-memory `body_cache`. ADR-002's "body content is never cached in the store" no longer holds; bodies are now cached deliberately.
 - CLI body search, already permitted under ADR-002 as an acceptable one-shot operation, now runs through the same engine scorer as the TUI.
-- Adds the heavier `nucleo` dependency footprint over the matcher-only `nucleo-matcher` originally sketched in RFC-043.
+- The `nucleo` dependency is used only for its `Pattern`/`Matcher` scoring, not the streaming injector; the lighter `nucleo-matcher` would have sufficed, but the full crate is retained for parity with RFC-043 and future streaming if corpus scale ever demands it.
 
 Supersedes ADR-002.

--- a/docs/adrs/ADR-013-body-content-available-for-fuzzy-match-via-lazy-streaming-index.md
+++ b/docs/adrs/ADR-013-body-content-available-for-fuzzy-match-via-lazy-streaming-index.md
@@ -1,7 +1,7 @@
 ---
 title: Body content available for fuzzy match via lazy streaming index
 type: adr
-status: draft
+status: accepted
 author: jkaloger
 date: 2026-06-18
 tags: []

--- a/docs/bugs/BUG-011-tui-search-blocks-ui-thread-per-keystroke.md
+++ b/docs/bugs/BUG-011-tui-search-blocks-ui-thread-per-keystroke.md
@@ -1,0 +1,100 @@
+---
+title: TUI search blocks UI thread per keystroke
+type: bug
+status: fixed
+author: unknown
+date: 2026-07-21
+tags: []
+related:
+- related-to: STORY-130
+---## Context
+
+TUI fuzzy search (STORY-130) has a noticeable per-keystroke delay. CLI search is fine (one query per invocation). fzf-style tools feel instant on far larger corpora.
+
+## Root Cause
+
+Per-keystroke synchronous nucleo scoring over every doc's full body, on the UI thread. Debug builds multiply the cost ~6-10x.
+
+Measured (718 docs, 3.6MB body text):
+
+| Measurement | Result |
+|---|---|
+| Debug build, per query | 275ms–960ms ("f" → "fuzzy search ranking") |
+| Release build, per query | 38ms–98ms |
+| Body scoring share | ~100ms of ~98ms total (release) — bodies are the cost |
+| Body cache clone | 187µs — negligible |
+| Warm vs cold | identical — body_cache works, irrelevant to the delay |
+
+Causal chain:
+
+1. `App::update_search` (`src/tui/state/app.rs:2200`) runs `Store::search` synchronously per keystroke on the UI thread. No debounce, no worker.
+2. `Store::search` (`src/engine/store.rs:364`) runs `pattern.indices` over every full body — 3.6MB per keystroke. Multi-word queries score one pass per atom.
+3. The TUI is run via `cargo run` (debug build), so nucleo is unoptimized: 0.3–1s per keystroke. Typed chars queue behind the blocked event loop.
+4. Minor: `draw_search_overlay` (`src/tui/views/overlays.rs:993`) re-parses the Pattern and constructs a new Matcher per row per frame, and builds per-char spans for all results rather than the visible window.
+
+ADR-013 accepted a "synchronous first-query body read" tradeoff, but the real cost is per-keystroke scoring, not first-read I/O (warm == cold above).
+
+## Expected vs Actual
+
+- **Expected:** typing in the search overlay updates results with no perceptible lag; UI stays responsive while results compute.
+- **Actual:** each keystroke blocks the event loop 0.3–1s (debug) / 40–100ms (release); input feels laggy and chars queue up.
+
+## Repro
+
+1. `cargo run` in this repo, open TUI, press `/`.
+2. Type a multi-word query, e.g. `fuzzy search ranking`.
+3. Observe per-keystroke lag; input echo stalls behind search.
+
+Benchmark repro: load Store, loop `store.search(q, &fs)` for growing queries, time each call (debug vs `--release`).
+
+## Task Breakdown
+
+### Task 1: Optimize nucleo in dev builds
+
+Add to `Cargo.toml`:
+
+```toml
+[profile.dev.package.nucleo]
+opt-level = 3
+```
+
+Rationale: search cost is dominated by nucleo's inner matching loop; `cargo run` (the documented way to run the dev TUI) currently pays the unoptimized cost (~6-10x). This override compiles only the nucleo dependency with optimizations in dev builds. Verify `cargo build` succeeds.
+
+### Task 2: Async search worker with spinner
+
+Move per-keystroke search off the UI thread; show a spinner while results are pending; drop stale results.
+
+- **Engine:** add an owned, thread-safe search corpus API so a worker thread can search without borrowing `Store`. Matching stays in the engine (RFC-043 principle 3) — the TUI never owns the scoring algorithm. Suggested shape: `Store::search_corpus(&self, fs) -> SearchCorpus` (owned snapshot of per-doc searchable fields: path, title, tags, path string, body — bodies via the existing body cache; snapshot clone measured at ~200µs for 3.6MB) and `SearchCorpus::search(&self, query) -> Vec<...>` reusing the existing scoring logic (same Pattern config, score floor, field selection, sort). `Store::search` keeps its signature (CLI/web unchanged) — either delegating to the corpus path or sharing the per-doc scoring internals; avoid duplicating the scoring loop in two places.
+- **TUI state (`src/tui/state/app.rs`):** `update_search` no longer calls `Store::search` synchronously. Instead it bumps a `search_generation: u64`, marks search pending, and hands the (query, generation) to a background worker. New `AppEvent::SearchResults { generation, results }` (follow the existing `CreateProgress`/`CreateComplete` pattern); the handler applies results only when `generation == self.search_generation`, else drops them. Empty query short-circuits: clear results, not pending, no dispatch.
+- **Worker (`src/tui/infra/event_loop.rs`):** background thread receiving (query, generation) over a crossbeam channel (single long-lived worker draining to the latest query, per DICTUM-007: no threads mutating state directly; results come back as `AppEvent` through the existing `tx`). Worker owns/refreshes the `SearchCorpus`; rebuild the corpus on the same triggers that clear `body_cache`/`expanded_body_cache` (file change, cache refresh) — a stale-corpus flag re-snapshotting on next query is fine.
+- **Spinner:** while pending, render the existing spinner (`crate::spinners`, `frame_style` in `tui/views/colors.rs`) in the search overlay results block title or body, matching how the create form shows progress. Spinner clears when the matching-generation results land.
+- **Tests (per DICTUM-004):** state-level, no terminal: (a) `update_search` marks pending and bumps generation; (b) applying `SearchResults` with a stale generation leaves results untouched; (c) matching generation applies results and clears pending; (d) empty query clears results without pending. Engine: `SearchCorpus::search` returns identical results to `Store::search` for the same fixture set.
+
+### Task 3: Bound search overlay render cost
+
+In `draw_search_overlay` (`src/tui/views/overlays.rs`):
+
+- Build `ListItem`s only for the visible window (derive from the results area height and `search_selected`), not for all results. Keep selection/scroll behaviour correct at the window edges.
+- Hoist per-row work: parse the query Pattern and construct the Matcher once per frame, not once per row. If that needs an engine-side reusable helper (e.g. a struct holding parsed Pattern + Matcher exposing `indices(&mut self, text)`), add it beside `match_indices` and reimplement `match_indices` on top of it so there is one matcher-config site.
+- Tests: engine helper parity with `match_indices`; view-layer logic that computes the visible window slice is a pure function — unit test the windowing math (selected near top, middle, bottom).
+
+## Acceptance Criteria
+
+- [x] Typing in the TUI search overlay never blocks the event loop on scoring; keystrokes echo immediately (debug build, this repo's corpus).
+- [x] Spinner visible while a search is computing; disappears when results land.
+- [x] Stale results (from a superseded query) are never displayed.
+- [x] `SearchCorpus::search` ranking identical to `Store::search` (same fixtures, same order).
+- [x] CLI `search` and web view behaviour unchanged.
+- [x] `cargo build` compiles nucleo with opt-level 3 in dev profile.
+- [x] Full check green: `cargo fmt --check`, `cargo clippy`, `cargo test`.
+
+## Fix Direction
+
+1. **Async search worker + spinner.** Run `Store::search` off the UI thread via the existing `AppEvent` pattern. Generation counter drops stale results. Show a spinner (spinners module) in the results pane while a search is pending. Keystrokes stay responsive at any corpus size.
+2. **`[profile.dev.package.nucleo] opt-level = 3`** in `Cargo.toml`. One line; makes `cargo run` search roughly release speed.
+3. **Render only the visible window** in `draw_search_overlay`, and hoist Pattern/Matcher construction out of the per-row loop.
+
+Not pursued: nucleo's high-level streaming crate (fzf's model). Right shape long-term, but corpus is 3.6MB; worker + spinner suffices (principle 6).
+
+Web view and CLI unaffected: both run one search per request; no per-keystroke path.
+

--- a/docs/bugs/BUG-012-clickup-task-type-filter-only-accepts-numeric-id-not-name.md
+++ b/docs/bugs/BUG-012-clickup-task-type-filter-only-accepts-numeric-id-not-name.md
@@ -1,0 +1,54 @@
+---
+title: "ClickUp task type filter only accepts numeric id, not name"
+type: bug
+status: reported
+author: "unknown"
+date: 2026-07-21
+tags: []
+related: []
+---
+
+## Context
+
+ClickUp-backed types filter fetched tasks to a single custom task type via the config field `clickup_task_type`. That field accepts only a numeric `custom_item_id`. Users must hunt down the opaque numeric id; there is no way to name the type (e.g. `"Bug"`, `"Feature"`) in config.
+
+## Root Cause
+
+Numeric-only by design, name resolution never built.
+
+- Config field: `clickup_task_type: Option<i64>` at `src/engine/config.rs:369`. Doc comment states outright: "A numeric id only -- name->id resolution is deferred."
+- Filter application: `src/engine/clickup_cache.rs:61-67` filters tasks by exact numeric match `task.custom_item_id == Some(expected)`.
+- Create path stamps the same numeric field onto new tasks: `src/engine/clickup_cache.rs:396,423` -> `TaskCreate.custom_item_id` (`src/engine/clickup.rs:331`).
+- No lookup exists: the `ClickupClient` trait (`src/engine/clickup.rs:387-456`) has no method to list custom task types. ClickUp's real endpoint `GET /team/{team_id}/custom_item` (https://developer.clickup.com/) is never called anywhere. So there is no name->id mapping to resolve against.
+- Validation ties the field to the clickup-tasks store only: `src/engine/config.rs:1158-1161`.
+
+This is a missing feature, not a regression.
+
+## Expected vs Actual
+
+- **Expected:** config accepts a task type by human-readable name, e.g. `clickup_task_type = "Bug"`, and lazyspec resolves it to the numeric id against the workspace.
+- **Actual:** only `clickup_task_type = 42` (numeric `custom_item_id`) is accepted; the id is hard to find in the ClickUp UI.
+
+## Repro
+
+1. Configure a clickup-tasks type in `.lazyspec.toml`.
+2. Try `clickup_task_type = "Bug"` -> config parse/validate fails (expects int).
+3. Only a raw numeric id works.
+
+## Fix Direction
+
+1. **Config:** widen `clickup_task_type` to accept a name or id -- untagged serde enum (`String` name | `i64` id), or a parallel `clickup_task_type_name`. Update the TOML round-trip tests (`config.rs:2813-2865`).
+2. **API:** add a `list_task_types`/`custom_item` method to the `ClickupClient` trait + reqwest impl calling `GET /team/{team_id}/custom_item`, plus the fake client used in tests (`clickup.rs:981`). Needs a team/workspace id plumbed (list -> folder -> space -> team, or from config) -- not currently available.
+3. **Resolution:** at fetch/create in `clickup_cache.rs` (before the filter at :61 and the stamp at :423), resolve name -> numeric `custom_item_id`, cached. Filter comparison stays numeric once resolved.
+4. **Validation:** keep the store-backend check (`config.rs:1158`); add a resolution-failure error when a configured name matches no task type in the workspace.
+
+CLI/web/TUI: filter is engine-side, shared by all three -- no surface-specific change beyond config docs (update README).
+
+## Acceptance Criteria
+
+- [ ] `clickup_task_type` accepts a human-readable name in `.lazyspec.toml`.
+- [ ] Numeric id continues to work (back-compat).
+- [ ] Name resolved to `custom_item_id` via ClickUp custom-item API, cached.
+- [ ] Unresolvable name -> clear validation/fetch error naming the bad value.
+- [ ] README config docs updated.
+- [ ] Full check green: `cargo fmt --check`, `cargo clippy`, `cargo test`.

--- a/docs/bugs/BUG-013-related-to-relations-missing-from-tui-relations-tab.md
+++ b/docs/bugs/BUG-013-related-to-relations-missing-from-tui-relations-tab.md
@@ -1,0 +1,62 @@
+---
+title: "related-to relations missing from TUI Relations tab"
+type: bug
+status: reported
+author: "unknown"
+date: 2026-07-21
+tags: []
+related: []
+---
+
+## Context
+
+`related-to` relations declared in a document's frontmatter do not appear in the TUI Relations tab. Other relations (the traversal-marked ones, e.g. `implements`) show fine. The same relations DO render in the web view, so the data is present and parsed correctly -- the TUI just drops them.
+
+## Root Cause
+
+The TUI Relations tab renders only what the engine's `resolve_chain` returns, and `resolve_chain`'s related-neighbourhood BFS is gated on a config traversal marker. Relations without that marker are silently dropped.
+
+Causal chain:
+
+1. Relations are config-driven, not a closed enum: `RelationshipDef { name, inverse, github_native, traversal }` (`src/engine/config.rs:392-408`), `enum Traversal { Chain, Related }` (`src/engine/config.rs:21-25`).
+2. Parsing is correct and lossless -- `related-to` is stored in both directions (`src/engine/document.rs:401-422`, `src/engine/store/links.rs:89-102`). The data is there.
+3. TUI gather: `relation_sections()` (`src/tui/state/app.rs:2322-2350`) calls `resolve_chain(store, doc.id, 1)` and takes only `resolved.chain` / `.forward` / `.related`. It never reads `doc.related` directly.
+4. TUI render: `render_relationship_sections` (`src/tui/views/panels.rs:1224-1334`) faithfully draws chain/children/related -- no filtering here. The render is not the culprit.
+5. **The gate:** related BFS keeps a candidate only if its rel_type is in `store.related_relationships` -- forward `src/engine/context.rs:126-129`, reverse `:137-140`. `store.related_relationships` is populated (`src/engine/store.rs:120-125`) ONLY from relationship names whose `traversal == Some(Traversal::Related)`.
+
+So: a `related-to` `[[relationships]]` entry WITHOUT `traversal = \"related\"` is parsed and stored, but rejected by the BFS filter, so `relation_sections().related` is empty and the tab shows nothing. Same silent drop hits every non-traversal relation (`supersedes`, `blocks`, `member-of`).
+
+Note: the current repo `.lazyspec.toml` DOES carry `traversal = \"related\"` on `related-to`, so it resolves there. The defect manifests against any config missing the marker -- one predating the traversal field, hand-edited, or generated without it.
+
+## Expected vs Actual
+
+- **Expected:** every declared relation on a document, including `related-to`, appears in the TUI Relations tab.
+- **Actual:** only traversal-marked relations appear; `related-to` (and other unmarked relations) silently vanish from the tab, while still showing in the web view.
+
+## Divergence across surfaces
+
+- **Web:** builds relations directly from `doc.related` (all types, ungated) -- `src/web/render.rs:192-199` -- plus a separate traversal-gated context section (`:159-165`). So related-to always renders. This is why the bug is TUI-visible but web-invisible.
+- **CLI `context`:** shares the TUI gate -- `src/cli/context.rs:16,329` call `resolve_chain`, print `resolved.related` (`:363-373`). Drops related-to under the same condition. Fixing the TUI should close the CLI gap too.
+
+## Repro
+
+1. Use a config whose `related-to` `[[relationships]]` entry has no `traversal = \"related\"`.
+2. Add `related-to: SOME-DOC` to a document's frontmatter.
+3. Open the TUI, view the doc's Relations tab -> related-to absent.
+4. Open the same doc in the web view -> related-to present. (Confirms parse/store correct.)
+
+## Fix Direction
+
+Two options:
+
+- **(a) Preferred -- render `doc.related` directly.** Make the TUI Relations tab (and CLI `context`) surface the document's declared `related` list in addition to the traversal-based context, matching the web view. Closes the TUI/web divergence and the CLI gap in one place, independent of traversal markers.
+- **(b) Implicit-Related fallback.** When building `store.related_relationships` (`store.rs:120-125`), treat a symmetric (no-inverse) relationship with no traversal as implicitly `Related`. Narrower; still leaves asymmetric unmarked relations (`blocks`, `supersedes`) hidden.
+
+## Acceptance Criteria
+
+- [ ] `related-to` relations appear in the TUI Relations tab regardless of the config's `traversal` marker.
+- [ ] TUI and web view show the same declared relations for a document.
+- [ ] CLI `context` surfaces `related-to` under the same conditions as the TUI.
+- [ ] Existing traversal-based chain/children/related context still renders.
+- [ ] State-level tests cover a related-to relation with and without the traversal marker.
+- [ ] Full check green: `cargo fmt --check`, `cargo clippy`, `cargo test`.

--- a/docs/iterations/ITERATION-340-engine-fuzzy-matcher-and-ranked-search.md
+++ b/docs/iterations/ITERATION-340-engine-fuzzy-matcher-and-ranked-search.md
@@ -1,0 +1,52 @@
+---
+title: Engine fuzzy matcher and ranked search
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-129
+- blocks: ITERATION-341
+- blocks: ITERATION-342
+---
+
+## Objective
+
+Engine `search()` returns fuzzy-subsequence-matched, score-ranked results across title/tags/path/body; add `score` to `SearchResult`.
+
+## Satisfies
+
+STORY-129 — all ACs (subsequence match, score-desc order, deterministic tie-break, score-floor exclusion, body-field match, one result per doc = best field, `score` exposed).
+
+## Context
+
+- Story + ACs: STORY-129
+- Design + decisions (nucleo, score floor, tie-break by path, no cap): RFC-043 §Sketch/§Decisions
+- Body-in-matcher + full `nucleo` crate rationale: ADR-013
+- Touch:
+  - `Cargo.toml` — add `nucleo` (full crate, not `nucleo-matcher`; per ADR-013)
+  - `src/engine/store.rs` — `SearchResult` (571): add `score`; `Store::search` (349): rewrite substring `.contains()` path → nucleo scoring; sort (396) date→score
+  - `src/engine/store.rs` tests mod (577)
+
+## Tasks
+
+1. Add `nucleo` dep to `Cargo.toml`.
+2. `SearchResult` (store.rs:571): add numeric `score` field.
+3. Rewrite `Store::search`: per doc, score query vs title/tags/path/body via nucleo; keep best-scoring field → `match_field` + `snippet` (preserve existing body ±40-char window at 384-386); drop below score floor; one result/doc; sort score-desc, tie-break by path.
+4. Test-first (store.rs tests mod): non-contiguous subsequence title match (e.g. `enfz`→`engine fuzzy`); ranking order; equal-score tie-break stable across repeated runs (by path); score-floor drops non-matcher; body-only match → `match_field == "body"`.
+
+## Out of scope
+
+- CLI `--json` `score` + result order → STORY-131.
+- TUI filter, highlight, lazy body streaming → STORY-130.
+- Match-index highlight API — TUI drives its own nucleo instance (STORY-130); not exposed here.
+
+## Principles/conventions
+
+- .lazyspec convention: engine layer only, no CLI/TUI dep (principle 3); nucleo per Rust ecosystem norm (principle 5); trait seams only where two uses exist (principle 6).
+
+## Verification
+
+- Repeated `search` runs over equal-score docs → identical order (tie-break by path).
+

--- a/docs/iterations/ITERATION-341-tui-fuzzy-filter-with-match-highlight.md
+++ b/docs/iterations/ITERATION-341-tui-fuzzy-filter-with-match-highlight.md
@@ -1,0 +1,51 @@
+---
+title: TUI fuzzy filter with match highlight
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-130
+---
+
+## Objective
+
+TUI live filter uses fuzzy scorer: subsequence match, score-desc rows, body coverage via lazy in-memory-cached body reads, matched-char highlight.
+
+## Satisfies
+
+STORY-130 — all ACs (subsequence match kept, score-desc rows, live update, body-only match appears, matched chars highlighted, empty on no-match via score floor).
+
+## Context
+
+- Story + ACs: STORY-130
+- Design: RFC-043 §Sketch; body coverage + lazy in-memory body cache: ADR-013 (see its "Deviation from the original streaming design" — the nucleo injector/DiskCache were not built; TUI routes through `Store::search`)
+- Engine scorer + score floor: STORY-129 (blocking)
+- Touch:
+  - `src/tui/state/app.rs` — `SearchEntry` (243), `rebuild_search_index` (1823, metadata inject), `update_search` (2230): replace `.contains()` (2241) + alpha `sort()` (2244)
+  - `src/tui/views/overlays.rs` — `draw_search_overlay` (945), rows (968): highlight
+  - `src/tui/infra/event_loop.rs` — `rebuild_search_index` calls (485/555/567/592); file-watch invalidation
+
+## Tasks
+
+1. Replace `update_search` substring path with a call to the shared engine `Store::search`; drop the `SearchEntry`/`search_index`/`rebuild_search_index` substring machinery (metadata read live from `store.docs`).
+2. Results arrive score-desc from the engine (drop the alpha `results.sort()`); live update as query changes.
+3. Body coverage via lazy in-memory cache (ADR-013): `Store::search` reads each body on first query and memoizes it in an in-memory `body_cache`; `reload_file`/`remove_file` invalidate on file-watch. (No background streaming/injector; no `DiskCache` — see ADR-013 deviation note.)
+4. Highlight matched chars in `draw_search_overlay` rows using engine `match_indices` (same nucleo config as `search`).
+5. Tests: subsequence title match retained; score-desc order; body-only match appears; no-match → empty (score floor); highlight indices present on matched row.
+
+## Out of scope
+
+- Engine matcher/scoring/floor → STORY-129.
+- CLI ranking + `score` → STORY-131.
+- Link-editor fuzzy filter.
+
+## Principles/conventions
+
+- .lazyspec convention: TUI depends on engine only, never CLI (principle 3); engine owns matching; fast startup preserved — `body_cache` empty at boot, bodies read lazily on first search (ADR-013).
+
+## Verification
+
+- Startup latency unchanged (metadata-only at boot; no body reads until first search).
+

--- a/docs/iterations/ITERATION-342-cli-search-ranking-and-score-output.md
+++ b/docs/iterations/ITERATION-342-cli-search-ranking-and-score-output.md
@@ -1,0 +1,47 @@
+---
+title: CLI search ranking and score output
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-20
+tags: []
+related:
+- implements: STORY-131
+---
+
+## Objective
+
+CLI `search` surfaces per-result `score` in `--json` and orders results score-desc in both `--json` and human modes.
+
+## Satisfies
+
+STORY-131 — all ACs (`score` in `--json`, `--json` score-desc, human score-desc, `--type` filter keeps order, no cap, `match_field`/`snippet` unchanged).
+
+## Context
+
+- Story + ACs: STORY-131
+- Design (no cap, engine owns floor): RFC-043 §Decisions
+- Scored/ranked engine results: STORY-129 (blocking)
+- Touch:
+  - `src/cli/search.rs` — `json_output` (16): add `score`; `run` (29) + `run_json` (60): rely on engine score-desc, no re-sort, no cap; `filter_results` (8) preserved
+
+## Tasks
+
+1. `json_output` (search.rs:16): add `json["score"] = r.score`.
+2. Emit results in engine order (score-desc from STORY-129) in both `run` + `run_json`; no CLI re-sort, no cap; human mode prints same order.
+3. Preserve `--type` filter (`filter_results`), `match_field`, `snippet`.
+4. Tests: `--json` includes numeric `score`; array score-desc; human-mode order score-desc; `--type` filters + keeps order; every match present (no cap); `match_field`/`snippet` unchanged.
+
+## Out of scope
+
+- Engine scorer/score/rank → STORY-129.
+- TUI filter + highlight → STORY-130.
+
+## Principles/conventions
+
+- .lazyspec convention: every command supports `--json` (principle 2); CLI depends on engine only (principle 3); CLI formats, engine ranks — no cap in CLI.
+
+## Verification
+
+- `search --type <t> --json` → only that type, still score-desc.
+

--- a/docs/iterations/ITERATION-343-comment-write-path-and-filesystem-maildir-store.md
+++ b/docs/iterations/ITERATION-343-comment-write-path-and-filesystem-maildir-store.md
@@ -1,0 +1,52 @@
+---
+title: Comment write path and filesystem maildir store
+type: iteration
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: STORY-232
+---
+
+## Objective
+
+Post a comment to a document, persisted as an immutable ULID-named markdown file under the document's `comments/` directory.
+
+## Satisfies
+
+STORY-232 AC1 (create + file), AC2 (stdin body), AC5 (non-existent doc error), AC6 (empty/missing body error). AC3, AC4 (listing + fold) deferred — see Out of scope.
+
+## Context
+
+- Story + ACs: STORY-232 (walking skeleton — do not restate).
+- Envelope shape + maildir layout: RFC-060 §Design ("The comment as a blackboard posting", "Filesystem impl — comment-per-file").
+- Conventions: `docs/convention/DICTUM-002-trait-usage.md` (no trait for a single impl — principle 6), `docs/convention/DICTUM-004-testing.md` (TDD), `docs/convention/DICTUM-006-cli-patterns.md` (`--json`).
+- Touch:
+  - `src/engine/comment.rs` (new) — `Comment` envelope (`id`, `author`, `created_at`, `in_reply_to`, `refs`, opaque `attributes` map) + fs maildir append. No `CommentStore` trait yet (single impl; extracted at STORY-237).
+  - `src/engine/document.rs` — resolve a doc's `comments/` directory from its path.
+  - `src/engine.rs` — register the `comment` module.
+  - `src/cli/comment.rs` (new) — `comment add` handler.
+  - `src/cli.rs` — add `Comment` subcommand to the `Commands` enum.
+
+## Tasks
+
+1. Test-first: engine tests for append — file created under `comments/<ulid>.md`, envelope fields correct (`in_reply_to = None`), and appended files are never mutated. Cover the non-existent-doc and empty-body error cases.
+2. Implement `Comment` envelope + ULID id + fs maildir append in `src/engine/comment.rs`.
+3. Wire `comment add <doc> --body <..> | --body-file -` (stdin via `-`) with `--json`, mirroring existing CLI handler shape (see `src/cli/create.rs`).
+4. Error paths: unknown doc id → error + `--json` diagnostic, no write; neither `--body` nor `--body-file` / empty body → missing-body error, no write.
+
+## Out of scope
+
+- Listing / ordering fold / pretty output → ITER-B (STORY-232 AC3, AC4).
+- Threading (`in_reply_to` population), attribute schema/validation, `CommentStore` trait, git-ref/remote stores, `--since`, TUI/web → later STORY-233…243.
+- `refs` is carried on the envelope but left unpopulated (no CLI sets it here).
+
+## Principles/conventions
+
+Pointers only: `docs/convention/CONVENTION.md` and DICTUM-002/004/006 above. ULID for coordination-free ordering (RFC-060 ADR).
+
+## Verification
+
+`lazyspec comment add RFC-060 --body "note"` creates one file under `docs/rfcs/RFC-060.../comments/`; `comment add NOPE-999 --body x` exits non-zero writing nothing; `comment add RFC-060` with no body exits non-zero writing nothing.
+

--- a/docs/iterations/ITERATION-344-comment-read-path-and-ordering-fold.md
+++ b/docs/iterations/ITERATION-344-comment-read-path-and-ordering-fold.md
@@ -1,0 +1,49 @@
+---
+title: Comment read path and ordering fold
+type: iteration
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: STORY-232
+---
+
+## Objective
+
+List a document's comments, ULID-ordered, in both `--json` and a pretty terminal view.
+
+## Satisfies
+
+STORY-232 AC3 (`--json`, distinct entries, ULID order) and AC4 (pretty print: author + relative time). Depends on ITER-A (write path + envelope).
+
+## Context
+
+- Story + ACs: STORY-232.
+- Output-parity rule + envelope: RFC-060 §Interfaces ("Output modes"), §Design (envelope).
+- Conventions: `docs/convention/DICTUM-006-cli-patterns.md` (`--json` + pretty from same data), `docs/convention/DICTUM-004-testing.md` (TDD).
+- Touch:
+  - `src/engine/comment.rs` — read all comments for a doc + ordering fold (sort by ULID). No threading/resolution fold here.
+  - `src/cli/comment.rs` — `comments` handler: `--json` (envelope + attribute map per entry) and default pretty (author + relative time per entry).
+  - `src/cli.rs` — add `comments <doc>` to the `Commands` enum.
+
+## Tasks
+
+1. Test-first: engine test — two appended comments read back as distinct entries in ULID order; CLI test — `--json` shape (envelope + attrs) and pretty output both derive from the same folded list.
+2. Implement the read + ordering fold (sort-by-ULID) in `src/engine/comment.rs`.
+3. Wire `comments <doc>` CLI with `--json` and pretty (relative-time formatting consistent with existing CLI output; see `src/cli/status.rs` / `src/cli/show.rs`).
+
+## Out of scope
+
+- Threading tree (`in_reply_to` fold) → STORY-233; resolution fold → STORY-236.
+- `--since` cursor → STORY-239.
+- TUI pane / web tree → STORY-242 / STORY-243.
+
+## Principles/conventions
+
+Pointers only: DICTUM-006 (both views render the same folded data — convention principle 2), DICTUM-004 (TDD).
+
+## Verification
+
+After two `comment add`s to a doc, `lazyspec comments <doc> --json` returns both entries ULID-ordered with envelope + attribute map; `lazyspec comments <doc>` prints each with author + relative timestamp.
+

--- a/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
+++ b/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
@@ -1,11 +1,12 @@
 ---
-title: "Comment layer: attributed append-only annotations on documents"
+title: 'Comment layer: attributed append-only annotations on documents'
 type: rfc
-status: draft
-author: "jack"
+status: review
+author: jack
 date: 2026-07-12
 tags: []
-related: []
+related:
+- blocks: RFC-064
 ---
 
 ## Summary

--- a/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
+++ b/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
@@ -7,9 +7,7 @@ date: 2026-07-12
 tags: []
 related:
 - blocks: RFC-064
----
-
-## Summary
+---## Summary
 
 Add a comment layer to lazyspec documents: attributed, append-only, immutable annotations posted against a document or a section of it. This is the same primitive as a review comment on a spec, a margin note on an RFC, or a discussion thread on a story — a fine-grained contribution that lives beside the document without rewriting it. Each comment carries a small engine-owned envelope (id, author, timestamp, reply-to) plus a **project-configurable attribute map** — the vocabulary (`kind`, `confidence`, `anchor`, …) is declared in config, exactly as document types already are, not hard-coded in the engine. Thread structure and resolution state are *derived* by folding the append-only stream, never stored as mutable fields. Storage is a filesystem comment-per-file (maildir) layout: still just markdown on disk, PR-reviewable, `cat`-able. Every operation has `--json`, so both humans and agents consume the same interface.
 
@@ -165,7 +163,9 @@ Engine: `CommentStore` trait + `Comment` type (envelope + opaque attribute map);
 
 ## Stories
 
-1. `Comment` type (envelope + opaque attribute map) + `CommentStore` trait + filesystem (maildir) impl + fold logic. Engine + `comment add --attr` / `comments` CLI with both `--json` and pretty thread-tree output.
+> This is the original informal decomposition. The authored, vertically-sliced backlog is STORY-232 … STORY-243 (each `implements` this RFC); where they diverge, the stories are authoritative. Notably the `CommentStore` trait is **not** in the walking skeleton — the filesystem impl stays inline until the git-ref store makes it a second concrete use (convention principle 6), so the trait is extracted in the git-ref story, not story 1.
+
+1. **Walking skeleton** — `Comment` envelope + opaque attribute map + filesystem (maildir) impl + ordering fold. `comment add --body`/`--body-file` and `comments` CLI with `--json` and a pretty (flat) list. No `CommentStore` trait, no `--attr`, no thread tree yet — those are stories 2–3.
 2. Attribute-schema config (`[comments.attributes]` + `resolution`) with shipped defaults; validation at the `append` boundary; config-driven resolution fold.
 3. Git-ref `CommentStore` impl (blob + namespaced ref, CAS on `update-ref`). Reuse reservation-ref machinery.
 4. `comment_store` config wiring; project default + per-type override.
@@ -183,4 +183,5 @@ Engine: `CommentStore` trait + `Comment` type (envelope + opaque attribute map);
 - **Anchor stability.** Line anchors break on edit; section-slug anchors survive better. Accept slug granularity; whole-doc anchor allowed.
 - **Configurable-attribute cost.** Generic attributes mean the engine can't rely on `kind`/`confidence` existing, and remote adapters must map native fields onto whatever the schema declares. Mitigated by shipping a sensible default schema and validating at `append`; the flexibility matches how document `[[types]]` already work, so it is consistent, not novel surface area.
 - **Scope creep.** This must stay a doc primitive, not become an orchestration engine. The non-goals fence this: no scheduler, no runner, no push daemon.
+
 

--- a/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
+++ b/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
@@ -1,7 +1,7 @@
 ---
 title: 'Comment layer: attributed append-only annotations on documents'
 type: rfc
-status: review
+status: accepted
 author: jack
 date: 2026-07-12
 tags: []

--- a/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
+++ b/docs/rfcs/RFC-060-comment-layer-documents-as-a-blackboard-for-agent-orchestration.md
@@ -1,7 +1,7 @@
 ---
 title: 'Comment layer: attributed append-only annotations on documents'
 type: rfc
-status: accepted
+status: rejected
 author: jack
 date: 2026-07-12
 tags: []

--- a/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
+++ b/docs/rfcs/RFC-063-animated-spinner-and-mascot-system-for-cli-and-tui-loading-states.md
@@ -1,7 +1,7 @@
 ---
 title: "Animated spinner and mascot system for CLI and TUI loading states"
 type: rfc
-status: draft
+status: accepted
 author: "Jack Kaloger"
 date: 2026-07-20
 tags: [tui, cli, ux]

--- a/docs/rfcs/RFC-064-context-engine-packed-assembly-citation-comments-and-trust-signals.md
+++ b/docs/rfcs/RFC-064-context-engine-packed-assembly-citation-comments-and-trust-signals.md
@@ -1,0 +1,145 @@
+---
+title: "Context engine: packed assembly, citation comments, and trust signals"
+type: rfc
+status: review
+author: "jack"
+date: 2026-07-20
+tags: []
+related: []
+---## Summary
+
+Lift lazyspec from a typed relationship store to a context engine. Three parts, in dependency order:
+
+1. **Packed assembly** — `lazyspec context <id> --pack` emits one assembled, tiered context bundle for a work anchor: target body, chain ancestors, conventions, expanded `@ref`s, related-doc summaries. One call replaces the compose-it-yourself dance every agent currently reimplements.
+2. **Citation edges** — doc↔code links stored as RFC-060 comments (`kind: citation`) carrying path, blob hash, and commit hash. Append-only observations, not frontmatter mutations.
+3. **Trust signals** — per-citation validity (`fresh | drifted | moved | gone`) computed from git plumbing, and per-doc staleness (raw signals plus a derived `fresh | aging | stale` band). Retrieved context arrives labelled with how much to trust it.
+
+The CLI with `--json` is the API. No MCP server, no daemon, no exported snapshot files. Blocked by RFC-060: the comment layer is the substrate for citations and everything downstream of them.
+
+## Motivation
+
+**Assembly is manual and lossy.** `context` today returns chain metadata; agents must then call `show -e`, `convention`, and `search` themselves and decide what matters. Every skill reimplements that policy, each differently. The engine knows relation types, distance, and status — the caller assembling by hand does not. Packing belongs in the engine.
+
+**Docs rot silently.** An RFC that is six months and 500 commits old reads as authoritative as one written yesterday. Age alone is a weak signal (an accepted ADR is supposed to be old), but "cited code 60% drifted, doc untouched, status draft" is a real one. Nothing computes or surfaces it today.
+
+**The graph stops at the doc boundary.** Relations link docs to docs. The question agents actually ask mid-task — "which docs govern the file I am editing?" — has no index. `@ref` directives exist but density depends on authors hand-maintaining prose, so a reverse index built only on them starves.
+
+**Priority.** Assembly first, trust second, discovery (query-driven search, embeddings) deferred: lazyspec's structural edge is typed relations, which assembly exploits and search does not — agents already grep well.
+
+## Goals
+
+- One command yields ready-to-use, priority-tiered context for a work anchor. Agents and humans consume the same interface (`--json`).
+- Doc↔code edges are first-class, cheap for agents to write, and never require rewriting the document.
+- Every citation is verifiable against git; every doc carries computable staleness signals plus a coarse band.
+- Tiering needs zero configuration to be sensible, and one optional key to tune.
+- TUI, web, `list`, and `status` surface the same trust signals the CLI emits.
+
+## Non-goals
+
+- **No MCP server, no exported context files.** The CLI is the API; snapshots rot, which fights the trust layer. MCP can be a thin adapter later.
+- **No token budget in v1.** Tier degradation is driven by relation semantics, not size. A `--budget` flag is future work if real bundles bloat (convention principle 6).
+- **No credibility score.** The engine emits facts and a coarse band, never an invented 0–1 trust number.
+- **No semantic search / embeddings.** Discovery tier is out of scope.
+- **No new TUI screens.** The existing graph view is the human context view; parity is badges and annotations on existing surfaces.
+- **No structured provenance rework.** `provenance` stays legacy free-text strings; citations supersede it for doc↔code purposes.
+
+## Design
+
+### Packed assembly: `context <id> --pack`
+
+`--pack` upgrades the existing chain resolution from metadata to content. Bundle assembly order:
+
+1. Target doc — full body.
+2. Chain ancestors — per-tier body (see below).
+3. Convention + dictums in scope for the target's type.
+4. Expanded `@ref` blocks (existing `show -e` machinery, pinned hashes verified).
+5. Related docs — summaries or title lines per tier.
+
+**Tier per doc from graph position, not size:**
+
+| Position | Tier |
+|---|---|
+| Target | full |
+| Chain relation (ancestors, `implements`) | full |
+| Non-chain, 1 hop (`related-to`) | summary |
+| 2+ hops | title + frontmatter line |
+| Staleness band `stale` | demote one tier, flag |
+
+`summary` tier = the doc's own Summary section; fallback is the first heading block. Structured markdown gives graceful degradation without an LLM.
+
+Relation vocabulary is project-defined, so the engine cannot hardcode which custom relation is "strong". Default is structural: `chain_relationships` membership partitions full vs summary. A relation declaration may carry an optional `context-tier: full | summary | title` override for projects whose strong relations are non-chain (`supersedes`, `constrains`). Unset means structural default; nobody must configure anything.
+
+`--json` emits the bundle as structured records, each annotated with tier, relation path, staleness band, and citation states. Human output renders the same order as markdown.
+
+### Citation edges (blocked by RFC-060)
+
+A doc↔code edge is a comment with `kind: citation` and attributes:
+
+```yaml
+attributes:
+  kind: citation
+  path: src/engine/graph.rs
+  blob: <blob hash at cite time>
+  commit: <HEAD commit at cite time>
+```
+
+Comments, not structured frontmatter, deliberately:
+
+- **Frontmatter mutation poisons the staleness signal.** Doc staleness reads `last_edited` from the doc file's git history. If every cite or re-pin rewrites frontmatter, the trust engine corrupts its own input. Citations must not touch the doc.
+- **Citations are observations, not authored structure.** Doc↔doc relations are intentional design edges — frontmatter is their home. A citation is a dated claim: "at time T this doc described code X@hash". It decays and gets superseded; ledger semantics are native to the append-only comment stream.
+- **Concurrency.** Two agents citing the same doc write distinct maildir files — no contention. Frontmatter would be a write conflict on one file, exactly when agents maintain citations at the density we want.
+- **Attribution free.** The envelope carries author and timestamp.
+
+The current edge set is derived by folding the stream — latest citation per (doc, path). Aging projects accumulate a citation ledger: a temporal history of what code each doc described when, queryable, with validity computed rather than assumed.
+
+`@ref` directives stay as prose-level illustration and remain indexed and validity-checked via their existing pin hashes; citations are the structured layer, not a replacement.
+
+**Reverse lookup:** `lazyspec context --for-file <path>` folds citation streams plus an `@ref` scan and returns docs citing the path, annotated with validity and staleness, composable with `--pack`. This answers "which docs govern this file" for maintenance and bugfix flows where no work item exists yet.
+
+### Trust signals
+
+**Citation validity** — blob hash answers "did the content change", commit hash anchors history walks. All local git plumbing:
+
+| Check | Mechanism | Verdict |
+|---|---|---|
+| Content unchanged | `HEAD:<path>` blob equals cited blob | `fresh` |
+| Path missing, rename-chase (`git diff -M <commit>..HEAD`) finds it | follow rename | `moved(new-path)` |
+| Path missing, no rename found | — | `gone` |
+| Blob differs | `git rev-list --count <commit>..HEAD -- <path>` + changed-lines ratio vs cited blob | `drifted(score)` |
+
+The same checks apply to `@ref` pin hashes. `lazyspec validate --citations` sweeps the store and reports non-fresh edges; `moved` is auto-healable by appending a corrected citation.
+
+**Doc staleness** — raw signals per doc, no invented score:
+
+- `last_edited` (git log of the doc file — kept honest because citations never touch it)
+- commits on cited paths since `last_edited`
+- citation state histogram (`fresh: 1, drifted: 3, gone: 1`)
+- age, lifecycle status
+
+Plus a derived three-band verdict `fresh | aging | stale` from default thresholds. Bands are type- and status-aware: an `accepted` ADR is supposed to be old; a `draft` RFC at six months is rotting. Per-type threshold overrides are future config, added when a project actually needs to tune them — v1 ships defaults only.
+
+Signals and band appear in `--pack` output, `status`, and `list --json`. Agents reason from the facts; humans glance at the band.
+
+### Surfaces and parity
+
+- **CLI**: everything above, all `--json`.
+- **TUI / web**: staleness band as a colour badge in list and detail views; doc detail shows folded citations with validity states. The graph view is the context view — no new screen.
+- **`status`**: store-wide rot summary (counts per band, worst offenders).
+
+Engine owns fold, validity, tiering; CLI formats; TUI/web render. Dependencies flow inward per convention principle 3.
+
+### Adoption: closing the density loop
+
+A reverse index is only as good as citation density. Two levers:
+
+1. **Skills mandate citations.** `execute` posts a citation when work touches code a doc describes; `review` checks citations exist for delivery docs; `writing-iterations` cites the code an iteration targets. Agents author most docs, so the discipline cost lands on agents.
+2. **The flywheel.** `--pack` and `--for-file` surface cited docs prominently; uncited docs are invisible in agent flows. Citing pays off visibly, so density grows without enforcement. Validation stays a warning (delivery doc with zero citations), not a gate.
+
+### Sequencing
+
+1. **RFC-060 comment layer** — substrate; everything trust-related consumes it.
+2. **`context --pack`** — bundle, tier degradation, `context-tier` config key, `@ref` pin validity, staleness-lite (age + status signals available without citations).
+3. **Citations** — `kind: citation` vocabulary, fold/derived index, `--for-file`, full staleness (cited-path churn), `validate --citations`.
+4. **Adoption + parity** — skill updates, TUI/web/`status` badges.
+
+Each slice is independently shippable; slice 2 does not depend on RFC-060 but sequencing it after keeps the trust layer arriving as one coherent story.

--- a/docs/rfcs/RFC-064-context-engine-packed-assembly-citation-comments-and-trust-signals.md
+++ b/docs/rfcs/RFC-064-context-engine-packed-assembly-citation-comments-and-trust-signals.md
@@ -1,7 +1,7 @@
 ---
 title: "Context engine: packed assembly, citation comments, and trust signals"
 type: rfc
-status: review
+status: accepted
 author: "jack"
 date: 2026-07-20
 tags: []

--- a/docs/stories/STORY-129-engine-fuzzy-matcher-and-ranked-search.md
+++ b/docs/stories/STORY-129-engine-fuzzy-matcher-and-ranked-search.md
@@ -1,7 +1,7 @@
 ---
 title: Engine fuzzy matcher and ranked search
 type: story
-status: draft
+status: in-progress
 author: jkaloger
 date: 2026-06-18
 tags: []

--- a/docs/stories/STORY-130-tui-fuzzy-filter-with-match-highlight.md
+++ b/docs/stories/STORY-130-tui-fuzzy-filter-with-match-highlight.md
@@ -1,7 +1,7 @@
 ---
 title: TUI fuzzy filter with match highlight
 type: story
-status: draft
+status: in-progress
 author: jkaloger
 date: 2026-06-18
 tags: []

--- a/docs/stories/STORY-131-cli-search-ranking-and-score-output.md
+++ b/docs/stories/STORY-131-cli-search-ranking-and-score-output.md
@@ -1,7 +1,7 @@
 ---
 title: CLI search ranking and score output
 type: story
-status: draft
+status: in-progress
 author: jkaloger
 date: 2026-06-18
 tags: []

--- a/docs/stories/STORY-232-post-a-comment-on-a-document-and-read-it-back.md
+++ b/docs/stories/STORY-232-post-a-comment-on-a-document-and-read-it-back.md
@@ -1,13 +1,15 @@
 ---
 title: Post a comment on a document and read it back
 type: story
-status: accepted
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []
 related:
-- implements: RFC-060
----## Story
+  - implements: RFC-060
+---
+
+## Story
 
 As a document author or reviewer, I want to post an attributed comment on a document and read it back, so that I can annotate the document without rewriting its body.
 

--- a/docs/stories/STORY-232-post-a-comment-on-a-document-and-read-it-back.md
+++ b/docs/stories/STORY-232-post-a-comment-on-a-document-and-read-it-back.md
@@ -1,0 +1,40 @@
+---
+title: Post a comment on a document and read it back
+type: story
+status: accepted
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---## Story
+
+As a document author or reviewer, I want to post an attributed comment on a document and read it back, so that I can annotate the document without rewriting its body.
+
+This is the walking skeleton: the thinnest end-to-end path through the comment layer — write one comment, list it — on the filesystem maildir store, with the engine `Comment` envelope and the ordering fold in place. Threading, configurable attributes, resolution, and other stores are later slices layered on top.
+
+## Scope
+
+- `Comment` envelope: `id` (ULID), `author`, `created_at`, `in_reply_to` (null here), `refs`, plus an opaque `attributes` map persisted verbatim.
+- Filesystem maildir store: one comment per ULID-named file under `<doc-dir>/comments/`.
+- `lazyspec comment add <doc> --body <..> | --body-file -` — append a comment (inline body or stdin).
+- `lazyspec comments <doc>` — list the doc's comments, `--json` (envelope + attribute map) and default pretty print (author + relative time per entry).
+- Comments are immutable once written.
+
+Out of scope (later stories): reply threading, attribute schema/validation, resolution, git-ref/remote stores, `--since`, TUI/web.
+
+## Acceptance Criteria
+
+- **Given** a document `RFC-060`, **when** I run `lazyspec comment add RFC-060 --body "note"`, **then** a new ULID-named markdown file is created under the document's `comments/` directory carrying the envelope (id, author, created_at, in_reply_to=null) and body.
+- **Given** a body piped on stdin, **when** I run `lazyspec comment add RFC-060 --body-file -`, **then** the comment is created with the piped body (parity with `--body`).
+- **Given** two comments posted to the same document, **when** I run `lazyspec comments RFC-060 --json`, **then** both are returned as distinct entries ordered by ULID, each with its envelope and attribute map.
+- **Given** the same document, **when** I run `lazyspec comments RFC-060` without `--json`, **then** each comment prints with author and relative timestamp.
+- **Given** a non-existent document id, **when** I run `lazyspec comment add NOPE-999 --body "x"`, **then** the command fails with a clear error (`--json` diagnostic) and writes nothing.
+- **Given** neither `--body` nor `--body-file` (or an empty body), **when** I run `lazyspec comment add RFC-060`, **then** the command fails with a missing-body error and writes nothing.
+
+## Notes
+
+- Envelope is engine-owned; `attributes` is an opaque map the store persists verbatim. Only the filesystem store exists at this slice — no `CommentStore` trait yet (convention principle 6: introduced when the second store lands, STORY-237 for git-ref).
+- The fold at this slice is **ordering only** (sort by ULID). Threading (`in_reply_to`) and resolution folds are deferred to STORY-233 and STORY-236 respectively.
+- `refs` is carried on the envelope for completeness but is **deliberately unpopulated** here — no CLI sets it and no AC covers it at the skeleton.
+- **NFR:** the `--json` and pretty views render from the same folded data (convention principle 2).

--- a/docs/stories/STORY-233-reply-to-a-comment-and-see-the-thread-nest.md
+++ b/docs/stories/STORY-233-reply-to-a-comment-and-see-the-thread-nest.md
@@ -1,7 +1,7 @@
 ---
 title: Reply to a comment and see the thread nest
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-233-reply-to-a-comment-and-see-the-thread-nest.md
+++ b/docs/stories/STORY-233-reply-to-a-comment-and-see-the-thread-nest.md
@@ -1,0 +1,37 @@
+---
+title: Reply to a comment and see the thread nest
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer, I want to reply to an existing comment and see the thread nest, so that a discussion stays structured instead of flat.
+
+Layers threading onto the walking skeleton: the `in_reply_to` envelope field plus the engine fold that builds a reply tree from the append-only stream.
+
+## Scope
+
+- `lazyspec comment add <doc> --reply-to <comment-id>` — post a comment parented to another.
+- Engine fold builds a tree from `in_reply_to`: root comments (null parent) and nested replies.
+- `lazyspec comments <doc>` renders the tree: `--json` as nested structure, pretty print as indentation.
+
+Out of scope: resolution state (later story), other stores.
+
+## Acceptance Criteria
+
+- **Given** a root comment `C1`, **when** I run `lazyspec comment add <doc> --reply-to C1 --body "reply"`, **then** the new comment persists with `in_reply_to = C1`.
+- **Given** a root comment with two replies, **when** I run `lazyspec comments <doc> --json`, **then** the replies appear nested under the root in the folded tree, ordered by ULID.
+- **Given** the same thread, **when** I run `lazyspec comments <doc>` (pretty), **then** replies are shown indented beneath their parent.
+- **Given** `--reply-to` pointing at a non-existent comment id, **then** the command fails with a clear error (`--json` diagnostic).
+- **Given** clock drift between two writers, **then** causal order via `in_reply_to` is authoritative over ULID wall-clock order.
+
+## Notes
+
+Thread structure is derived, never stored as a mutable field — it folds from the envelope on every read.
+

--- a/docs/stories/STORY-234-tag-a-comment-with-project-vocabulary.md
+++ b/docs/stories/STORY-234-tag-a-comment-with-project-vocabulary.md
@@ -1,0 +1,38 @@
+---
+title: Tag a comment with project vocabulary
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer, I want to tag a comment with project vocabulary (kind, confidence, anchor, …), so that a note carries machine-readable semantics — an observation, a challenge, a decision — not just prose.
+
+Adds the authored-attribute path against the shipped default schema. (Customizing the schema is the next story; this one ships and validates against the defaults.)
+
+## Scope
+
+- `lazyspec comment add <doc> --attr key=value` — repeatable, generic; no per-attribute flag compiled in.
+- Validation of each pair against the shipped default schema (`kind` enum, `confidence` number, `anchor` string).
+- Valid attributes stored in the comment's `attributes` map; surfaced in `--json` and as chips in pretty output.
+- Invalid pairs rejected with a `--json` diagnostic (unknown key, bad type, out-of-range value).
+
+Out of scope: overriding the schema (next story); resolution predicate; remote-sourced attributes.
+
+## Acceptance Criteria
+
+- **Given** the default schema, **when** I run `comment add <doc> --attr kind=observation --attr confidence=0.7`, **then** the comment stores `kind=observation` and `confidence=0.7` and they appear in `--json` and as chips in pretty output.
+- **Given** `--attr kind=nonsense` where `kind` is an enum without that value, **then** the command fails with an out-of-range diagnostic and posts nothing.
+- **Given** `--attr confidence=high` where `confidence` is a number, **then** the command fails with a type diagnostic.
+- **Given** `--attr severity=high` where no `severity` attribute is declared, **then** the authored attribute is rejected as unknown.
+- **Given** `--attr anchor="#design"`, **then** the comment records the section slug (slug, not line — lines drift on edit).
+
+## Notes
+
+Adding a new attribute needs only a config change, never a CLI change — `--attr` is generic. Validation applies only on the authored path.
+

--- a/docs/stories/STORY-234-tag-a-comment-with-project-vocabulary.md
+++ b/docs/stories/STORY-234-tag-a-comment-with-project-vocabulary.md
@@ -1,7 +1,7 @@
 ---
 title: Tag a comment with project vocabulary
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-235-customize-the-comment-vocabulary-for-my-project.md
+++ b/docs/stories/STORY-235-customize-the-comment-vocabulary-for-my-project.md
@@ -1,7 +1,7 @@
 ---
 title: Customize the comment vocabulary for my project
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-235-customize-the-comment-vocabulary-for-my-project.md
+++ b/docs/stories/STORY-235-customize-the-comment-vocabulary-for-my-project.md
@@ -1,0 +1,37 @@
+---
+title: Customize the comment vocabulary for my project
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a project maintainer, I want to define my own comment vocabulary in config, so that comments carry the semantics my domain needs (`severity`, `tags`, `resolves`, …) instead of a fixed social-feature schema.
+
+Mirrors how document `[[types]]` are configured: the engine ships a default schema and hard-codes none of it.
+
+## Scope
+
+- `[comments.attributes]` config block declaring each attribute: `type` (`enum` / `number` / `string` / `list`), allowed values or range, `default`, `required`.
+- Project overrides the shipped default schema wholesale (rename, drop, constrain, add).
+- The authored-attribute validation from the prior story reads this schema; defaults apply when unset.
+
+Out of scope: resolution predicate config (next story); adapter-sourced attributes.
+
+## Acceptance Criteria
+
+- **Given** no `[comments.attributes]` in config, **when** I post a comment, **then** the shipped default schema (`kind`, `confidence`, `anchor`) is in force.
+- **Given** a config declaring `severity` as an enum `[low, medium, high]`, **when** I run `comment add --attr severity=high`, **then** it validates and stores; `--attr severity=urgent` is rejected.
+- **Given** a config that drops `confidence`, **when** I run `comment add --attr confidence=0.7`, **then** it is rejected as unknown.
+- **Given** an attribute declared `required`, **when** I post without it, **then** the command fails naming the missing attribute.
+- **Given** an attribute declared with a `default`, **when** I post without it, **then** the comment records the default value.
+
+## Notes
+
+Consistent with document-type configurability — not novel surface area. The engine never relies on `kind`/`confidence` existing.
+

--- a/docs/stories/STORY-236-resolve-a-comment-thread.md
+++ b/docs/stories/STORY-236-resolve-a-comment-thread.md
@@ -1,7 +1,7 @@
 ---
 title: Resolve a comment thread
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-236-resolve-a-comment-thread.md
+++ b/docs/stories/STORY-236-resolve-a-comment-thread.md
@@ -1,0 +1,38 @@
+---
+title: Resolve a comment thread
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer, I want to resolve a comment thread, so that a discussion is marked settled without erasing the reasoning that led there.
+
+Resolution is itself an append — a comment carrying the configured resolution attribute — and resolved-state is folded from a config-driven predicate, never written as a mutable field.
+
+## Scope
+
+- `lazyspec comment resolve <thread-root>` — appends a comment referencing the root, carrying the configured resolution attribute (default `kind=decision`).
+- `resolution` config: the predicate that marks a thread resolved (default `kind == decision`).
+- The fold computes resolved-state per thread from the predicate.
+- `comments <doc>` surfaces resolved state in `--json` and pretty output.
+
+Out of scope: collapse-resolved rendering in TUI/web (those stories); GC of resolved threads (deferred past v1).
+
+## Acceptance Criteria
+
+- **Given** a thread root `C1`, **when** I run `lazyspec comment resolve C1`, **then** a new comment is appended `in_reply_to`/referencing `C1` carrying the resolution attribute — and `C1` itself is unchanged.
+- **Given** a config `resolution` predicate `kind == decision`, **when** a thread contains a comment with `kind=decision`, **then** the folded thread reports resolved.
+- **Given** a config that sets the resolution predicate to a different attribute, **when** that attribute appears, **then** resolved-state folds from the new predicate — no compiled-in policy.
+- **Given** a resolved thread, **when** a further reply is appended, **then** the thread and its history remain intact (append-only; resolution is not a terminal lock).
+- Resolved state appears in both `--json` and pretty output.
+
+## Notes
+
+Event sourcing: resolution status is derived, not stored. What counts as resolved is project policy.
+

--- a/docs/stories/STORY-237-post-and-read-comments-live-via-a-git-ref-store.md
+++ b/docs/stories/STORY-237-post-and-read-comments-live-via-a-git-ref-store.md
@@ -1,0 +1,38 @@
+---
+title: Post and read comments live via a git-ref store
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As an agent (or a human working fast), I want to post and read comments through a low-latency local git-ref store, so that rapid chatter is conflict-free and lock-free without committing a file per note.
+
+This is the second concrete comment store, and it is what justifies extracting the `CommentStore` trait (convention principle 6: indirection when there are two concrete uses). Reuses the reservation-ref / lease machinery already in the codebase.
+
+## Scope
+
+- `CommentStore` trait extracted (`append`, `thread`, `since`) with the filesystem impl refactored behind it and a new git-ref impl added.
+- Git-ref impl: body → `git hash-object -w` (immutable blob); pointer → `refs/lazyspec/comments/<doc>/<ulid>`. `git update-ref` old-value check as atomic compare-and-swap for optimistic concurrency.
+- `comment_store` config: project default plus optional per-type override, values `filesystem | git-ref` (remote adapters are their own stories).
+- `comment add` / `comments` work unchanged against whichever store is configured.
+
+Out of scope: `fetch` materialization to markdown (next story); `--since`; remote adapters; TUI/web.
+
+## Acceptance Criteria
+
+- **Given** `comment_store = "git-ref"`, **when** I run `comment add <doc> --body "x"`, **then** a blob is written and a ref under `refs/lazyspec/comments/<doc>/` points at it — with no commit and no branch pollution.
+- **Given** two concurrent writers to the same thread, **then** the `update-ref` CAS yields exactly one winner per ref and neither corrupts the other — distinct ULIDs never contend.
+- **Given** `comment_store = "git-ref"`, **when** I run `comments <doc> --json`, **then** the folded thread is rendered via `git cat-file` (comments are not files on disk in this store).
+- **Given** a per-type `comment_store` override, **then** that type's documents use the overriding store while others use the project default.
+- The engine fold is store-agnostic — the same fold serves filesystem and git-ref.
+
+## Notes
+
+Trade-off: git-ref comments are opaque (not `cat`-able) and GitHub rejects pushes to `refs/lazyspec/*` — so this store is local / self-hosted / bare-remote. Cross-host sharing is the `fetch`-materialize story.
+

--- a/docs/stories/STORY-237-post-and-read-comments-live-via-a-git-ref-store.md
+++ b/docs/stories/STORY-237-post-and-read-comments-live-via-a-git-ref-store.md
@@ -1,7 +1,7 @@
 ---
 title: Post and read comments live via a git-ref store
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-238-fetch-materializes-git-ref-comments-to-markdown.md
+++ b/docs/stories/STORY-238-fetch-materializes-git-ref-comments-to-markdown.md
@@ -1,0 +1,36 @@
+---
+title: Fetch materializes git-ref comments to markdown
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer, I want `lazyspec fetch` to materialize git-ref comments into committed markdown, so that ephemeral live chatter becomes a durable, `cat`-able, PR-reviewable artifact I can share.
+
+Extends the existing `fetch` command (which already pulls git-ref / remote documents into local markdown) one layer down to comments — no bespoke `comment materialize` verb (convention principle 5: reuse the norm).
+
+## Scope
+
+- `lazyspec fetch` folds ref-backed comment streams into committed maildir markdown files under each document's `comments/` directory, alongside the documents it already fetches.
+- `--type <doc-type>` filter is honoured for comments as it is for documents.
+- Materialized comments are ordinary markdown (the filesystem-store shape), so all existing readers work.
+
+Out of scope: `--since` cursor (next story); native GitHub/ClickUp comment fetch (their own stories).
+
+## Acceptance Criteria
+
+- **Given** a document with git-ref comments, **when** I run `lazyspec fetch`, **then** each ref-backed comment is written as a ULID-named markdown file under the doc's `comments/` directory, `cat`-able and PR-reviewable.
+- **Given** a materialized thread, **when** I run `comments <doc>`, **then** the folded result matches the ref-backed fold (materialization is loss-free for envelope + attributes).
+- **Given** `fetch --type rfc`, **then** only rfc documents' comments are materialized.
+- **Given** a comment already materialized, **when** I run `fetch` again, **then** it is not duplicated (idempotent by ULID filename).
+
+## Notes
+
+This is the bridge from the live lane (git-ref) to the durable/shared lane (committed markdown). Which store is live vs durable is configuration, not hard-coded policy. Cross-GitHub sharing goes through this materialized markdown, not raw refs.
+

--- a/docs/stories/STORY-238-fetch-materializes-git-ref-comments-to-markdown.md
+++ b/docs/stories/STORY-238-fetch-materializes-git-ref-comments-to-markdown.md
@@ -1,7 +1,7 @@
 ---
 title: Fetch materializes git-ref comments to markdown
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-239-catch-up-on-comments-since-a-revision.md
+++ b/docs/stories/STORY-239-catch-up-on-comments-since-a-revision.md
@@ -1,7 +1,7 @@
 ---
 title: Catch up on comments since a revision
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-239-catch-up-on-comments-since-a-revision.md
+++ b/docs/stories/STORY-239-catch-up-on-comments-since-a-revision.md
@@ -1,0 +1,36 @@
+---
+title: Catch up on comments since a revision
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As an agent or a returning reviewer, I want to see only the comments added since a known revision, so that I can catch up on what changed without re-reading a whole thread.
+
+Adds the `since` capability to the `CommentStore` trait and exposes it on the read path.
+
+## Scope
+
+- `CommentStore::since(doc, cursor)` implemented for filesystem and git-ref stores.
+- `lazyspec comments <doc> --since <rev>` — returns only comments after the cursor.
+- `--json` returns the delta with a cursor the caller can persist for the next poll.
+
+Out of scope: any scheduler / control loop (RFC non-goal — orchestration is a downstream consumer, not built here).
+
+## Acceptance Criteria
+
+- **Given** a thread with comments before and after revision `R`, **when** I run `comments <doc> --since R --json`, **then** only comments after `R` are returned.
+- **Given** no comments since `R`, **then** an empty set is returned (not an error).
+- **Given** the returned delta, **then** it carries a cursor usable as the `--since` argument for the following call.
+- **Given** the git-ref store, **then** `--since` resolves the cursor against the ref namespace; against filesystem it resolves against commit/ULID ordering.
+
+## Notes
+
+This capability is what an external orchestrator's change-detection loop would consume — a legitimate downstream consumer, explicitly not an orchestrator built inside lazyspec.
+

--- a/docs/stories/STORY-240-github-issues-comment-adapter.md
+++ b/docs/stories/STORY-240-github-issues-comment-adapter.md
@@ -1,0 +1,38 @@
+---
+title: GitHub-issues comment adapter
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer working GitHub-issue-backed documents, I want native GitHub issue comments to appear as lazyspec comments — including reactions and labels — so that the discussion on the issue is visible in the same thread view as everything else.
+
+A thin adapter over the existing github-issues store backend, pulled in by `lazyspec fetch`.
+
+## Scope
+
+- GitHub-issues comment adapter: a native issue comment maps 1:1 to a `Comment` (envelope from the issue-comment metadata; body verbatim).
+- Side-channel data projected onto the attribute map dynamically, with no config: reactions → `attributes.reactions.{+1,heart,…}`, labels → `attributes.labels`.
+- Adapter-sourced attributes bypass authored-path schema validation and are surfaced as-is (read-only mirror of the remote source of truth).
+- Fetched during `lazyspec fetch` for github-issues-typed documents.
+
+Out of scope: ClickUp (its own story); writing reactions back (read-only); posting to GitHub (native issue-comment write is a separate concern if ever wanted).
+
+## Acceptance Criteria
+
+- **Given** a github-issues-backed document with native issue comments, **when** I run `lazyspec fetch`, **then** each native comment appears as a `Comment` in `comments <doc>`.
+- **Given** a native comment with three 👍 reactions, **then** it surfaces `attributes.reactions.+1 = 3` with no config entry declaring `reactions`.
+- **Given** issue labels, **then** they surface as `attributes.labels` verbatim.
+- **Given** an adapter-sourced attribute not in the authored schema, **then** it is preserved (not rejected) — the open-map rule: unknown authored attributes are rejected, unknown adapter attributes are kept.
+- **Given** adapter-sourced attributes, **then** they are read-only — lazyspec does not write reactions/labels back.
+
+## Notes
+
+Contrast with authored attributes: the schema constrains what may be authored, not what may appear. GitHub reactions/labels flow through verbatim.
+

--- a/docs/stories/STORY-240-github-issues-comment-adapter.md
+++ b/docs/stories/STORY-240-github-issues-comment-adapter.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub-issues comment adapter
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-241-clickup-comment-adapter.md
+++ b/docs/stories/STORY-241-clickup-comment-adapter.md
@@ -1,0 +1,38 @@
+---
+title: ClickUp comment adapter
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a reviewer working ClickUp-task-backed documents, I want native ClickUp task comments to appear as lazyspec comments — including reactions and tags — so that task discussion shows in the same thread view.
+
+A thin adapter over the existing ClickUp store backend, pulled in by `lazyspec fetch`. Sibling to the GitHub-issues adapter, but ClickUp's native shape differs (tags, task-comment structure).
+
+## Scope
+
+- ClickUp comment adapter: a native task comment maps 1:1 to a `Comment`.
+- Side-channel data projected onto the attribute map dynamically, no config: reactions → `attributes.reactions.*`, tags → `attributes.tags`.
+- Adapter-sourced attributes bypass authored-path validation, surfaced as-is (read-only).
+- Fetched during `lazyspec fetch` for clickup-typed documents.
+
+Out of scope: GitHub (its own story); writing back to ClickUp (read-only mirror).
+
+## Acceptance Criteria
+
+- **Given** a ClickUp-backed document with native task comments, **when** I run `lazyspec fetch`, **then** each appears as a `Comment` in `comments <doc>`.
+- **Given** a native comment with reactions, **then** they surface under `attributes.reactions.*` with no config declaring them.
+- **Given** task tags, **then** they surface as `attributes.tags` verbatim.
+- **Given** adapter-sourced attributes, **then** they are preserved (open map) and read-only.
+- **Given** both a GitHub-issues and a ClickUp document in the same project, **then** each surfaces its native side-channel shape and both render identically in `comments --json`.
+
+## Notes
+
+Same open-map discipline as the GitHub adapter; only the native source shape differs. The adapter knows its source's shape and emits attributes on read.
+

--- a/docs/stories/STORY-241-clickup-comment-adapter.md
+++ b/docs/stories/STORY-241-clickup-comment-adapter.md
@@ -1,7 +1,7 @@
 ---
 title: ClickUp comment adapter
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-242-tui-comment-thread-pane.md
+++ b/docs/stories/STORY-242-tui-comment-thread-pane.md
@@ -1,7 +1,7 @@
 ---
 title: TUI comment thread pane
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/docs/stories/STORY-242-tui-comment-thread-pane.md
+++ b/docs/stories/STORY-242-tui-comment-thread-pane.md
@@ -1,0 +1,38 @@
+---
+title: TUI comment thread pane
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a TUI user, I want a thread/chat-like pane per document, so that I can read and post comments in context without leaving the terminal.
+
+The TUI surface of the comment layer. Attribute-driven: it renders whatever attributes each comment carries, authored or adapter-sourced, with no hard-coded slot for `kind` or `confidence`.
+
+## Scope
+
+- A comment pane bound to the selected document: nested reply bubbles, author + timestamp headers, attribute chips per node.
+- Collapse-resolved threads; jump-to-anchor (navigate to the `anchor` section slug).
+- Inline reply: post a comment / reply from the pane.
+- Renders from the same engine fold the CLI uses (TUI depends on engine, not CLI — convention principle 3).
+
+Out of scope: web view (sibling story); any engine/CLI change (those shipped in earlier stories).
+
+## Acceptance Criteria
+
+- **Given** a document with a threaded discussion, **when** I open its comment pane, **then** replies render nested under their parents with author + relative time and attribute chips.
+- **Given** a comment with an adapter-sourced `reactions` attribute, **then** its chip renders alongside authored chips — no hard-coded column; unknown attributes still display.
+- **Given** a resolved thread, **when** collapse-resolved is active, **then** it collapses; expanding shows the full history.
+- **Given** a comment with an `anchor`, **when** I jump-to-anchor, **then** the document view scrolls to that section slug.
+- **Given** the pane, **when** I post a reply inline, **then** it appends via the engine and appears in the pane.
+
+## Notes
+
+Ships together with the web-view story (per CLAUDE.md: TUI, web, CLI move together). Both render the same folded tree; this story is the TUI half.
+

--- a/docs/stories/STORY-243-web-view-comment-thread.md
+++ b/docs/stories/STORY-243-web-view-comment-thread.md
@@ -1,0 +1,36 @@
+---
+title: Web-view comment thread
+type: story
+status: draft
+author: jack
+date: 2026-07-21
+tags: []
+related:
+- implements: RFC-060
+---
+
+## Story
+
+As a web-view user, I want the comment thread rendered on a document page, so that I can read the discussion in the browser view alongside the TUI and CLI.
+
+The web surface of the comment layer, sibling to the TUI pane. Same folded tree, attribute-driven rendering.
+
+## Scope
+
+- Web view renders the folded comment tree per document: nested replies, author + timestamp, attribute chips.
+- Resolved-state shown; attribute chips cover authored and adapter-sourced attributes with no hard-coded slot.
+- Renders from the same engine fold (web depends on engine).
+
+Out of scope: TUI pane (sibling story). Whether the web view is read-only or supports posting follows the web view's existing capability for other document operations — match it, do not invent a one-off write path here.
+
+## Acceptance Criteria
+
+- **Given** a document with a threaded, partly-resolved discussion, **when** I open its web page, **then** the thread renders as a nested tree with author, timestamp, resolved-state, and attribute chips.
+- **Given** a comment carrying an adapter-sourced attribute (e.g. `reactions`), **then** it renders as a chip alongside authored attributes — no hard-coded `kind`/`confidence` slot.
+- **Given** the same document, **then** the web tree and the TUI pane render the same folded structure (parity).
+- **Given** the web view's existing interaction model, **then** comment rendering matches it (read-only vs interactive) rather than introducing a bespoke path.
+
+## Notes
+
+Per CLAUDE.md the three surfaces move together; this is the web half of the pairing with the TUI thread pane. All surfaces are attribute-driven.
+

--- a/docs/stories/STORY-243-web-view-comment-thread.md
+++ b/docs/stories/STORY-243-web-view-comment-thread.md
@@ -1,7 +1,7 @@
 ---
 title: Web-view comment thread
 type: story
-status: draft
+status: rejected
 author: jack
 date: 2026-07-21
 tags: []

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -20,10 +20,41 @@ fn json_output(results: &[SearchResult]) -> String {
             let mut json = doc_to_json(r.doc);
             json["match_field"] = serde_json::Value::String(r.match_field.to_string());
             json["snippet"] = serde_json::Value::String(r.snippet.clone());
+            json["score"] = serde_json::Value::from(r.score);
             json
         })
         .collect();
     serde_json::to_string_pretty(&items).unwrap()
+}
+
+// `results` arrives already score-descending from `Store::search`; this only
+// formats, it never re-sorts or caps.
+fn human_output(store: &Store, query: &str, results: &[SearchResult]) -> String {
+    if results.is_empty() {
+        return format!("No results for \"{}\"\n", query);
+    }
+    let colors = StatusColors::load(store.root()).unwrap_or_default();
+    let mut output = String::new();
+    for r in results {
+        output.push_str(&format!(
+            "{} {}\n",
+            doc_card(
+                &colors,
+                &r.doc.title,
+                &r.doc.doc_type,
+                &r.doc.status,
+                r.doc.assignee.as_deref(),
+                &r.doc.path
+            ),
+            dim(&format!("[{}]", r.match_field)),
+        ));
+        output.push_str(&format!(
+            "  {}\n",
+            dim(&format!("...{}...", r.snippet.trim()))
+        ));
+        output.push('\n');
+    }
+    output
 }
 
 pub fn run(store: &Store, query: &str, doc_type: Option<&str>, json: bool, fs: &dyn FileSystem) {
@@ -33,27 +64,7 @@ pub fn run(store: &Store, query: &str, doc_type: Option<&str>, json: bool, fs: &
     if json {
         println!("{}", json_output(&results));
     } else {
-        if results.is_empty() {
-            println!("No results for \"{}\"", query);
-            return;
-        }
-        let colors = StatusColors::load(store.root()).unwrap_or_default();
-        for r in &results {
-            println!(
-                "{} {}",
-                doc_card(
-                    &colors,
-                    &r.doc.title,
-                    &r.doc.doc_type,
-                    &r.doc.status,
-                    r.doc.assignee.as_deref(),
-                    &r.doc.path
-                ),
-                dim(&format!("[{}]", r.match_field)),
-            );
-            println!("  {}", dim(&format!("...{}...", r.snippet.trim())));
-            println!();
-        }
+        print!("{}", human_output(store, query, &results));
     }
 }
 
@@ -61,4 +72,168 @@ pub fn run_json(store: &Store, query: &str, doc_type: Option<&str>, fs: &dyn Fil
     let mut results = store.search(query, fs);
     filter_results(&mut results, doc_type);
     json_output(&results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::config::Config;
+    use crate::engine::fs::RealFileSystem;
+    use tempfile::TempDir;
+
+    fn write_doc(
+        root: &std::path::Path,
+        dir: &str,
+        filename: &str,
+        doc_type: &str,
+        title: &str,
+        body: &str,
+    ) {
+        let full_dir = root.join(dir);
+        std::fs::create_dir_all(&full_dir).unwrap();
+        std::fs::write(
+            full_dir.join(filename),
+            format!(
+                "---\ntitle: \"{}\"\ntype: {}\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: []\n---\n{}\n",
+                title, doc_type, body
+            ),
+        )
+        .unwrap();
+    }
+
+    fn write_rfc(root: &std::path::Path, filename: &str, title: &str, body: &str) {
+        write_doc(root, "docs/rfcs", filename, "rfc", title, body);
+    }
+
+    fn load_store(root: &std::path::Path) -> Store {
+        Store::load(root, &Config::default()).unwrap()
+    }
+
+    // AC1: `search --json` includes a numeric `score` field per result.
+    #[test]
+    fn json_output_includes_numeric_score() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_rfc(root, "RFC-001-fuzzy.md", "fuzzy matcher", "body");
+        let store = load_store(root);
+
+        let output = run_json(&store, "fuzzy", None, &RealFileSystem);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0]["score"].is_number());
+        assert!(parsed[0]["score"].as_u64().unwrap() > 0);
+    }
+
+    // AC2: the `--json` array is ordered score-descending.
+    #[test]
+    fn run_json_orders_results_by_score_descending() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // Non-contiguous, weaker match at the earlier-sorting path so ordering
+        // can only come from score, not the path tie-break.
+        write_rfc(root, "RFC-001-weak.md", "xfxuxzxzxyx", "body");
+        write_rfc(root, "RFC-002-strong.md", "fuzzy matcher", "body");
+        let store = load_store(root);
+
+        let output = run_json(&store, "fuzzy", None, &RealFileSystem);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["title"], "fuzzy matcher");
+        let s0 = parsed[0]["score"].as_u64().unwrap();
+        let s1 = parsed[1]["score"].as_u64().unwrap();
+        assert!(s0 > s1);
+    }
+
+    // AC3: human-readable mode prints results in the same score-descending order.
+    #[test]
+    fn human_output_orders_results_by_score_descending() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_rfc(root, "RFC-001-weak.md", "xfxuxzxzxyx", "body");
+        write_rfc(root, "RFC-002-strong.md", "fuzzy matcher", "body");
+        let store = load_store(root);
+
+        let mut results = store.search("fuzzy", &RealFileSystem);
+        filter_results(&mut results, None);
+        let out = human_output(&store, "fuzzy", &results);
+
+        let strong_idx = out.find("fuzzy matcher").expect("strong match printed");
+        let weak_idx = out.find("xfxuxzxzxyx").expect("weak match printed");
+        assert!(
+            strong_idx < weak_idx,
+            "higher-scoring result should print first"
+        );
+    }
+
+    // AC4: `--type` filters to the requested type and the survivors stay
+    // score-descending.
+    #[test]
+    fn type_filter_keeps_score_descending_order() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_rfc(root, "RFC-001-weak.md", "xfxuxzxzxyx", "body");
+        write_rfc(root, "RFC-002-strong.md", "fuzzy matcher", "body");
+        write_doc(
+            root,
+            "docs/adrs",
+            "ADR-001-fuzzy.md",
+            "adr",
+            "fuzzy adr",
+            "body",
+        );
+        let store = load_store(root);
+
+        let output = run_json(&store, "fuzzy", Some("rfc"), &RealFileSystem);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.iter().all(|d| d["type"] == "rfc"));
+        let s0 = parsed[0]["score"].as_u64().unwrap();
+        let s1 = parsed[1]["score"].as_u64().unwrap();
+        assert!(s0 >= s1);
+    }
+
+    // AC5: the CLI applies no result cap; every matching document is present.
+    #[test]
+    fn run_json_applies_no_result_cap() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        for i in 0..30 {
+            write_rfc(
+                root,
+                &format!("RFC-{:03}-fuzzy.md", i),
+                &format!("fuzzy item {}", i),
+                "body",
+            );
+        }
+        let store = load_store(root);
+
+        let output = run_json(&store, "fuzzy", None, &RealFileSystem);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.len(), 30, "every match should be present, no cap");
+    }
+
+    // AC6: `match_field`/`snippet` keep reporting the pre-scoring values.
+    #[test]
+    fn match_field_and_snippet_unchanged_by_scoring() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_rfc(
+            root,
+            "RFC-001-fuzzy.md",
+            "unrelated title",
+            "a fuzzy body match here",
+        );
+        let store = load_store(root);
+
+        let output = run_json(&store, "fuzzy", None, &RealFileSystem);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed[0]["match_field"], "body");
+        assert!(parsed[0]["snippet"].as_str().unwrap().contains("fuzzy"));
+        assert!(parsed[0]["score"].is_number());
+    }
 }

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -368,44 +368,17 @@ impl Store {
         let mut results = Vec::new();
 
         for meta in self.docs.values() {
-            // Track the single best-scoring field for this document. A `None`
-            // score from `nucleo` means the field did not match at all; a
-            // document whose fields all score `None` is dropped (the score
-            // floor). Strict `>` keeps the earliest field on ties, so field
-            // selection is deterministic regardless of `docs` iteration order.
-            let mut best: Option<(u32, &'static str, String)> = None;
-
-            let mut consider = |score: u32, field: &'static str, snippet: &dyn Fn() -> String| {
-                if best.as_ref().is_none_or(|(b, _, _)| score > *b) {
-                    best = Some((score, field, snippet()));
-                }
-            };
-
-            if let Some(score) = pattern.score(Utf32Str::new(&meta.title, &mut buf), &mut matcher) {
-                consider(score, "title", &|| meta.title.clone());
-            }
-
-            for tag in &meta.tags {
-                if let Some(score) = pattern.score(Utf32Str::new(tag, &mut buf), &mut matcher) {
-                    consider(score, "tag", &|| tag.clone());
-                }
-            }
-
-            let path_str = meta.path.to_string_lossy();
-            if let Some(score) = pattern.score(Utf32Str::new(&path_str, &mut buf), &mut matcher) {
-                consider(score, "path", &|| path_str.to_string());
-            }
-
-            if let Some(body) = self.cached_or_read_body(&meta.path, fs) {
-                let mut indices: Vec<u32> = Vec::new();
-                if let Some(score) =
-                    pattern.indices(Utf32Str::new(&body, &mut buf), &mut matcher, &mut indices)
-                {
-                    consider(score, "body", &|| body_snippet(&body, &indices, query));
-                }
-            }
-
-            if let Some((score, match_field, snippet)) = best {
+            let body = self.cached_or_read_body(&meta.path, fs);
+            if let Some((score, match_field, snippet)) = score_doc_fields(
+                &pattern,
+                &mut matcher,
+                &mut buf,
+                query,
+                &meta.title,
+                &meta.tags,
+                &meta.path,
+                body.as_deref(),
+            ) {
                 results.push(SearchResult {
                     doc: meta,
                     match_field,
@@ -421,6 +394,24 @@ impl Store {
                 .then_with(|| a.doc.path.cmp(&b.doc.path))
         });
         results
+    }
+
+    /// An owned snapshot of every doc's searchable fields, so a background
+    /// thread can run [`SearchCorpus::search`] without borrowing the store.
+    /// Bodies come through the same memoizing cache as [`Store::search`], so a
+    /// warm snapshot is a plain clone of in-memory strings.
+    pub fn search_corpus(&self, fs: &dyn FileSystem) -> SearchCorpus {
+        let docs = self
+            .docs
+            .values()
+            .map(|meta| CorpusDoc {
+                path: meta.path.clone(),
+                title: meta.title.clone(),
+                tags: meta.tags.clone(),
+                body: self.cached_or_read_body(&meta.path, fs),
+            })
+            .collect();
+        SearchCorpus { docs }
     }
 
     /// Body text for `path`, served from the in-memory body cache when present
@@ -439,6 +430,116 @@ impl Store {
     }
 }
 
+/// Score one document's fields against a parsed pattern, returning the single
+/// best-scoring `(score, field, snippet)` or `None` when nothing matches (the
+/// score floor). Strict `>` keeps the earliest field on ties, so field
+/// selection is deterministic. Shared by [`Store::search`] and
+/// [`SearchCorpus::search`] so both paths rank identically.
+#[allow(clippy::too_many_arguments)]
+fn score_doc_fields(
+    pattern: &Pattern,
+    matcher: &mut Matcher,
+    buf: &mut Vec<char>,
+    query: &str,
+    title: &str,
+    tags: &[String],
+    path: &Path,
+    body: Option<&str>,
+) -> Option<(u32, &'static str, String)> {
+    let mut best: Option<(u32, &'static str, String)> = None;
+
+    let mut consider = |score: u32, field: &'static str, snippet: &dyn Fn() -> String| {
+        if best.as_ref().is_none_or(|(b, _, _)| score > *b) {
+            best = Some((score, field, snippet()));
+        }
+    };
+
+    if let Some(score) = pattern.score(Utf32Str::new(title, buf), matcher) {
+        consider(score, "title", &|| title.to_string());
+    }
+
+    for tag in tags {
+        if let Some(score) = pattern.score(Utf32Str::new(tag, buf), matcher) {
+            consider(score, "tag", &|| tag.clone());
+        }
+    }
+
+    let path_str = path.to_string_lossy();
+    if let Some(score) = pattern.score(Utf32Str::new(&path_str, buf), matcher) {
+        consider(score, "path", &|| path_str.to_string());
+    }
+
+    if let Some(body) = body {
+        let mut indices: Vec<u32> = Vec::new();
+        if let Some(score) = pattern.indices(Utf32Str::new(body, buf), matcher, &mut indices) {
+            consider(score, "body", &|| body_snippet(body, &indices, query));
+        }
+    }
+
+    best
+}
+
+#[derive(Clone)]
+struct CorpusDoc {
+    path: PathBuf,
+    title: String,
+    tags: Vec<String>,
+    body: Option<String>,
+}
+
+/// An owned, `Send` snapshot of the store's searchable fields, built by
+/// [`Store::search_corpus`]. Lets a background worker run the engine's fuzzy
+/// ranking off the UI thread; scoring stays here so no frontend ever owns the
+/// matching algorithm (RFC-043 principle 3).
+#[derive(Clone)]
+pub struct SearchCorpus {
+    docs: Vec<CorpusDoc>,
+}
+
+/// [`SearchResult`] without the `&DocMeta` borrow: what a corpus search can
+/// hand across a thread boundary.
+#[derive(Debug, Clone)]
+pub struct CorpusSearchResult {
+    pub path: PathBuf,
+    pub match_field: &'static str,
+    pub snippet: String,
+    pub score: u32,
+}
+
+impl SearchCorpus {
+    /// Identical ranking to [`Store::search`]: same pattern config, score
+    /// floor, best-field selection, and score-desc / path-asc ordering.
+    pub fn search(&self, query: &str) -> Vec<CorpusSearchResult> {
+        let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
+        let mut matcher = Matcher::new(NucleoConfig::DEFAULT);
+        let mut buf: Vec<char> = Vec::new();
+        let mut results = Vec::new();
+
+        for doc in &self.docs {
+            if let Some((score, match_field, snippet)) = score_doc_fields(
+                &pattern,
+                &mut matcher,
+                &mut buf,
+                query,
+                &doc.title,
+                &doc.tags,
+                &doc.path,
+                doc.body.as_deref(),
+            ) {
+                results.push(CorpusSearchResult {
+                    path: doc.path.clone(),
+                    match_field,
+                    snippet,
+                    score,
+                });
+            }
+        }
+
+        results.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
+        results
+    }
+}
+
 /// Char indices within `text` that `query` fuzzy-matches, using the same matcher
 /// configuration as [`Store::search`]. Empty when `query` is empty or does not
 /// match `text`, so a caller can highlight exactly the matched characters of a
@@ -447,22 +548,49 @@ impl Store {
 /// Lives beside `search` so both surfaces (CLI, TUI) share one matcher config;
 /// the TUI must never own the scoring/matching algorithm (RFC-043 principle 3).
 pub fn match_indices(query: &str, text: &str) -> Vec<u32> {
-    if query.is_empty() {
-        return Vec::new();
+    IndexMatcher::new(query).indices(text)
+}
+
+/// Reusable form of [`match_indices`]: parses the query pattern and builds the
+/// matcher once, so a caller highlighting many texts against one query (e.g.
+/// every visible row of the TUI search overlay, per frame) pays the setup cost
+/// once instead of per text. Same semantics as [`match_indices`].
+pub struct IndexMatcher {
+    pattern: Option<Pattern>,
+    matcher: Matcher,
+    buf: Vec<char>,
+}
+
+impl IndexMatcher {
+    pub fn new(query: &str) -> Self {
+        let pattern = (!query.is_empty())
+            .then(|| Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart));
+        Self {
+            pattern,
+            matcher: Matcher::new(NucleoConfig::DEFAULT),
+            buf: Vec::new(),
+        }
     }
-    let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
-    let mut matcher = Matcher::new(NucleoConfig::DEFAULT);
-    let mut buf: Vec<char> = Vec::new();
-    let mut indices: Vec<u32> = Vec::new();
-    if pattern
-        .indices(Utf32Str::new(text, &mut buf), &mut matcher, &mut indices)
-        .is_some()
-    {
-        indices.sort_unstable();
-        indices.dedup();
-        indices
-    } else {
-        Vec::new()
+
+    pub fn indices(&mut self, text: &str) -> Vec<u32> {
+        let Some(pattern) = &self.pattern else {
+            return Vec::new();
+        };
+        let mut indices: Vec<u32> = Vec::new();
+        if pattern
+            .indices(
+                Utf32Str::new(text, &mut self.buf),
+                &mut self.matcher,
+                &mut indices,
+            )
+            .is_some()
+        {
+            indices.sort_unstable();
+            indices.dedup();
+            indices
+        } else {
+            Vec::new()
+        }
     }
 }
 
@@ -947,6 +1075,42 @@ mod tests {
         assert_eq!(results[0].score, tag_only[0].score);
     }
 
+    // AC (BUG-011): the owned corpus ranks exactly like the borrowing search --
+    // same order, path, field, snippet, and score -- across queries that hit the
+    // title (scattered and exact), tag-vs-title best-field selection, the score
+    // floor, a body-only match, and the path tie-break.
+    #[test]
+    fn corpus_search_matches_store_search_results_and_order() {
+        let (store, fs) = search_store(&[
+            ("RFC-001-x.md", "xfxuxzxzxyx", &[], "x"),
+            ("RFC-002-y.md", "fuzzy", &[], "y"),
+            (
+                "RFC-003-m.md",
+                "custom order rebuild engine",
+                &["core"],
+                "unrelated body text",
+            ),
+            ("RFC-004-c.md", "hello", &[], "the fuzzy matcher lives here"),
+            ("RFC-005-a.md", "alpha", &[], "body one"),
+            ("RFC-006-b.md", "alpha", &[], "body two"),
+        ]);
+
+        let corpus = store.search_corpus(&fs);
+
+        for query in ["fuzzy", "core", "alpha", "enfz", "zzqqww"] {
+            let expected = store.search(query, &fs);
+            let actual = corpus.search(query);
+
+            assert_eq!(expected.len(), actual.len(), "query {query:?}");
+            for (e, a) in expected.iter().zip(actual.iter()) {
+                assert_eq!(e.doc.path, a.path, "query {query:?}");
+                assert_eq!(e.match_field, a.match_field, "query {query:?}");
+                assert_eq!(e.snippet, a.snippet, "query {query:?}");
+                assert_eq!(e.score, a.score, "query {query:?}");
+            }
+        }
+    }
+
     #[test]
     fn match_indices_returns_the_matched_subsequence_positions() {
         // `tff` matches "tui fuzzy filter" as t(0) f(4) f(10): non-contiguous.
@@ -965,6 +1129,21 @@ mod tests {
     fn match_indices_empty_when_no_match_or_empty_query() {
         assert!(match_indices("zzz", "hello world").is_empty());
         assert!(match_indices("", "hello world").is_empty());
+    }
+
+    #[test]
+    fn index_matcher_reused_across_texts_agrees_with_match_indices() {
+        let texts = ["tui fuzzy filter", "hello world", "", "Fuzzy TUI Frontend"];
+        for query in ["tff", "hello", "zzz", ""] {
+            let mut reused = IndexMatcher::new(query);
+            for text in texts {
+                assert_eq!(
+                    reused.indices(text),
+                    match_indices(query, text),
+                    "query {query:?} text {text:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -43,6 +43,13 @@ pub struct Store {
     /// walked by [`resolve_chain`](crate::engine::context::resolve_chain)'s
     /// related neighbourhood.
     pub(crate) related_relationships: Vec<String>,
+    /// Raw document bodies memoized on first read during [`search`](Store::search),
+    /// so repeated fuzzy queries (a live TUI filter re-runs on every keystroke)
+    /// score body text from memory instead of re-reading each file from disk.
+    /// Startup stays metadata-only (ADR-013): nothing is loaded here until a
+    /// search touches the body. Entries are dropped on `reload_file`/`remove_file`
+    /// so a changed body is re-read (file-watch invalidation).
+    pub(crate) body_cache: std::sync::Mutex<HashMap<PathBuf, String>>,
 }
 
 impl Store {
@@ -127,6 +134,7 @@ impl Store {
             parse_errors,
             chain_relationships,
             related_relationships,
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         };
         store.propagate_parent_links();
 
@@ -285,6 +293,10 @@ impl Store {
         relative_path: &Path,
         fs: &dyn FileSystem,
     ) -> Result<()> {
+        // Drop any memoized body so a changed file is re-read (file-watch
+        // invalidation, ADR-013). Covers both the removed and re-parsed cases.
+        self.body_cache.lock().unwrap().remove(relative_path);
+
         let full_path = root.join(relative_path);
         if !fs.exists(&full_path) {
             self.docs.remove(relative_path);
@@ -314,6 +326,7 @@ impl Store {
     }
 
     pub fn remove_file(&mut self, relative_path: &Path) {
+        self.body_cache.lock().unwrap().remove(relative_path);
         self.docs.remove(relative_path);
         self.rebuild_links();
     }
@@ -383,7 +396,7 @@ impl Store {
                 consider(score, "path", &|| path_str.to_string());
             }
 
-            if let Ok(body) = self.get_body_raw(&meta.path, fs) {
+            if let Some(body) = self.cached_or_read_body(&meta.path, fs) {
                 let mut indices: Vec<u32> = Vec::new();
                 if let Some(score) =
                     pattern.indices(Utf32Str::new(&body, &mut buf), &mut matcher, &mut indices)
@@ -408,6 +421,48 @@ impl Store {
                 .then_with(|| a.doc.path.cmp(&b.doc.path))
         });
         results
+    }
+
+    /// Body text for `path`, served from the in-memory body cache when present
+    /// and otherwise read from disk and memoized. `None` when the file cannot be
+    /// read. See [`body_cache`](Store::body_cache) for the ADR-013 rationale.
+    fn cached_or_read_body(&self, path: &Path, fs: &dyn FileSystem) -> Option<String> {
+        if let Some(body) = self.body_cache.lock().unwrap().get(path) {
+            return Some(body.clone());
+        }
+        let body = self.get_body_raw(path, fs).ok()?;
+        self.body_cache
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf(), body.clone());
+        Some(body)
+    }
+}
+
+/// Char indices within `text` that `query` fuzzy-matches, using the same matcher
+/// configuration as [`Store::search`]. Empty when `query` is empty or does not
+/// match `text`, so a caller can highlight exactly the matched characters of a
+/// rendered field. Indices are ascending and de-duplicated.
+///
+/// Lives beside `search` so both surfaces (CLI, TUI) share one matcher config;
+/// the TUI must never own the scoring/matching algorithm (RFC-043 principle 3).
+pub fn match_indices(query: &str, text: &str) -> Vec<u32> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
+    let mut matcher = Matcher::new(NucleoConfig::DEFAULT);
+    let mut buf: Vec<char> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    if pattern
+        .indices(Utf32Str::new(text, &mut buf), &mut matcher, &mut indices)
+        .is_some()
+    {
+        indices.sort_unstable();
+        indices.dedup();
+        indices
+    } else {
+        Vec::new()
     }
 }
 
@@ -890,6 +945,62 @@ mod tests {
         assert_eq!(tag_only.len(), 1);
         assert_eq!(tag_only[0].match_field, "tag");
         assert_eq!(results[0].score, tag_only[0].score);
+    }
+
+    #[test]
+    fn match_indices_returns_the_matched_subsequence_positions() {
+        // `tff` matches "tui fuzzy filter" as t(0) f(4) f(10): non-contiguous.
+        let idx = match_indices("tff", "tui fuzzy filter");
+        assert_eq!(idx, vec![0, 4, 10]);
+        assert_eq!(
+            "tui fuzzy filter".chars().next(),
+            Some('t'),
+            "index 0 is the leading 't'"
+        );
+        assert_eq!("tui fuzzy filter".chars().nth(4), Some('f'));
+        assert_eq!("tui fuzzy filter".chars().nth(10), Some('f'));
+    }
+
+    #[test]
+    fn match_indices_empty_when_no_match_or_empty_query() {
+        assert!(match_indices("zzz", "hello world").is_empty());
+        assert!(match_indices("", "hello world").is_empty());
+    }
+
+    #[test]
+    fn search_reads_body_from_cache_until_reload_invalidates_it() {
+        // Body match works; the body is then memoized. Editing the file on disk
+        // WITHOUT reloading keeps the stale (cached) body, so the new token does
+        // not match. `reload_file` drops the entry, and the fresh body is re-read.
+        let (mut store, fs) = search_store(&[("RFC-001-c.md", "hello", &[], "the fuzzy matcher")]);
+        let path = PathBuf::from("docs/rfcs/RFC-001-c.md");
+
+        assert_eq!(store.search("fuzzy", &fs).len(), 1, "cold body match");
+
+        // Rewrite the body on disk: drop "fuzzy", add "gadget".
+        fs.add_file(
+            PathBuf::from("/fake/root").join(&path),
+            "---\ntitle: \"hello\"\ntype: rfc\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: []\n---\nthe gadget matcher\n",
+        );
+
+        assert!(
+            store.search("gadget", &fs).is_empty(),
+            "cached body is stale until reload"
+        );
+
+        store
+            .reload_file(Path::new("/fake/root"), &path, &fs)
+            .unwrap();
+
+        assert_eq!(
+            store.search("gadget", &fs).len(),
+            1,
+            "reload invalidates the cache; the new body is re-read and matches"
+        );
+        assert!(
+            store.search("fuzzy", &fs).is_empty(),
+            "the old body token no longer matches after reload"
+        );
     }
 
     fn github_issues_config() -> Config {

--- a/src/engine/store.rs
+++ b/src/engine/store.rs
@@ -8,6 +8,8 @@ use crate::engine::fs::{FileSystem, RealFileSystem};
 use crate::engine::git_ref::GitRefOps;
 use crate::engine::refs::RefExpander;
 use anyhow::Result;
+use nucleo::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo::{Config as NucleoConfig, Matcher, Utf32Str};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -347,55 +349,81 @@ impl Store {
     }
 
     pub fn search(&self, query: &str, fs: &dyn FileSystem) -> Vec<SearchResult<'_>> {
-        let query_lower = query.to_lowercase();
+        let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
+        let mut matcher = Matcher::new(NucleoConfig::DEFAULT);
+        let mut buf: Vec<char> = Vec::new();
         let mut results = Vec::new();
 
         for meta in self.docs.values() {
-            if meta.title.to_lowercase().contains(&query_lower) {
-                results.push(SearchResult {
-                    doc: meta,
-                    match_field: "title",
-                    snippet: meta.title.clone(),
-                });
-                continue;
+            // Track the single best-scoring field for this document. A `None`
+            // score from `nucleo` means the field did not match at all; a
+            // document whose fields all score `None` is dropped (the score
+            // floor). Strict `>` keeps the earliest field on ties, so field
+            // selection is deterministic regardless of `docs` iteration order.
+            let mut best: Option<(u32, &'static str, String)> = None;
+
+            let mut consider = |score: u32, field: &'static str, snippet: &dyn Fn() -> String| {
+                if best.as_ref().is_none_or(|(b, _, _)| score > *b) {
+                    best = Some((score, field, snippet()));
+                }
+            };
+
+            if let Some(score) = pattern.score(Utf32Str::new(&meta.title, &mut buf), &mut matcher) {
+                consider(score, "title", &|| meta.title.clone());
             }
 
-            if meta
-                .tags
-                .iter()
-                .any(|t| t.to_lowercase().contains(&query_lower))
-            {
-                let matched_tag = meta
-                    .tags
-                    .iter()
-                    .find(|t| t.to_lowercase().contains(&query_lower))
-                    .unwrap();
-                results.push(SearchResult {
-                    doc: meta,
-                    match_field: "tag",
-                    snippet: matched_tag.clone(),
-                });
-                continue;
+            for tag in &meta.tags {
+                if let Some(score) = pattern.score(Utf32Str::new(tag, &mut buf), &mut matcher) {
+                    consider(score, "tag", &|| tag.clone());
+                }
+            }
+
+            let path_str = meta.path.to_string_lossy();
+            if let Some(score) = pattern.score(Utf32Str::new(&path_str, &mut buf), &mut matcher) {
+                consider(score, "path", &|| path_str.to_string());
             }
 
             if let Ok(body) = self.get_body_raw(&meta.path, fs) {
-                let body_lower = body.to_lowercase();
-                if let Some(pos) = body_lower.find(&query_lower) {
-                    let start = body.floor_char_boundary(pos.saturating_sub(40));
-                    let end = body.ceil_char_boundary((pos + query.len() + 40).min(body.len()));
-                    let snippet = body[start..end].to_string();
-                    results.push(SearchResult {
-                        doc: meta,
-                        match_field: "body",
-                        snippet,
-                    });
+                let mut indices: Vec<u32> = Vec::new();
+                if let Some(score) =
+                    pattern.indices(Utf32Str::new(&body, &mut buf), &mut matcher, &mut indices)
+                {
+                    consider(score, "body", &|| body_snippet(&body, &indices, query));
                 }
+            }
+
+            if let Some((score, match_field, snippet)) = best {
+                results.push(SearchResult {
+                    doc: meta,
+                    match_field,
+                    snippet,
+                    score,
+                });
             }
         }
 
-        results.sort_by(|a, b| DocMeta::sort_by_date(a.doc, b.doc));
+        results.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.doc.path.cmp(&b.doc.path))
+        });
         results
     }
+}
+
+/// Build a body snippet centred on the first fuzzy-matched character, preserving
+/// the historical ±40-character window (`nucleo` gives scattered match indices
+/// rather than a contiguous substring position).
+fn body_snippet(body: &str, indices: &[u32], query: &str) -> String {
+    let first_char = indices.first().copied().unwrap_or(0) as usize;
+    let pos = body
+        .char_indices()
+        .nth(first_char)
+        .map(|(b, _)| b)
+        .unwrap_or(0);
+    let start = body.floor_char_boundary(pos.saturating_sub(40));
+    let end = body.ceil_char_boundary((pos + query.len() + 40).min(body.len()));
+    body[start..end].to_string()
 }
 
 fn materialize_git_ref_cache(
@@ -572,6 +600,7 @@ pub struct SearchResult<'a> {
     pub doc: &'a DocMeta,
     pub match_field: &'static str,
     pub snippet: String,
+    pub score: u32,
 }
 
 #[cfg(test)]
@@ -718,6 +747,149 @@ mod tests {
         assert!(doc2.is_some());
         assert_eq!(doc2.unwrap().title, "Second RFC");
         assert_eq!(doc2.unwrap().id, "RFC-002");
+    }
+
+    /// Build an in-memory store of RFC documents from `(filename, title, tags, body)`
+    /// tuples, so the fuzzy `search` tests can control every match surface.
+    fn search_store(entries: &[(&str, &str, &[&str], &str)]) -> (Store, InMemoryFileSystem) {
+        let fs = InMemoryFileSystem::new();
+        let root = PathBuf::from("/fake/root");
+        let rfc_dir = root.join("docs/rfcs");
+        fs.add_dir(rfc_dir.clone());
+
+        for (filename, title, tags, body) in entries {
+            let tags_yaml = if tags.is_empty() {
+                "[]".to_string()
+            } else {
+                let items: Vec<String> = tags.iter().map(|t| format!("\"{}\"", t)).collect();
+                format!("[{}]", items.join(", "))
+            };
+            let content = format!(
+                "---\ntitle: \"{}\"\ntype: rfc\nstatus: draft\nauthor: \"test\"\ndate: 2026-01-01\ntags: {}\n---\n{}\n",
+                title, tags_yaml, body
+            );
+            fs.add_file(rfc_dir.join(filename), &content);
+        }
+
+        let config = Config::default();
+        let store = Store::load_with_fs(&root, &config, &fs, None).unwrap();
+        (store, fs)
+    }
+
+    #[test]
+    fn search_matches_non_contiguous_subsequence_in_title() {
+        // `enfz` is a subsequence of "engine fuzzy" (e-n from "engine", f-z from
+        // "fuzzy") but never a contiguous substring; the old `.contains()` path
+        // would have missed it. Filename has no matchable chars so only the title
+        // matches.
+        let (store, fs) = search_store(&[("RFC-001-doc.md", "engine fuzzy", &[], "some body")]);
+
+        let results = store.search("enfz", &fs);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].doc.title, "engine fuzzy");
+        assert_eq!(results[0].match_field, "title");
+        assert!(results[0].score > 0);
+    }
+
+    #[test]
+    fn search_ranks_by_score_descending() {
+        // The stronger (contiguous, exact) match lives at the later-sorting path,
+        // so if it ranks first the ordering must come from score, not the
+        // path tie-break.
+        let (store, fs) = search_store(&[
+            ("RFC-001-x.md", "xfxuxzxzxyx", &[], "x"),
+            ("RFC-002-y.md", "fuzzy", &[], "y"),
+        ]);
+
+        let results = store.search("fuzzy", &fs);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].doc.title, "fuzzy");
+        assert!(results[0].score > results[1].score);
+    }
+
+    #[test]
+    fn search_tie_break_by_path_is_stable_across_runs() {
+        // Both docs match only via their identical title "alpha", producing equal
+        // scores; their filenames carry no 'l'/'p'/'h' so the path field never
+        // matches and cannot break the tie by score.
+        let (store, fs) = search_store(&[
+            ("RFC-001-x.md", "alpha", &[], "body one"),
+            ("RFC-002-y.md", "alpha", &[], "body two"),
+        ]);
+
+        let first = store.search("alpha", &fs);
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].score, first[1].score);
+        assert!(first[0].doc.path < first[1].doc.path);
+
+        let baseline: Vec<PathBuf> = first.iter().map(|r| r.doc.path.clone()).collect();
+        for _ in 0..5 {
+            let again: Vec<PathBuf> = store
+                .search("alpha", &fs)
+                .iter()
+                .map(|r| r.doc.path.clone())
+                .collect();
+            assert_eq!(again, baseline);
+        }
+    }
+
+    #[test]
+    fn search_score_floor_excludes_non_matches() {
+        // "datb" is a subsequence of "database" but not of "frontend" (no 'a'
+        // after its trailing 'd'); the non-matcher must be dropped entirely.
+        let (store, fs) = search_store(&[
+            ("RFC-001-a.md", "database", &[], "x"),
+            ("RFC-002-b.md", "frontend", &[], "y"),
+        ]);
+
+        let results = store.search("datb", &fs);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].doc.title, "database");
+    }
+
+    #[test]
+    fn search_body_only_match_sets_match_field_body() {
+        // "fuzzy" appears only in the body: the title "hello" and the filename
+        // (no 'u'/'z'/'y') do not match.
+        let (store, fs) =
+            search_store(&[("RFC-001-c.md", "hello", &[], "the fuzzy matcher lives here")]);
+
+        let results = store.search("fuzzy", &fs);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_field, "body");
+        assert!(results[0].snippet.contains("fuzzy"));
+    }
+
+    #[test]
+    fn search_multi_field_match_returns_one_result_with_best_field_score() {
+        // "core" matches the title only as a scattered subsequence
+        // ("custom order rebuild engine") but matches the tag exactly. The exact
+        // tag match outscores the title, so the doc yields exactly one result
+        // naming the tag and carrying the tag field's (higher) score.
+        let (store, fs) = search_store(&[(
+            "RFC-001-m.md",
+            "custom order rebuild engine",
+            &["core"],
+            "unrelated body text",
+        )]);
+
+        let results = store.search("core", &fs);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_field, "tag");
+
+        // The reported score equals the best (tag) field's score in isolation:
+        // a doc whose only matchable surface is the same "core" tag scores
+        // identically, since nucleo scores each haystack independently.
+        let (tag_only_store, tag_fs) = search_store(&[("RFC-002-n.md", "zzz", &["core"], "zzz")]);
+        let tag_only = tag_only_store.search("core", &tag_fs);
+        assert_eq!(tag_only.len(), 1);
+        assert_eq!(tag_only[0].match_field, "tag");
+        assert_eq!(results[0].score, tag_only[0].score);
     }
 
     fn github_issues_config() -> Config {

--- a/src/engine/validation.rs
+++ b/src/engine/validation.rs
@@ -1260,6 +1260,7 @@ mod attr_schema_tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -1355,6 +1356,7 @@ mod attr_schema_tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -1502,6 +1504,7 @@ mod unknown_relationship_tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -1590,6 +1593,7 @@ mod parent_link_chain_tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -482,7 +482,6 @@ fn reload_session(
     app.refresh_validation(config);
     // Mirror the cache resets the CacheRefresh and GhPushResult(Ok) arms perform.
     app.filtered_docs_cache = None;
-    app.rebuild_search_index();
     app.build_doc_tree();
     app.git_status_cache.invalidate();
     app.expanded_body_cache.clear();
@@ -552,7 +551,6 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
             app.last_sync = Some(Instant::now());
             app.gh_fetch_warnings = warnings;
             app.filtered_docs_cache = None;
-            app.rebuild_search_index();
             app.refresh_validation(config);
         }
         AppEvent::GhPushResult(result) => {
@@ -564,7 +562,6 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
                         app.store = refreshed;
                     }
                     app.filtered_docs_cache = None;
-                    app.rebuild_search_index();
                     app.refresh_validation(config);
                     app.expanded_body_cache.clear();
                     app.disk_cache.clear();
@@ -589,7 +586,6 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
                 Ok(create_result) => {
                     let _ = app.store.reload_file(root, &create_result.path, &*app.fs);
                     app.filtered_docs_cache = None;
-                    app.rebuild_search_index();
                     if let Some(type_idx) = app
                         .doc_types
                         .iter()

--- a/src/tui/infra/event_loop.rs
+++ b/src/tui/infra/event_loop.rs
@@ -571,6 +571,12 @@ fn handle_app_event(app: &mut App, event: AppEvent, root: &Path, config: &Config
                 }
             }
         }
+        AppEvent::SearchResults {
+            generation,
+            results,
+        } => {
+            app.apply_search_results(generation, results);
+        }
         AppEvent::CreateStarted => {}
         AppEvent::CreateProgress { message, state } => {
             if app.create_form.active && app.create_form.loading {
@@ -667,6 +673,38 @@ pub fn run(store: Store, config: &Config) -> Result<()> {
 
     let (tx, rx) = crossbeam_channel::unbounded();
     app.event_tx = tx.clone();
+
+    // Background search worker (BUG-011): fuzzy-scoring every doc body takes
+    // tens of milliseconds, which blocked the event loop when run per keystroke.
+    // The worker owns each request's corpus snapshot (DICTUM-007: threads never
+    // touch App state; messages only) and drains the channel to the newest
+    // request before searching, so a burst of keystrokes costs one search.
+    // Results carry their generation; the handler drops stale ones.
+    let (search_tx, search_rx) = crossbeam_channel::unbounded::<crate::tui::state::SearchRequest>();
+    app.search_tx = search_tx;
+    let search_result_tx = tx.clone();
+    std::thread::spawn(move || {
+        while let Ok(mut req) = search_rx.recv() {
+            while let Ok(newer) = search_rx.try_recv() {
+                req = newer;
+            }
+            let results: Vec<std::path::PathBuf> = req
+                .corpus
+                .search(&req.query)
+                .into_iter()
+                .map(|r| r.path)
+                .collect();
+            if search_result_tx
+                .send(AppEvent::SearchResults {
+                    generation: req.generation,
+                    results,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
 
     let shared_gh_store: Option<Arc<Mutex<GithubIssuesStore>>> =
         if crate::tui::has_pollable_types(&config) {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -11,7 +11,7 @@ pub(crate) use app::parity_seed;
 pub use app::{
     anchor_to_flat, resolve_editor_command, resolve_editor_command_from, resolve_editor_from, App,
     AppEvent, ConfigDep, CreateResult, DocListNode, FilterField, GraphAnchor, GraphNode,
-    PreviewTab, ScaffoldResult, SearchEntry, ViewMode,
+    PreviewTab, ScaffoldResult, ViewMode,
 };
 #[cfg(feature = "agent")]
 pub use forms::AgentDialog;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -11,7 +11,7 @@ pub(crate) use app::parity_seed;
 pub use app::{
     anchor_to_flat, resolve_editor_command, resolve_editor_command_from, resolve_editor_from, App,
     AppEvent, ConfigDep, CreateResult, DocListNode, FilterField, GraphAnchor, GraphNode,
-    PreviewTab, ScaffoldResult, ViewMode,
+    PreviewTab, ScaffoldResult, SearchRequest, ViewMode,
 };
 #[cfg(feature = "agent")]
 pub use forms::AgentDialog;

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -240,11 +240,6 @@ fn rule_write(rule: &mut ValidationRule, key: &RuleKey, value: SettingsValue) {
     }
 }
 
-pub struct SearchEntry {
-    pub path: PathBuf,
-    pub searchable: String, // pre-lowercased "title\0tag1\0tag2\0path"
-}
-
 pub struct CreateResult {
     pub path: PathBuf,
     pub doc_type: DocType,
@@ -591,7 +586,6 @@ pub struct App {
         Vec<crate::tui::content::diagram::DiagramBlock>,
     )>,
     pub filtered_docs_cache: Option<Vec<PathBuf>>,
-    pub search_index: Vec<SearchEntry>,
     pub git_branch: Option<String>,
     pub git_status_cache: GitStatusCache,
     pub gh_conflict_message: Option<String>,
@@ -760,7 +754,6 @@ impl App {
             ascii_diagrams: false,
             diagram_blocks_cache: None,
             filtered_docs_cache: None,
-            search_index: Vec::new(),
             git_branch,
             git_status_cache,
             gh_conflict_message: None,
@@ -795,7 +788,6 @@ impl App {
             frame_idx: 0,
         };
         app.apply_config(config);
-        app.rebuild_search_index();
         app.refresh_available_tags();
         app.build_doc_tree();
         app
@@ -852,7 +844,6 @@ impl App {
         self.validation_warnings
             .extend(self.gh_fetch_warnings.iter().cloned());
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
     }
 
     pub fn cycle_mode(&mut self) {
@@ -1820,27 +1811,6 @@ impl App {
         self.refresh_available_tags();
     }
 
-    pub fn rebuild_search_index(&mut self) {
-        self.search_index = self
-            .store
-            .all_docs()
-            .iter()
-            .map(|doc| {
-                let mut searchable = doc.title.to_lowercase();
-                for tag in &doc.tags {
-                    searchable.push('\0');
-                    searchable.push_str(&tag.to_lowercase());
-                }
-                searchable.push('\0');
-                searchable.push_str(&doc.path.to_string_lossy().to_lowercase());
-                SearchEntry {
-                    path: doc.path.clone(),
-                    searchable,
-                }
-            })
-            .collect();
-    }
-
     pub fn reset_filters(&mut self) {
         self.filter_status = None;
         self.filter_tag = None;
@@ -2234,15 +2204,16 @@ impl App {
             return;
         }
 
-        let query = self.search_query.to_lowercase();
-        let mut results: Vec<_> = self
-            .search_index
-            .iter()
-            .filter(|e| e.searchable.contains(&query))
-            .map(|e| e.path.clone())
+        // Fuzzy, ranked results from the shared engine scorer (STORY-129): the
+        // TUI never owns the matching algorithm. Results already arrive sorted by
+        // score descending with a path tie-break, and the engine's score floor
+        // drops non-matches, so an unmatched query yields an empty list.
+        self.search_results = self
+            .store
+            .search(&self.search_query, &*self.fs)
+            .into_iter()
+            .map(|r| r.doc.path.clone())
             .collect();
-        results.sort();
-        self.search_results = results;
         self.search_selected = 0;
     }
 
@@ -2573,7 +2544,6 @@ impl App {
         // Reload again to pick up the relation changes
         let _ = self.store.reload_file(root, &relative, &*self.fs);
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
 
         let doc_type = self.create_form.doc_type.clone();
         if let Some(type_idx) = self.doc_types.iter().position(|t| *t == doc_type) {
@@ -2626,7 +2596,6 @@ impl App {
         )?;
         self.store.remove_file(&doc_path);
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
 
         self.close_delete_confirm();
         self.build_doc_tree();
@@ -2916,7 +2885,6 @@ impl App {
         }
         self.store.reload_file(root, &doc_path, &*self.fs)?;
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
         self.build_doc_tree();
         self.status_picker.error = None;
         self.close_status_picker();
@@ -3088,7 +3056,6 @@ impl App {
 
         self.store.reload_file(root, &doc_path, &*self.fs)?;
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
         self.build_doc_tree();
         self.close_provenance_editor();
         Ok(())
@@ -3202,7 +3169,6 @@ impl App {
         // not the viewed doc. Reload whichever file actually changed.
         self.store.reload_file(root, &outcome.source, &*self.fs)?;
         self.filtered_docs_cache = None;
-        self.rebuild_search_index();
         self.build_doc_tree();
         self.link_editor.error = None;
         self.close_link_editor();
@@ -3534,7 +3500,6 @@ pub(crate) mod parity_seed {
             ascii_diagrams: false,
             diagram_blocks_cache: None,
             filtered_docs_cache: None,
-            search_index: Vec::new(),
             git_branch: None,
             git_status_cache: GitStatusCache::new(tmp.path()),
             gh_conflict_message: None,
@@ -3615,7 +3580,6 @@ pub(crate) mod parity_seed {
         }
 
         app.store = Store::load(&root, &Config::default()).unwrap();
-        app.rebuild_search_index();
         app.build_doc_tree();
     }
 
@@ -3922,6 +3886,7 @@ mod tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         };
 
         let (tx, _rx) = crossbeam_channel::unbounded();
@@ -4013,7 +3978,6 @@ mod tests {
             ascii_diagrams: false,
             diagram_blocks_cache: None,
             filtered_docs_cache: None,
-            search_index: Vec::new(),
             git_branch: None,
             git_status_cache: GitStatusCache::new(Path::new(".")),
             gh_conflict_message: None,
@@ -4258,6 +4222,7 @@ mod tests {
             parse_errors: Vec::new(),
             chain_relationships: vec!["implements".to_string()],
             related_relationships: vec!["related-to".to_string()],
+            body_cache: std::sync::Mutex::new(HashMap::new()),
         };
 
         let meta_a = DocMeta {
@@ -5127,6 +5092,137 @@ mod tests {
         let mut app = make_test_app(0);
         app.store = store;
         (tmp, app)
+    }
+
+    /// An rfc doc with an explicit `title` and `body` and no tags, so a search
+    /// test controls exactly which surface (title vs body) a query can match.
+    fn titled_doc(title: &str, body: &str) -> String {
+        format!(
+            "---\ntitle: \"{title}\"\ntype: rfc\nstatus: draft\nauthor: t\ndate: 2026-04-01\ntags: []\n---\n\n{body}\n"
+        )
+    }
+
+    /// Titles of the current `search_results`, in result order.
+    fn result_titles(app: &App) -> Vec<String> {
+        app.search_results
+            .iter()
+            .map(|p| app.store.get(p).unwrap().title.clone())
+            .collect()
+    }
+
+    // AC: a query whose chars appear in a title in order but not contiguously
+    // ("tff" in "tui fuzzy filter") is kept -- the old `.contains()` filter would
+    // have dropped it.
+    #[test]
+    fn update_search_keeps_non_contiguous_title_subsequence() {
+        let (_tmp, mut app) = app_with_store(&[(
+            "docs/rfcs/RFC-001-a.md",
+            &titled_doc("tui fuzzy filter", "unrelated body"),
+        )]);
+
+        app.search_query = "tff".to_string();
+        app.update_search();
+
+        assert_eq!(result_titles(&app), vec!["tui fuzzy filter".to_string()]);
+    }
+
+    // AC: rows are ordered by relevance score descending. The strong (exact)
+    // match sits at the LATER-sorting path, so leading it proves the order comes
+    // from score, not the path tie-break.
+    #[test]
+    fn update_search_orders_by_relevance_score_descending() {
+        let (_tmp, mut app) = app_with_store(&[
+            ("docs/rfcs/RFC-001-a.md", &titled_doc("xfxuxzxzxyx", "b1")),
+            ("docs/rfcs/RFC-002-b.md", &titled_doc("fuzzy", "b2")),
+        ]);
+
+        app.search_query = "fuzzy".to_string();
+        app.update_search();
+
+        assert_eq!(
+            result_titles(&app),
+            vec!["fuzzy".to_string(), "xfxuxzxzxyx".to_string()]
+        );
+    }
+
+    // AC: a query that fuzzy-matches only within a body (not title/tags/path)
+    // still surfaces the document.
+    #[test]
+    fn update_search_surfaces_body_only_match() {
+        let (_tmp, mut app) = app_with_store(&[(
+            "docs/rfcs/RFC-001-a.md",
+            &titled_doc("hello", "the quadratic solver lives here"),
+        )]);
+
+        app.search_query = "quadratic".to_string();
+        app.update_search();
+
+        assert_eq!(result_titles(&app), vec!["hello".to_string()]);
+    }
+
+    // AC: a query nothing fuzzy-matches yields an empty list -- non-matches are
+    // dropped by the engine's score floor, not shown unhighlighted.
+    #[test]
+    fn update_search_empty_when_nothing_matches() {
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "world body"))]);
+
+        app.search_query = "zzqqww".to_string();
+        app.update_search();
+
+        assert!(app.search_results.is_empty());
+    }
+
+    // AC: the characters that matched are visually highlighted in the rendered
+    // row. The matched title chars render bold + yellow; an unmatched title char
+    // does not.
+    #[test]
+    fn search_overlay_highlights_matched_title_chars() {
+        use crate::tui::views::StatusPalette;
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("fuzzy", "body"))]);
+        app.search_mode = true;
+        app.search_query = "fzy".to_string(); // matches f(0) z(2) y(4) of "fuzzy"
+        app.update_search();
+        assert_eq!(app.search_results.len(), 1);
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let palette = StatusPalette::default();
+        terminal
+            .draw(|f| crate::tui::views::overlays::draw_search_overlay(f, &app, &palette))
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+
+        let mut matched_cells = 0usize;
+        let mut plain_u = false;
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                let cell = buffer.cell((x, y)).unwrap();
+                let sym = cell.symbol();
+                let highlighted = cell.fg == ratatui::style::Color::Yellow
+                    && cell.modifier.contains(ratatui::style::Modifier::BOLD);
+                if (sym == "f" || sym == "z" || sym == "y") && highlighted {
+                    matched_cells += 1;
+                }
+                // The 'u' at index 1 of "fuzzy" is NOT part of the match, so it
+                // must render without the highlight style.
+                if sym == "u" && !highlighted {
+                    plain_u = true;
+                }
+            }
+        }
+
+        assert!(
+            matched_cells >= 3,
+            "matched title chars f/z/y should render highlighted (yellow+bold)"
+        );
+        assert!(
+            plain_u,
+            "the unmatched 'u' should render without the highlight style"
+        );
     }
 
     /// The `DocMeta` whose id matches, cloned out of the store.

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -245,6 +245,16 @@ pub struct CreateResult {
     pub doc_type: DocType,
 }
 
+/// One keystroke's worth of work for the background search worker. Carries its
+/// own corpus snapshot so freshness is trivial: every request searches the
+/// store exactly as it stood when the key was handled, and the worker never
+/// borrows `Store` (which lives on the UI thread).
+pub struct SearchRequest {
+    pub corpus: crate::engine::store::SearchCorpus,
+    pub query: String,
+    pub generation: u64,
+}
+
 pub enum AppEvent {
     Terminal(crossterm::event::KeyEvent),
     FileChange(notify::Event),
@@ -264,6 +274,10 @@ pub enum AppEvent {
     },
     CreateComplete {
         result: Result<CreateResult, String>,
+    },
+    SearchResults {
+        generation: u64,
+        results: Vec<PathBuf>,
     },
     CacheRefresh {
         warnings: Vec<String>,
@@ -502,6 +516,17 @@ pub struct App {
     pub search_query: String,
     pub search_results: Vec<std::path::PathBuf>,
     pub search_selected: usize,
+    /// True while a search request is in flight on the worker; the overlay
+    /// renders a spinner until the matching-generation results land.
+    pub search_pending: bool,
+    /// Monotonic id stamped onto each dispatched search; results carrying an
+    /// older generation are dropped so a slow search never overwrites a newer
+    /// query's results.
+    pub search_generation: u64,
+    /// Sender to the background search worker (BUG-011). Like `event_tx`, a
+    /// throwaway channel at construction; the event loop rebinds it when it
+    /// spawns the worker, so state code just sends and ignores errors.
+    pub search_tx: crossbeam_channel::Sender<SearchRequest>,
     pub show_help: bool,
     pub help_scroll: u16,
     /// Maximum legal `help_scroll` for the current help content + viewport,
@@ -659,6 +684,7 @@ impl App {
         fs: Box<dyn FileSystem>,
     ) -> Self {
         let (event_tx, _event_rx) = crossbeam_channel::unbounded();
+        let (search_tx, _search_rx) = crossbeam_channel::unbounded();
         let git_branch = query_git_branch(store.root());
         let git_status_cache = GitStatusCache::new(store.root());
         #[cfg(feature = "agent")]
@@ -687,6 +713,9 @@ impl App {
             search_query: String::new(),
             search_results: Vec::new(),
             search_selected: 0,
+            search_pending: false,
+            search_generation: 0,
+            search_tx,
             show_help: false,
             help_scroll: 0,
             help_max_scroll: 0,
@@ -2188,6 +2217,8 @@ impl App {
         self.search_query.clear();
         self.search_results.clear();
         self.search_selected = 0;
+        self.search_pending = false;
+        self.search_generation = self.search_generation.wrapping_add(1);
     }
 
     pub fn exit_search(&mut self) {
@@ -2195,26 +2226,67 @@ impl App {
         self.search_query.clear();
         self.search_results.clear();
         self.search_selected = 0;
+        self.search_pending = false;
+        self.search_generation = self.search_generation.wrapping_add(1);
     }
 
+    /// Dispatch the current query to the background search worker (BUG-011):
+    /// scoring 700+ full bodies per keystroke blocked the event loop, so the UI
+    /// thread only snapshots the corpus (a cheap clone via the engine body
+    /// cache) and stamps a fresh generation; results arrive later as
+    /// [`AppEvent::SearchResults`] and are applied by [`apply_search_results`].
+    /// The generation bump on an empty query invalidates any in-flight search
+    /// so its late results cannot repopulate a cleared list.
+    ///
+    /// Fuzzy, ranked results still come from the shared engine scorer
+    /// (STORY-129): the TUI never owns the matching algorithm.
     pub fn update_search(&mut self) {
+        self.search_generation = self.search_generation.wrapping_add(1);
+        self.search_selected = 0;
+
         if self.search_query.is_empty() {
             self.search_results.clear();
-            self.search_selected = 0;
+            self.search_pending = false;
             return;
         }
 
-        // Fuzzy, ranked results from the shared engine scorer (STORY-129): the
-        // TUI never owns the matching algorithm. Results already arrive sorted by
-        // score descending with a path tie-break, and the engine's score floor
-        // drops non-matches, so an unmatched query yields an empty list.
-        self.search_results = self
-            .store
-            .search(&self.search_query, &*self.fs)
-            .into_iter()
-            .map(|r| r.doc.path.clone())
-            .collect();
+        self.search_pending = true;
+        let corpus = self.store.search_corpus(&*self.fs);
+        let _ = self.search_tx.send(SearchRequest {
+            corpus,
+            query: self.search_query.clone(),
+            generation: self.search_generation,
+        });
+    }
+
+    /// Apply worker results, dropping them silently when the generation is
+    /// stale (a newer keystroke has already superseded the query).
+    pub fn apply_search_results(&mut self, generation: u64, results: Vec<std::path::PathBuf>) {
+        if generation != self.search_generation {
+            return;
+        }
+        self.search_results = results;
         self.search_selected = 0;
+        self.search_pending = false;
+    }
+
+    /// Test-only synchronous search: dispatch, then run the corpus search
+    /// inline and apply, so ranking tests exercise the exact production path
+    /// (corpus snapshot -> engine scorer -> apply) without a worker thread.
+    #[cfg(test)]
+    pub(crate) fn run_search_now(&mut self) {
+        self.update_search();
+        if self.search_query.is_empty() {
+            return;
+        }
+        let results = self
+            .store
+            .search_corpus(&*self.fs)
+            .search(&self.search_query)
+            .into_iter()
+            .map(|r| r.path)
+            .collect();
+        self.apply_search_results(self.search_generation, results);
     }
 
     pub fn select_search_result(&mut self) {
@@ -3414,6 +3486,7 @@ pub(crate) mod parity_seed {
         let tmp = TempDir::new().unwrap();
         let store = Store::load(tmp.path(), &Config::default()).unwrap();
         let (tx, _rx) = crossbeam_channel::unbounded();
+        let (search_tx, _search_rx) = crossbeam_channel::unbounded();
         #[cfg(feature = "agent")]
         let agent_spawner = AgentSpawner::new(store.root());
         let config = Config::default();
@@ -3433,6 +3506,9 @@ pub(crate) mod parity_seed {
             search_query: String::new(),
             search_results: Vec::new(),
             search_selected: 0,
+            search_pending: false,
+            search_generation: 0,
+            search_tx,
             show_help: false,
             help_scroll: 0,
             help_max_scroll: 0,
@@ -3684,7 +3760,7 @@ pub(crate) mod parity_seed {
                 populate_docs(&mut app);
                 app.search_mode = true;
                 app.search_query = "title".to_string();
-                app.update_search(); // results non-empty
+                app.run_search_now(); // results non-empty (search is async in prod)
                 app.search_selected = 1; // middle: Up and Down both move
             }
             KeyContext::Fullscreen => {
@@ -3890,6 +3966,7 @@ mod tests {
         };
 
         let (tx, _rx) = crossbeam_channel::unbounded();
+        let (search_tx, _search_rx) = crossbeam_channel::unbounded();
         let config = Config::default();
 
         #[cfg(feature = "agent")]
@@ -3911,6 +3988,9 @@ mod tests {
             search_query: String::new(),
             search_results: Vec::new(),
             search_selected: 0,
+            search_pending: false,
+            search_generation: 0,
+            search_tx,
             show_help: false,
             help_scroll: 0,
             help_max_scroll: 0,
@@ -5121,7 +5201,7 @@ mod tests {
         )]);
 
         app.search_query = "tff".to_string();
-        app.update_search();
+        app.run_search_now();
 
         assert_eq!(result_titles(&app), vec!["tui fuzzy filter".to_string()]);
     }
@@ -5137,7 +5217,7 @@ mod tests {
         ]);
 
         app.search_query = "fuzzy".to_string();
-        app.update_search();
+        app.run_search_now();
 
         assert_eq!(
             result_titles(&app),
@@ -5155,7 +5235,7 @@ mod tests {
         )]);
 
         app.search_query = "quadratic".to_string();
-        app.update_search();
+        app.run_search_now();
 
         assert_eq!(result_titles(&app), vec!["hello".to_string()]);
     }
@@ -5168,9 +5248,98 @@ mod tests {
             app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "world body"))]);
 
         app.search_query = "zzqqww".to_string();
+        app.run_search_now();
+
+        assert!(app.search_results.is_empty());
+    }
+
+    // AC (BUG-011 a): each dispatch marks the search pending and bumps the
+    // generation, and the request lands on the worker channel with that
+    // generation and the current query.
+    #[test]
+    fn update_search_marks_pending_and_bumps_generation() {
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "body"))]);
+        let (tx, rx) = crossbeam_channel::unbounded();
+        app.search_tx = tx;
+
+        let before = app.search_generation;
+        app.search_query = "hel".to_string();
+        app.update_search();
+
+        assert!(app.search_pending);
+        assert_eq!(app.search_generation, before + 1);
+        let req = rx.try_recv().expect("a request is dispatched");
+        assert_eq!(req.query, "hel");
+        assert_eq!(req.generation, app.search_generation);
+    }
+
+    // AC (BUG-011 b): results stamped with a stale generation are dropped
+    // silently -- current results and the pending flag stay untouched.
+    #[test]
+    fn stale_generation_results_are_dropped() {
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "body"))]);
+
+        app.search_query = "hel".to_string();
+        app.update_search();
+        app.search_query = "hell".to_string();
+        app.update_search();
+
+        let stale = app.search_generation - 1;
+        app.apply_search_results(stale, vec![PathBuf::from("docs/rfcs/RFC-001-a.md")]);
+
+        assert!(app.search_results.is_empty(), "stale results not applied");
+        assert!(app.search_pending, "still waiting on the live generation");
+    }
+
+    // AC (BUG-011 c): matching-generation results are applied and clear the
+    // pending flag (which also clears the overlay spinner).
+    #[test]
+    fn matching_generation_results_apply_and_clear_pending() {
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "body"))]);
+
+        app.search_query = "hel".to_string();
+        app.update_search();
+        app.search_selected = 3;
+
+        let path = PathBuf::from("docs/rfcs/RFC-001-a.md");
+        app.apply_search_results(app.search_generation, vec![path.clone()]);
+
+        assert_eq!(app.search_results, vec![path]);
+        assert!(!app.search_pending);
+        assert_eq!(app.search_selected, 0);
+    }
+
+    // AC (BUG-011 d): an empty query clears results immediately without going
+    // pending or dispatching to the worker; the generation bump invalidates any
+    // in-flight search so its late results cannot repopulate the cleared list.
+    #[test]
+    fn empty_query_clears_results_without_pending() {
+        let (_tmp, mut app) =
+            app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("hello", "body"))]);
+        let (tx, rx) = crossbeam_channel::unbounded();
+        app.search_tx = tx;
+
+        app.search_query = "hel".to_string();
+        app.run_search_now();
+        assert!(!app.search_results.is_empty());
+        let in_flight = app.search_generation;
+        let _ = rx.try_recv();
+
+        app.search_query.clear();
         app.update_search();
 
         assert!(app.search_results.is_empty());
+        assert!(!app.search_pending);
+        assert!(rx.try_recv().is_err(), "empty query dispatches nothing");
+
+        app.apply_search_results(in_flight, vec![PathBuf::from("docs/rfcs/RFC-001-a.md")]);
+        assert!(
+            app.search_results.is_empty(),
+            "late results for the pre-clear query stay dropped"
+        );
     }
 
     // AC: the characters that matched are visually highlighted in the rendered
@@ -5185,7 +5354,7 @@ mod tests {
             app_with_store(&[("docs/rfcs/RFC-001-a.md", &titled_doc("fuzzy", "body"))]);
         app.search_mode = true;
         app.search_query = "fzy".to_string(); // matches f(0) z(2) y(4) of "fuzzy"
-        app.update_search();
+        app.run_search_now();
         assert_eq!(app.search_results.len(), 1);
 
         let backend = TestBackend::new(80, 24);

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -984,12 +984,36 @@ pub fn draw_search_overlay(f: &mut Frame, app: &App, colors: &StatusPalette) {
                 }
                 None => Span::raw(" "),
             };
-            let line = Line::from(vec![
-                gutter_span,
-                Span::raw(format!("  {:<40} ", title)),
-                Span::styled(status_str, Style::default().fg(status_clr)),
-            ]);
-            ListItem::new(line)
+
+            // Highlight the title characters the query fuzzy-matched, using the
+            // engine matcher's indices so the on-screen feedback matches the
+            // ranking (STORY-130). A body-only match yields no title indices, so
+            // the row simply renders unhighlighted.
+            let matched: std::collections::HashSet<usize> =
+                crate::engine::store::match_indices(&app.search_query, title)
+                    .into_iter()
+                    .map(|i| i as usize)
+                    .collect();
+            let highlight = Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD);
+
+            let mut spans = vec![gutter_span, Span::raw("  ")];
+            let title_width = title.chars().count();
+            for (i, ch) in title.chars().enumerate() {
+                if matched.contains(&i) {
+                    spans.push(Span::styled(ch.to_string(), highlight));
+                } else {
+                    spans.push(Span::raw(ch.to_string()));
+                }
+            }
+            // Left-align to width 40 like the previous `{:<40}` (no truncation).
+            if title_width < 40 {
+                spans.push(Span::raw(" ".repeat(40 - title_width)));
+            }
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(status_str, Style::default().fg(status_clr)));
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -1025,22 +1025,21 @@ pub fn draw_search_overlay(f: &mut Frame, app: &App, colors: &StatusPalette) {
         })
         .collect();
 
-    // While a search is in flight on the worker, the results title carries the
-    // shared loading face (same spinner machinery as the create form); it
-    // disappears when the matching-generation results land and clear
-    // `search_pending`.
-    let results_title = if app.search_pending {
-        let frame = crate::spinners::spinner("face")
-            .compact(crate::spinners::SpinnerState::Loading, app.frame_idx);
-        let style = super::colors::frame_style(frame.colour);
-        Line::from(vec![
-            Span::raw(" Results "),
-            Span::styled(frame.lines.join(""), style),
-            Span::raw(" "),
-        ])
+    // The results title always carries the shared face (same spinner machinery
+    // as the create form): the loading face while a search is in flight on the
+    // worker, the happy idle face otherwise.
+    let state = if app.search_pending {
+        crate::spinners::SpinnerState::Loading
     } else {
-        Line::from(" Results ")
+        crate::spinners::SpinnerState::Idle
     };
+    let frame = crate::spinners::spinner("face").compact(state, app.frame_idx);
+    let style = super::colors::frame_style(frame.colour);
+    let results_title = Line::from(vec![
+        Span::raw(" Results "),
+        Span::styled(frame.lines.join(""), style),
+        Span::raw(" "),
+    ]);
 
     let list = List::new(items)
         .block(

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -964,8 +964,16 @@ pub fn draw_search_overlay(f: &mut Frame, app: &App, colors: &StatusPalette) {
     );
     f.render_widget(input, layout[0]);
 
-    let items: Vec<ListItem> = app
-        .search_results
+    // Only the visible window of results becomes ListItems: building per-char
+    // spans (and running the matcher) for all 450+ rows every frame is the
+    // render-side half of BUG-011. One IndexMatcher parses the query pattern
+    // once per frame instead of once per row.
+    let window = layout[1].height.saturating_sub(2) as usize;
+    let start = window_start(app.search_selected, app.search_results.len(), window);
+    let end = (start + window).min(app.search_results.len());
+    let mut index_matcher = crate::engine::store::IndexMatcher::new(&app.search_query);
+
+    let items: Vec<ListItem> = app.search_results[start..end]
         .iter()
         .map(|path| {
             let doc = app.store.get(path);
@@ -989,11 +997,11 @@ pub fn draw_search_overlay(f: &mut Frame, app: &App, colors: &StatusPalette) {
             // engine matcher's indices so the on-screen feedback matches the
             // ranking (STORY-130). A body-only match yields no title indices, so
             // the row simply renders unhighlighted.
-            let matched: std::collections::HashSet<usize> =
-                crate::engine::store::match_indices(&app.search_query, title)
-                    .into_iter()
-                    .map(|i| i as usize)
-                    .collect();
+            let matched: std::collections::HashSet<usize> = index_matcher
+                .indices(title)
+                .into_iter()
+                .map(|i| i as usize)
+                .collect();
             let highlight = Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD);
@@ -1017,17 +1025,45 @@ pub fn draw_search_overlay(f: &mut Frame, app: &App, colors: &StatusPalette) {
         })
         .collect();
 
+    // While a search is in flight on the worker, the results title carries the
+    // shared loading face (same spinner machinery as the create form); it
+    // disappears when the matching-generation results land and clear
+    // `search_pending`.
+    let results_title = if app.search_pending {
+        let frame = crate::spinners::spinner("face")
+            .compact(crate::spinners::SpinnerState::Loading, app.frame_idx);
+        let style = super::colors::frame_style(frame.colour);
+        Line::from(vec![
+            Span::raw(" Results "),
+            Span::styled(frame.lines.join(""), style),
+            Span::raw(" "),
+        ])
+    } else {
+        Line::from(" Results ")
+    };
+
     let list = List::new(items)
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .title(" Results ")
+                .title(results_title)
                 .border_style(Style::default().fg(Color::DarkGray)),
         )
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    let mut state = ListState::default().with_selected(Some(app.search_selected));
+    // Items are a window slice, so the selection must be window-relative.
+    let mut state = ListState::default().with_selected(Some(app.search_selected - start));
     f.render_stateful_widget(list, layout[1], &mut state);
+}
+
+/// First visible index of a `window`-row view over a `len`-item list keeping
+/// `selected` visible: 0 until the selection passes the first window, then the
+/// selection rides the bottom edge, clamped so the last window is full.
+fn window_start(selected: usize, len: usize, window: usize) -> usize {
+    if window == 0 || len <= window {
+        return 0;
+    }
+    selected.saturating_sub(window - 1).min(len - window)
 }
 
 pub fn draw_gh_conflict(f: &mut Frame, app: &App) {
@@ -1118,5 +1154,47 @@ fn display_name(path: &std::path::Path) -> &str {
             .unwrap_or("?"),
         Some(name) => name,
         None => "?",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::window_start;
+
+    #[test]
+    fn window_start_zero_when_list_fits_in_window() {
+        assert_eq!(window_start(0, 4, 10), 0);
+        assert_eq!(window_start(3, 4, 10), 0);
+        assert_eq!(window_start(0, 10, 10), 0);
+    }
+
+    #[test]
+    fn window_start_zero_while_selection_within_first_window() {
+        assert_eq!(window_start(0, 100, 10), 0);
+        assert_eq!(window_start(9, 100, 10), 0);
+    }
+
+    #[test]
+    fn window_start_slides_to_keep_middle_selection_visible() {
+        assert_eq!(window_start(10, 100, 10), 1);
+        assert_eq!(window_start(50, 100, 10), 41);
+    }
+
+    #[test]
+    fn window_start_clamps_at_end_of_list() {
+        assert_eq!(window_start(99, 100, 10), 90);
+        assert_eq!(window_start(95, 100, 10), 86);
+    }
+
+    #[test]
+    fn window_start_of_one_tracks_selection_exactly() {
+        assert_eq!(window_start(0, 100, 1), 0);
+        assert_eq!(window_start(7, 100, 1), 7);
+        assert_eq!(window_start(99, 100, 1), 99);
+    }
+
+    #[test]
+    fn window_start_zero_when_window_is_zero() {
+        assert_eq!(window_start(5, 100, 0), 0);
     }
 }

--- a/tests/integration/store_test.rs
+++ b/tests/integration/store_test.rs
@@ -256,9 +256,13 @@ fn store_search_matches_tags() {
     let fixture = setup_fixture();
     let store = fixture.store();
 
+    // "events" is an exact tag on the ADR; under fuzzy matching it is also a
+    // subsequence of the RFC title ("event sourcing"), so both docs surface.
+    // The tag-carrying doc must be among the matches.
     let results = store.search("events", &lazyspec::engine::fs::RealFileSystem);
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].doc.title, "Adopt Event Sourcing");
+    assert!(results
+        .iter()
+        .any(|r| r.doc.title == "Adopt Event Sourcing"));
 }
 
 #[test]

--- a/tests/integration/tui_search_test.rs
+++ b/tests/integration/tui_search_test.rs
@@ -32,6 +32,33 @@ fn setup_app_with_docs() -> (TestFixture, App) {
     (fixture, app)
 }
 
+/// Search is async in production (BUG-011): `update_search` only dispatches to
+/// a worker. Drive the same sequence minus the thread: dispatch, run the
+/// corpus search inline the way the worker does, and apply under the live
+/// generation.
+fn run_search(app: &mut App) {
+    app.update_search();
+    if app.search_query.is_empty() {
+        return;
+    }
+    assert!(
+        app.search_pending,
+        "non-empty query must mark search in flight"
+    );
+    let results: Vec<PathBuf> = app
+        .store
+        .search_corpus(&*app.fs)
+        .search(&app.search_query)
+        .into_iter()
+        .map(|r| r.path)
+        .collect();
+    app.apply_search_results(app.search_generation, results);
+    assert!(
+        !app.search_pending,
+        "applied results must clear the pending flag"
+    );
+}
+
 #[test]
 fn test_enter_search() {
     let (_fixture, mut app) = setup_app_with_docs();
@@ -50,7 +77,7 @@ fn test_exit_search() {
 
     app.enter_search();
     app.search_query.push_str("alpha");
-    app.update_search();
+    run_search(&mut app);
     assert!(!app.search_results.is_empty());
 
     app.exit_search();
@@ -67,7 +94,7 @@ fn test_update_search_filters_by_title() {
 
     app.enter_search();
     app.search_query.push_str("unique");
-    app.update_search();
+    run_search(&mut app);
 
     assert_eq!(app.search_results.len(), 1);
     assert!(app.search_results[0]
@@ -81,13 +108,17 @@ fn test_update_search_empty_query_clears_results() {
 
     app.enter_search();
     app.search_query.push_str("alpha");
-    app.update_search();
+    run_search(&mut app);
     assert!(!app.search_results.is_empty());
 
     app.search_query.clear();
     app.update_search();
 
     assert!(app.search_results.is_empty());
+    assert!(
+        !app.search_pending,
+        "empty query clears synchronously without dispatching a search"
+    );
 }
 
 #[test]
@@ -96,13 +127,13 @@ fn test_update_search_resets_selected() {
 
     app.enter_search();
     app.search_query.push_str("rfc");
-    app.update_search();
+    run_search(&mut app);
     assert!(app.search_results.len() >= 2);
     app.search_selected = 1;
 
     app.search_query.clear();
     app.search_query.push_str("alpha");
-    app.update_search();
+    run_search(&mut app);
 
     assert_eq!(app.search_selected, 0);
 }
@@ -113,7 +144,7 @@ fn test_select_search_result_navigates_to_doc() {
 
     app.enter_search();
     app.search_query.push_str("unique");
-    app.update_search();
+    run_search(&mut app);
     assert_eq!(app.search_results.len(), 1);
 
     app.select_search_result();


### PR DESCRIPTION
## Why

Search matched literal substrings only, so a typo or partial term found nothing, and matches across title/tag/body carried no ranking (RFC-043). The TUI's search also ran synchronously on the UI thread, so it froze on every keystroke once a project had enough docs (BUG-011).

## What this enables

Title, tag, path, and body queries now match fuzzy subsequences via `nucleo`, scored and sorted best-match-first with a deterministic tie-break — one result per doc, not one per field. The TUI highlights the matched spans and runs search off the UI thread against a cached corpus, so typing stays responsive. `search --json` in the CLI now surfaces the numeric score and preserves that same ordering.

## Notes

Per lazyspec's spec-first workflow, this branch also carries forward-looking planning docs added ahead of implementation: two new bug reports (BUG-012, BUG-013), a comment-system RFC/story/iteration set (STORY-232–243, RFC-064, ITERATION-343/344), and a `clickup` doc type in `.lazyspec.toml`. None of these have corresponding code changes in this PR.

## Related

Implements RFC-043, STORY-129, STORY-130, STORY-131, ITERATION-340, ITERATION-341, ITERATION-342. Fixes BUG-011.
