### PR TITLE
feat(github): relationship-driven native sub-issues, ordinary relations on GitHub-authored issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Projects whose `[[types]]` predate the lifecycle axis can backfill the default l
 
 The relationship vocabulary is config-driven, just like document types. Each `[[relationships]]` block declares a relationship `name` and an optional `inverse` keyword. A directional relationship declares its inverse (for example `implements` / `implemented-by`); a relationship with no `inverse` is symmetric (for example `related-to`). `link`/`unlink` resolve the keyword you type against this registry: a canonical `name` links in the stated direction, while a declared `inverse` flips it and stores the canonical relation on the target. `validate` flags any document carrying a relationship name not declared here.
 
-A relationship may also declare `traversal`, which governs how it participates in context traversal: `chain` relationships form the parent-child hierarchy that `parent-child` validation rules and the context chain walk follow, while `related` relationships form the symmetric related-context neighbourhood. A relationship with no `traversal` participates in neither.
+A relationship may also declare `traversal`, which governs how it participates in context traversal: `chain` relationships form the parent-child hierarchy that `parent-child` validation rules and the context chain walk follow, while `related` relationships form the symmetric related-context neighbourhood. A relationship with no `traversal` participates in neither walk, but the target document's own declared relations still surface in the related section of `context` (and the TUI Relations tab) at one hop.
 
 ```toml
 [[relationships]]

--- a/docs/bugs/BUG-013-related-to-relations-missing-from-tui-relations-tab.md
+++ b/docs/bugs/BUG-013-related-to-relations-missing-from-tui-relations-tab.md
@@ -1,7 +1,7 @@
 ---
 title: "related-to relations missing from TUI Relations tab"
 type: bug
-status: reported
+status: fixed
 author: "unknown"
 date: 2026-07-21
 tags: []

--- a/docs/bugs/BUG-014-ordinary-relation-link-fails-on-github-issue-without-lazyspec-body-comment.md
+++ b/docs/bugs/BUG-014-ordinary-relation-link-fails-on-github-issue-without-lazyspec-body-comment.md
@@ -1,0 +1,65 @@
+---
+title: "ordinary relation link fails on github issue without lazyspec body comment"
+type: bug
+status: reported
+author: "jkaloger"
+date: 2026-07-24
+tags: []
+related: []
+---
+
+## Context
+
+Linking an ordinary (non-native) relation — e.g. `related-to` — on a github-issues doc whose remote issue body carries no lazyspec HTML comment fails hard:
+
+```
+$ lazyspec link PARENT-88 related-to PARENT-64
+Error: no lazyspec HTML comment found in issue body
+```
+
+Issues created directly on GitHub (empty or prose-only body) hit this. Native relations (`implements` via sub-issue, `blocks` via dependency, `targets` via milestone) work on the same issues because they bypass the body merge entirely — which makes the failure look like "related-to doesn't show up" rather than "link failed".
+
+## Root Cause
+
+Ordinary relations round-trip through the issue body. `GithubIssuesStore::merge_relation_to_remote` (`src/engine/store_dispatch.rs`) parses the remote body with a hard `?`:
+
+```rust
+let (mut remote_meta, remote_prose) = issue_body::deserialize(&remote_issue.body, &ctx)?;
+```
+
+`issue_body::deserialize` → `extract_comment` (`src/engine/issue_body.rs:351`) errors when the body has no `<!-- lazyspec ... -->` comment. Link aborts before the remote write AND before the cache mirror (push-first design), so the edge never exists anywhere — nothing in the TUI Relations tab, nothing in `context`.
+
+Causal chain:
+
+1. Issue authored on GitHub → body `null` or plain prose, no lazyspec comment.
+2. `lazyspec link A related-to B` → rel has no `github_native` → `merge_relation_to_remote`.
+3. `deserialize` fails → whole link errors → no remote edit, no cache frontmatter write.
+4. `unlink` dies on the same path. TUI link editor (`confirm_link`) surfaces the same error in `link_editor.error`.
+
+The fetch side already tolerates this: `parse_issue` (`src/engine/issue_cache.rs`) falls back to synthesizing meta from issue fields when `deserialize` fails. The write-merge side has no such fallback — asymmetric.
+
+Distinct from BUG-013 (traversal-marker gating in `resolve_chain`): here the relation is never persisted at all.
+
+## Expected vs Actual
+
+- **Expected:** linking an ordinary relation on any github-issues doc succeeds; the first lazyspec write adopts a GitHub-authored issue by adding the lazyspec comment, preserving the existing body as prose.
+- **Actual:** link/unlink error out on comment-less bodies; the relation is silently absent from every surface.
+
+## Repro
+
+1. Create an issue directly on GitHub (no lazyspec comment in body) under a github-issues type; `lazyspec fetch`.
+2. `lazyspec link <that-doc> related-to <any-doc>` → `Error: no lazyspec HTML comment found in issue body`.
+3. Relations tab / `lazyspec context` show nothing (edge never written).
+
+## Fix Direction
+
+In `merge_relation_to_remote`, fall back on deserialize failure: synthesize meta from remote issue fields (title/labels/state → type/tags/status, empty `related`) mirroring `parse_issue`'s fallback, treat the entire remote body as prose, then merge the edge and serialize. First ordinary link adopts the issue. Consider extracting the fallback shared with `parse_issue`. Check `push_cache`/`check_lock` and the clickup merge path for the same class of failure.
+
+## Acceptance Criteria
+
+- [ ] `link`/`unlink` of an ordinary relation succeeds on a github-issues doc whose remote body has no lazyspec comment.
+- [ ] The pre-existing remote body text is preserved as prose beneath the newly written comment.
+- [ ] Native-relation behaviour unchanged.
+- [ ] Test covers link + unlink against a comment-less remote body.
+- [ ] Full check green: `cargo fmt --check`, `cargo clippy`, `cargo test`.
+

--- a/docs/iterations/ITERATION-347-sub-issue-native-write-path-via-link-unlink.md
+++ b/docs/iterations/ITERATION-347-sub-issue-native-write-path-via-link-unlink.md
@@ -1,0 +1,46 @@
+---
+title: Sub-issue native write path via link/unlink
+type: iteration
+status: in-progress
+author: unknown
+date: 2026-07-24
+tags: []
+related:
+- implements: STORY-245
+- blocks: ITERATION-348
+---
+
+## Objective
+
+`link`/`unlink` write GitHub-native sub-issue edge for relationship with `github_native = "sub-issue"`.
+
+## Satisfies
+
+STORY-245 AC1 (link → addSubIssue), AC2 (unlink → removeSubIssue), AC3 (single-parent error), AC6 (opportunistic no-op), AC7 (config validation ≤1 sub-issue rel), AC8 (fake seam tests). AC4, AC5 deferred — see Out of scope.
+
+## Context
+
+- Story + design: STORY-245 (direction: source = child, target = parent)
+- Precedent to mirror: `apply_native_dependency` src/engine/ops/link.rs:355 (dispatch shape, opportunistic guard, resync return)
+- Mutations exist: `ADD_SUB_ISSUE_MUTATION` / `REMOVE_SUB_ISSUE_MUTATION` src/engine/gh_subissue.rs
+- Node ids: `IssueMap` src/engine/issue_map.rs (`node_id`, may be empty on legacy maps — treat empty as error telling user to re-fetch)
+- Config: `github_native: Option<String>` src/engine/config.rs:398, `relationship_by_github_native` config.rs:1246
+- Wire points: `link_inner` src/engine/ops/link.rs:99, unlink path link.rs:448, `resync_after_native_edge` link.rs:684
+- Convention: docs/convention (traits at I/O seams, fakes at seams only)
+
+## Tasks
+
+1. Config validation: reject config where >1 relationship declares `github_native = "sub-issue"` (STORY-245 AC7). Test first.
+2. `apply_native_subissue` in src/engine/ops/link.rs mirroring `apply_native_dependency`: guard (rel is sub-issue native + both endpoints same-repo github-issues), resolve node ids from IssueMap, link → `addSubIssue(issueId: target-node, subIssueId: source-node)`, unlink → `removeSubIssue`, return `true` → resync. Fake at `GhGraphql` seam, test-first.
+3. Single-parent guard: before addSubIssue, query child's existing parent (GraphQL `parent` field on Issue); if set and ≠ target, fail naming existing parent, no mutation (AC3).
+4. Wire into `link_inner` + unlink path. Opportunistic fall-through tests: filesystem/cross-store endpoints → no native call, relation recorded (AC6).
+
+## Out of scope
+
+- Fetch read-back (STORY-245 AC4, AC5) → next iteration.
+- Subdir-structural path changes — none.
+- Reparent semantics — explicit non-goal in STORY-245.
+
+## Verification
+
+Empty `node_id` in issue map → clear error, no mutation. Config with `implements` sub-issue-native + filesystem-only docs → all existing tests green (regression-free).

--- a/docs/iterations/ITERATION-347-sub-issue-native-write-path-via-link-unlink.md
+++ b/docs/iterations/ITERATION-347-sub-issue-native-write-path-via-link-unlink.md
@@ -1,7 +1,7 @@
 ---
 title: Sub-issue native write path via link/unlink
 type: iteration
-status: in-progress
+status: complete
 author: unknown
 date: 2026-07-24
 tags: []

--- a/docs/iterations/ITERATION-348-sub-issue-read-back-on-fetch-for-flat-docs.md
+++ b/docs/iterations/ITERATION-348-sub-issue-read-back-on-fetch-for-flat-docs.md
@@ -1,0 +1,42 @@
+---
+title: Sub-issue read-back on fetch for flat docs
+type: iteration
+status: in-progress
+author: unknown
+date: 2026-07-24
+tags: []
+related:
+- implements: STORY-245
+---
+
+## Objective
+
+`fetch` reads native sub-issue edges back as configured relation for flat (non-subdir) parents; subdir nesting unchanged.
+
+## Satisfies
+
+STORY-245 AC4 (flat docs → relation injection), AC5 (subdir parents still nest).
+
+## Context
+
+- Story + design: STORY-245 §Read path (split consumption by parent type)
+- Existing sub-issue fetch: `fetch_sub_issue_nodes_batch` + resolve src/engine/issue_cache.rs:646, nesting consumer issue_cache.rs:417 (ITERATION-224 behavior)
+- Precedent to mirror: dependency read-back (ITERATION-346, `relationship_by_github_native("dependency")` src/engine/issue_cache.rs:429)
+- Config lookup: `relationship_by_github_native("sub-issue")`, `subdirectory` flag on type defs
+- Prior write path: previous iteration (blocks this one)
+
+## Tasks
+
+1. Test-first: fake GraphQL returning sub-issue edges between two flat issue-docs → fetch injects configured relation (child forward, parent inverse), no subdir nesting (AC4).
+2. Split consumption in issue_cache: parent type `subdirectory: true` → nest (today); else if a rel declares `github_native = "sub-issue"` → inject relation; else → today's behavior.
+3. Regression test: subdir-type parent still materializes nested docs exactly as ITERATION-224 tests expect (AC5).
+4. Removal case: edge gone on remote → relation dropped on re-fetch, no duplicates (mirror dependency read-back drop tests).
+
+## Out of scope
+
+- Write path — previous iteration.
+- Nesting-to-relation migration for existing caches — fetch is authoritative, no migration.
+
+## Verification
+
+`show --json` / `status --json` reflect round-tripped relation with correct direction, no output-shape change.

--- a/docs/iterations/ITERATION-348-sub-issue-read-back-on-fetch-for-flat-docs.md
+++ b/docs/iterations/ITERATION-348-sub-issue-read-back-on-fetch-for-flat-docs.md
@@ -1,7 +1,7 @@
 ---
 title: Sub-issue read-back on fetch for flat docs
 type: iteration
-status: in-progress
+status: complete
 author: unknown
 date: 2026-07-24
 tags: []

--- a/docs/iterations/ITERATION-349-adopt-comment-less-github-issue-body-on-ordinary-relation-merge.md
+++ b/docs/iterations/ITERATION-349-adopt-comment-less-github-issue-body-on-ordinary-relation-merge.md
@@ -1,0 +1,46 @@
+---
+title: Adopt comment-less github issue body on ordinary relation merge
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-24
+tags: []
+related:
+- implements: STORY-246
+- related-to: BUG-014
+---
+
+## Objective
+
+`link`/`unlink` of ordinary relation succeed on github-issues doc with comment-less remote body — first write adopts issue, prose preserved.
+
+## Satisfies
+
+STORY-246 AC1–AC5 (single coupled slice: fallback + adopt + preserve).
+
+## Context
+
+- Story + design: STORY-246 §Design
+- Root cause + repro: BUG-014
+- Fix site: `merge_relation_to_remote` src/engine/store_dispatch.rs (hard `?` on `issue_body::deserialize`)
+- Fallback precedent to mirror: `parse_issue` src/engine/issue_cache.rs:853 (deserialize fail → synthesized meta, whole body = prose)
+- Deserialize/error origin: `extract_comment` src/engine/issue_body.rs:351
+- Convention: principle 6 — extract shared fallback helper only if two call sites fall out naturally
+
+## Tasks
+
+1. Test-first (MockGhClient): remote body `null`/empty → link merges relation, `issue_edit` body carries lazyspec comment + relation (AC1).
+2. Test: remote body prose-only, no comment → link succeeds, prose verbatim under new comment (AC3).
+3. Test: unlink same relation on adopted issue → relation removed from comment + cache (AC2).
+4. Impl: in `merge_relation_to_remote`, deserialize failure → fallback meta from remote issue fields (title/labels→type+tags, state→lifecycle status, created date, empty related), body = prose; then existing delta+serialize path.
+5. Regression: native rel link/unlink tests untouched/green (AC4).
+
+## Out of scope
+
+- clickup merge path, `push_cache`/`check_lock` same-class audit — follow-up if affected (story §Design).
+- Fetch side — already tolerant.
+
+## Verification
+
+Live repro from BUG-014: `lazyspec link PARENT-88 related-to PARENT-64` succeeds; relation in `context --json` + Relations tab. Full check: `cargo fmt --check`, `cargo clippy`, `cargo test`.
+

--- a/docs/iterations/ITERATION-350-relations-tab-and-context-surface-declared-related-list-ungated.md
+++ b/docs/iterations/ITERATION-350-relations-tab-and-context-surface-declared-related-list-ungated.md
@@ -1,0 +1,46 @@
+---
+title: Relations tab and context surface declared related list ungated
+type: iteration
+status: complete
+author: jkaloger
+date: 2026-07-24
+tags: []
+related:
+- implements: BUG-013
+---
+
+## Objective
+
+TUI Relations tab + CLI `context` show every declared relation from `doc.related` — no traversal-marker gate — matching web view.
+
+## Satisfies
+
+BUG-013 AC1–AC6 (single coupled slice: TUI + CLI parity + tests).
+
+## Context
+
+- Root cause + repro + fix direction (a): BUG-013 §Root Cause, §Fix Direction
+- Gate being bypassed: related BFS filter src/engine/context.rs:126-129, :137-140; `store.related_relationships` src/engine/store.rs:120-125
+- TUI gather to change: `relation_sections()` src/tui/state/app.rs:2322-2350 (reads only `resolve_chain` output)
+- CLI gather to change: src/cli/context.rs:16,329 (prints `resolved.related` :363-373)
+- Pattern to match: web builds from `doc.related` directly, src/web/render.rs:192-199
+- Render side untouched: `render_relationship_sections` src/tui/views/panels.rs:1224-1334
+- Convention: principle 6 — TUI + CLI = two call sites, shared engine helper justified
+
+## Tasks
+
+1. Test-first (state-level): doc with `related-to`, config WITHOUT `traversal = "related"` → `relation_sections()` includes it. Fails on current code.
+2. Test: same relation WITH traversal marker → appears once, no duplicate against BFS-derived related.
+3. Impl: engine helper merging `doc.related` (declared, all rel types) into related output, dedupe by (rel_type, id); consume from `relation_sections()`. Do NOT widen `resolve_chain` BFS itself — web layers `doc.related` separately and would double up.
+4. CLI `context`: consume same helper; declared relations in text + `--json` output.
+5. Regression: existing chain/children/traversal-related context tests green (AC4).
+
+## Out of scope
+
+- Fix direction (b) implicit-Related fallback in `store.related_relationships` — rejected, bug §Fix Direction.
+- Web view — already correct.
+- Config validation warning for unmarked relationships — separate concern if wanted.
+
+## Verification
+
+Repro from BUG-013 §Repro: strip `traversal = "related"` from `related-to` in config → relation visible in Relations tab + `context --json`. Full check: `cargo fmt --check`, `cargo clippy`, `cargo test`.

--- a/docs/stories/STORY-245-relationship-driven-github-native-sub-issues.md
+++ b/docs/stories/STORY-245-relationship-driven-github-native-sub-issues.md
@@ -1,0 +1,72 @@
+---
+title: Relationship-driven GitHub-native sub-issues
+type: story
+status: in-progress
+author: unknown
+date: 2026-07-24
+tags: []
+related:
+- implements: RFC-050
+---
+
+## Problem
+
+GitHub native sub-issue edges bind only to subdir structure: `index.md` parent + sibling child `.md` files (`gh_subissue.rs` reconciles from directory layout; `ops/create.rs` nests at create time). A flat two-type model — e.g. `feature` docs and `story` docs, every story a sub-issue of its feature — cannot produce native sub-issue edges at all. `github_native = "sub-issue"` parses and round-trips through config, but no link path consumes it: `relationship_by_github_native` is only ever called with `"milestone"` and `"dependency"`.
+
+Result: teams organizing github-issues docs by relationship (`STORY implements FEATURE`) get no native parent/child nesting on GitHub — the hierarchy the board, tracking UI, and progress bars read from stays empty. STORY-244 already made this move for `blocks` → native dependencies; this story extends the same opportunistic-native pattern to sub-issues.
+
+## Goal
+
+Any `[[relationships]]` entry may declare `github_native = "sub-issue"`. When both endpoints are same-repo github-issues docs, `lazyspec link CHILD <rel> PARENT` writes the native sub-issue edge (**source = child, target = parent**: `STORY-A implements FEATURE-A` → `addSubIssue(issueId: feature, subIssueId: story)`), `unlink` removes it, and `fetch` reads native sub-issue edges back as the configured relation. Everywhere else — filesystem docs, cross-store, cross-repo — the relation stays comment/graph-backed with no native call and no error. No new CLI command.
+
+## Design
+
+### Opportunistic native, mirroring STORY-244
+
+Same model as `github_native = "dependency"`: universal semantic relation gains an optional native edge. Fires only when both endpoints resolve to github-issues docs (same repo under lazyspec's one-repo-per-store model); otherwise a silent comment/graph-backed no-op. Existing filesystem usage regression-free.
+
+### Config
+
+`github_native = "sub-issue"` on the chosen relationship (e.g. `implements`). Field and parse already exist. New config validation: **at most one relationship may declare `github_native = "sub-issue"`** — GitHub sub-issues are single-parent, two competing relations would fight over the edge.
+
+### Write path — link / unlink
+
+`apply_native_subissue` alongside `apply_native_dependency` (src/engine/ops/link.rs), wired into `link_inner` and the unlink path. Reuses `ADD_SUB_ISSUE_MUTATION` / `REMOVE_SUB_ISSUE_MUTATION` from src/engine/gh_subissue.rs via the existing `GhGraphql` seam (sub-issues are GraphQL-only; node ids from the issue map / cache). Returns `true` on a native call so the caller routes through `resync_after_native_edge`.
+
+**Single-parent enforcement:** linking a child that already has a native parent fails with a clear error naming the existing parent — no silent reparent. Reparenting is `unlink` old, `link` new.
+
+### Read path — fetch
+
+Fetch already batch-resolves native sub-issue edges (`fetch_sub_issue_nodes_batch`, src/engine/issue_cache.rs) to materialize subdir nesting. Split that consumption by parent type:
+
+- Parent doc's type has `subdirectory: true` → materialize as nested subdir docs (today's behavior, ITERATION-224).
+- Otherwise, and a relationship declares `github_native = "sub-issue"` → inject the relation (child → parent via the configured name, inverse on the parent), mirroring dependency read-back.
+- Neither → current behavior (nest), preserving back-compat for configs with no sub-issue relationship.
+
+### Coexistence with subdir path
+
+Subdir-structural reconcile (`reconcile_subissues` keyed off `materialize_subdir`) is untouched and remains the authority for `subdirectory: true` types. Relationship path handles flat docs only. The two writers are mutually exclusive by parent type, so no double-write.
+
+### Surfaces
+
+Engine owns dispatch + read-back; CLI `link`/`unlink` route through `link_inner` (no CLI surface change beyond behavior); TUI link/unlink and web view inherit the native edge through the same engine path. `show --json` / `status --json` reflect round-tripped relations with no output-shape change.
+
+## Non-goals
+
+- Reparenting semantics (`replaceParent`) — explicit unlink+link only.
+- Cross-repo sub-issues — GitHub permits same-owner cross-repo, lazyspec's one-repo-per-store model does not; stays comment-backed.
+- Changing subdir-structural sub-issue behavior — untouched.
+- Native binding for other semantic relations — only the one configured relationship.
+- Conflict detection on native writes — inherits last-write-wins + resync.
+- New CLI command or flag.
+
+## Acceptance criteria
+
+- **Given** a relationship (e.g. `implements`) configured with `github_native = "sub-issue"` and two same-repo github-issues docs STORY-A, FEATURE-A, **when** `lazyspec link STORY-A implements FEATURE-A` runs, **then** STORY-A becomes a native sub-issue of FEATURE-A (`addSubIssue`), the relation is recorded, and affected issue caches resync.
+- **Given** the same, **when** `lazyspec unlink STORY-A implements FEATURE-A` runs, **then** the native sub-issue edge is removed and the relation record dropped.
+- **Given** STORY-A already a native sub-issue of FEATURE-A, **when** `lazyspec link STORY-A implements FEATURE-B` runs, **then** the command fails with an error naming FEATURE-A as the existing parent and no native mutation fires.
+- **Given** a native sub-issue edge set on GitHub out-of-band between two flat (non-subdir) issue-docs, **when** `lazyspec fetch` runs, **then** it surfaces as the configured relation with correct direction (child holds the forward relation, parent the inverse) in `show --json` / `status --json`, not as subdir nesting.
+- **Given** a subdir-type parent, **when** `fetch` runs, **then** sub-issues still materialize as nested subdir docs exactly as today.
+- **Given** a link where either endpoint is a filesystem doc, cross-store, or cross-repo, **when** `link`/`unlink` runs, **then** no native call fires, the relation is recorded comment/graph-backed, no error.
+- **Given** two relationships both declaring `github_native = "sub-issue"`, **when** config loads, **then** validation rejects it with a clear message.
+- **Given** the native write path, **then** it is exercised through a fake at the `GhGraphql` seam (no live GitHub in tests), consistent with dependency/membership tests.

--- a/docs/stories/STORY-245-relationship-driven-github-native-sub-issues.md
+++ b/docs/stories/STORY-245-relationship-driven-github-native-sub-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Relationship-driven GitHub-native sub-issues
 type: story
-status: in-progress
+status: complete
 author: unknown
 date: 2026-07-24
 tags: []

--- a/docs/stories/STORY-246-link-ordinary-relations-on-github-authored-issues.md
+++ b/docs/stories/STORY-246-link-ordinary-relations-on-github-authored-issues.md
@@ -1,0 +1,40 @@
+---
+title: Link ordinary relations on GitHub-authored issues
+type: story
+status: draft
+author: jkaloger
+date: 2026-07-24
+tags: []
+related:
+- related-to: BUG-014
+---
+
+## Problem
+
+As a user linking docs, I can't add an ordinary relation (`related-to`, `supersedes`, …) to a github-issues doc whose issue was authored directly on GitHub. The remote body has no lazyspec HTML comment, and the body-merge write path (`GithubIssuesStore::merge_relation_to_remote`) hard-fails on `issue_body::deserialize`:
+
+```
+$ lazyspec link PARENT-88 related-to PARENT-64
+Error: no lazyspec HTML comment found in issue body
+```
+
+The link aborts before the remote write and before the cache mirror, so the relation exists nowhere — Relations tab and `context` show nothing. Native relations (sub-issue, dependency, milestone) work on the same issues because they bypass the body, which disguises the failure as "related-to doesn't show up". The fetch side already tolerates comment-less bodies (`parse_issue` falls back to synthesized meta); the write side doesn't. Root cause in BUG-014.
+
+## Goal
+
+Linking or unlinking an ordinary relation on any github-issues doc succeeds regardless of whether the remote body carries a lazyspec comment. The first lazyspec write **adopts** a GitHub-authored issue: it writes the lazyspec comment with the merged relation and preserves the entire pre-existing body as prose beneath it. Behaviour is identical from CLI `link`/`unlink` and the TUI link editor (both share `ops::link`).
+
+## Design
+
+In `merge_relation_to_remote` (src/engine/store_dispatch.rs), when `issue_body::deserialize` fails, fall back the way `parse_issue` (src/engine/issue_cache.rs) does: synthesize `DocMeta` from the remote issue's fields (title, labels → type/tags, open/closed → lifecycle status, created date, empty `related`), and treat the whole remote body as prose. Then apply the relation delta and serialize as normal. Extract the fallback shared with `parse_issue` only if it falls out naturally — two call sites justify it (convention principle 6).
+
+Out of scope: the clickup merge path and `push_cache`/`check_lock` — audit them for the same failure class and file follow-ups if affected, but don't bundle fixes here.
+
+## Acceptance Criteria
+
+- [ ] Given a github-issues doc whose remote body is empty or prose-only (no lazyspec comment), when I `lazyspec link <doc> related-to <other>`, then the link succeeds, the remote body gains a lazyspec comment carrying the relation, and the relation appears in `context --json` and the TUI Relations tab.
+- [ ] Given that adopted issue, when I `lazyspec unlink` the same relation, then the unlink succeeds and the relation is removed from the remote comment and the cache.
+- [ ] Given a remote body with pre-existing prose and no comment, when the first ordinary link lands, then the prose is preserved verbatim beneath the new comment.
+- [ ] Native-relation link/unlink behaviour is unchanged.
+- [ ] Full check green: `cargo fmt --check`, `cargo clippy`, `cargo test`.
+

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -9,11 +9,12 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 pub use crate::engine::context::{
-    resolve_chain, resolve_forest, ContextNode, RelatedRef, ResolvedContext,
+    merge_declared_related, resolve_chain, resolve_forest, ContextNode, RelatedRef, ResolvedContext,
 };
 
 pub fn run_json(store: &Store, id: &str, depth: usize) -> Result<String> {
-    let resolved = resolve_chain(store, id, depth)?;
+    let mut resolved = resolve_chain(store, id, depth)?;
+    merge_declared_related(store, &mut resolved);
     let chain: Vec<_> = resolved
         .nodes
         .iter()
@@ -326,7 +327,8 @@ pub fn run_forest_human(store: &Store, anchor: Option<&str>) -> Result<String> {
 }
 
 pub fn run_human(store: &Store, id: &str, depth: usize) -> Result<String> {
-    let resolved = resolve_chain(store, id, depth)?;
+    let mut resolved = resolve_chain(store, id, depth)?;
+    merge_declared_related(store, &mut resolved);
     let colors = StatusColors::load(store.root()).unwrap_or_default();
     let mut output = String::new();
 

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -1090,6 +1090,19 @@ impl Config {
             ),
         };
 
+        let sub_issue_rels: Vec<&str> = relationships
+            .iter()
+            .filter(|r| r.github_native.as_deref() == Some("sub-issue"))
+            .map(|r| r.name.as_str())
+            .collect();
+        if sub_issue_rels.len() > 1 {
+            bail!(
+                "at most one relationship may declare github_native = \"sub-issue\" \
+                 (GitHub sub-issues are single-parent); found {}",
+                sub_issue_rels.join(", ")
+            );
+        }
+
         let rules = raw.rules.unwrap_or_default();
 
         let any_sqids = types
@@ -1861,6 +1874,67 @@ name = "related-to"
         assert!(
             emitted.contains("github_native = \"membership\""),
             "{emitted}"
+        );
+    }
+
+    // STORY-245 AC7: at most one relationship may declare
+    // github_native = "sub-issue" -- GitHub sub-issues are single-parent, so two
+    // competing relations would fight over the edge. Config load must reject it
+    // with a message naming both offending relationships.
+    #[test]
+    fn two_sub_issue_native_relationships_rejected() {
+        let toml_str = r#"
+[[types]]
+name = "story"
+plural = "stories"
+dir = "docs/stories"
+prefix = "STORY"
+
+[[relationships]]
+name = "implements"
+inverse = "implemented-by"
+github_native = "sub-issue"
+
+[[relationships]]
+name = "parent-of"
+inverse = "child-of"
+github_native = "sub-issue"
+"#;
+        let err = Config::parse(toml_str).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("sub-issue"),
+            "error should mention sub-issue, got: {msg}"
+        );
+        assert!(
+            msg.contains("implements") && msg.contains("parent-of"),
+            "error should name both offending relationships, got: {msg}"
+        );
+    }
+
+    // A single sub-issue-native relationship is fine.
+    #[test]
+    fn one_sub_issue_native_relationship_ok() {
+        let toml_str = r#"
+[[types]]
+name = "story"
+plural = "stories"
+dir = "docs/stories"
+prefix = "STORY"
+
+[[relationships]]
+name = "implements"
+inverse = "implemented-by"
+github_native = "sub-issue"
+"#;
+        let config = Config::parse(toml_str).unwrap();
+        assert_eq!(
+            config
+                .relationship_by_name("implements")
+                .unwrap()
+                .github_native
+                .as_deref(),
+            Some("sub-issue")
         );
     }
 

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -175,6 +175,44 @@ pub fn resolve_chain<'a>(store: &'a Store, id: &str, depth: usize) -> Result<Res
     })
 }
 
+/// Merge the target's own declared relations into `resolved.related`, so
+/// relations whose type carries no traversal marker still surface (BUG-013).
+/// Chain-typed relations and targets already on the chain stay excluded --
+/// they belong to the chain/forward sections -- and entries the related BFS
+/// already found dedupe on (relation type, target path). Callers that layer
+/// `doc.related` themselves (the web view) must not call this.
+pub fn merge_declared_related<'a>(store: &'a Store, resolved: &mut ResolvedContext<'a>) {
+    let chain_paths: HashSet<&PathBuf> = resolved.nodes.iter().map(|n| &n.doc.path).collect();
+    let mut seen: HashSet<(String, PathBuf)> = resolved
+        .related
+        .iter()
+        .map(|r| (r.relation.to_string(), r.doc.path.clone()))
+        .collect();
+
+    let target = resolved.target;
+    let declared: Vec<RelatedRef<'a>> = target
+        .related
+        .iter()
+        .filter(|rel| {
+            !store
+                .chain_relationships
+                .iter()
+                .any(|c| c.as_str() == rel.rel_type.as_str())
+        })
+        .filter_map(|rel| store.resolve_relation_target(&rel.target).map(|d| (rel, d)))
+        .filter(|(_, d)| !chain_paths.contains(&d.path))
+        .filter(|(rel, d)| seen.insert((rel.rel_type.to_string(), d.path.clone())))
+        .map(|(rel, d)| RelatedRef {
+            doc: d,
+            relation: rel.rel_type.clone(),
+            distance: 1,
+            via: target.path.clone(),
+        })
+        .collect();
+
+    resolved.related.extend(declared);
+}
+
 /// Context forest, roots-first. When `anchor` is `None`, discovers every
 /// document and, for each, its in-graph parents (resolved via
 /// [`Store::resolve_relation_target`] over the configured parent-child
@@ -722,6 +760,87 @@ mod tests {
         assert!(
             resolved.related.is_empty(),
             "no related markers => no related"
+        );
+    }
+
+    // --- merge_declared_related ---------------------------------------------
+
+    #[test]
+    fn merge_declared_related_surfaces_relation_without_traversal_marker() {
+        // `blocks` carries no traversal marker in the starter config, so the
+        // related BFS drops it; the merge must surface it, rel type intact.
+        let (_tmp, store) = store_from(&[
+            (
+                "docs/rfcs/RFC-001-anchor.md",
+                &doc_md("Anchor", "rfc", "- blocks: RFC-002"),
+            ),
+            ("docs/rfcs/RFC-002-near.md", &doc_md("Near", "rfc", "[]")),
+        ]);
+
+        let mut resolved = resolve_chain(&store, "RFC-001", 1).unwrap();
+        assert!(resolved.related.is_empty(), "BFS drops unmarked relations");
+
+        merge_declared_related(&store, &mut resolved);
+
+        assert_eq!(resolved.related.len(), 1);
+        assert_eq!(resolved.related[0].doc.id, "RFC-002");
+        assert_eq!(resolved.related[0].relation.as_str(), "blocks");
+        assert_eq!(resolved.related[0].distance, 1);
+    }
+
+    #[test]
+    fn merge_declared_related_dedupes_on_relation_type_and_target() {
+        // RFC-002 is declared under both `related-to` (already found by the
+        // BFS) and `blocks` (unmarked): the merge must not re-add the BFS
+        // entry, but the second rel type is its own entry.
+        let (_tmp, store) = store_from(&[
+            (
+                "docs/rfcs/RFC-001-anchor.md",
+                &doc_md("Anchor", "rfc", "- related-to: RFC-002\n- blocks: RFC-002"),
+            ),
+            ("docs/rfcs/RFC-002-near.md", &doc_md("Near", "rfc", "[]")),
+        ]);
+
+        let mut resolved = resolve_chain(&store, "RFC-001", 1).unwrap();
+        merge_declared_related(&store, &mut resolved);
+
+        let pairs: Vec<(String, String)> = resolved
+            .related
+            .iter()
+            .map(|r| (r.relation.to_string(), r.doc.id.clone()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("related-to".to_string(), "RFC-002".to_string()),
+                ("blocks".to_string(), "RFC-002".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_declared_related_skips_chain_relations_and_chain_members() {
+        // `implements: RFC-001` is a chain relation (already in nodes) and a
+        // declared `related-to` pointing at a chain member is skipped too, so
+        // the related section stays disjoint from the chain.
+        let (_tmp, store) = store_from(&[
+            ("docs/rfcs/RFC-001-base.md", &doc_md("Base", "rfc", "[]")),
+            (
+                "docs/stories/STORY-001-mid.md",
+                &doc_md(
+                    "Mid",
+                    "story",
+                    "- implements: RFC-001\n- related-to: RFC-001",
+                ),
+            ),
+        ]);
+
+        let mut resolved = resolve_chain(&store, "STORY-001", 1).unwrap();
+        merge_declared_related(&store, &mut resolved);
+
+        assert!(
+            resolved.related.is_empty(),
+            "chain relations and chain members must not leak into related"
         );
     }
 

--- a/src/engine/gh_subissue.rs
+++ b/src/engine/gh_subissue.rs
@@ -43,6 +43,13 @@ const SUB_ISSUES_QUERY: &str =
 const SUB_ISSUES_BATCH_QUERY: &str =
     "query($ids: [ID!]!) { nodes(ids: $ids) { ... on Issue { id subIssues(first: 100) { nodes { id } } } } }";
 
+/// Batched read of each child issue's native sub-issue PARENT number via
+/// `nodes(ids:)`. The mirror image of [`SUB_ISSUES_BATCH_QUERY`]: it walks the
+/// `parent` edge (child -> parent) so a flat doc can read back which issue it is
+/// a sub-issue of. `parent` is `null` for top-level issues.
+const SUB_ISSUE_PARENT_BATCH_QUERY: &str =
+    "query($ids: [ID!]!) { nodes(ids: $ids) { ... on Issue { id parent { number } } } }";
+
 /// GitHub caps a single `nodes(ids:)` selection at 100 ids.
 pub const SUB_ISSUE_BATCH_MAX: usize = 100;
 
@@ -208,6 +215,36 @@ pub fn fetch_sub_issue_nodes_batch(
     Ok(out)
 }
 
+/// Resolve the native sub-issue PARENT issue number for up to
+/// [`SUB_ISSUE_BATCH_MAX`] child issues in one query. Returns `child_node ->
+/// parent number`, omitting children with no parent (top-level issues) so a
+/// caller can tell "no parent" from "not queried". Numbers (not node ids) are
+/// returned so read-back resolves parents by number via the issue map, exactly
+/// as the native dependency read-back does.
+pub fn fetch_sub_issue_parent_numbers_batch(
+    gql: &dyn GhGraphql,
+    child_nodes: &[String],
+) -> Result<HashMap<String, u64>> {
+    debug_assert!(child_nodes.len() <= SUB_ISSUE_BATCH_MAX);
+    let resp = gql.graphql(
+        SUB_ISSUE_PARENT_BATCH_QUERY,
+        &[("ids", GqlVar::StrList(child_nodes.to_vec()))],
+    )?;
+    let mut out = HashMap::new();
+    let Some(nodes) = resp.pointer("/data/nodes").and_then(|v| v.as_array()) else {
+        return Ok(out);
+    };
+    for node in nodes {
+        let Some(child) = node.get("id").and_then(|i| i.as_str()) else {
+            continue;
+        };
+        if let Some(number) = node.pointer("/parent/number").and_then(|n| n.as_u64()) {
+            out.insert(child.to_string(), number);
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,6 +393,28 @@ mod tests {
         let first = &repris[0].1;
         assert!(first.contains(&("subIssueId".to_string(), GqlVar::Str("I_a".to_string()))));
         assert!(first.contains(&("afterId".to_string(), GqlVar::Str(String::new()))));
+    }
+
+    // Read-back: children with a parent map to that parent's number; a
+    // parentless (top-level) issue is omitted so callers can tell it apart.
+    #[test]
+    fn parent_numbers_batch_maps_children_and_omits_parentless() {
+        let resp = serde_json::json!({
+            "data": { "nodes": [
+                {"id": "I_child", "parent": {"number": 100}},
+                {"id": "I_top", "parent": null},
+            ]}
+        });
+        let client = MockGhClient::new().with_graphql_responses(vec![resp]);
+
+        let out = fetch_sub_issue_parent_numbers_batch(
+            &client,
+            &["I_child".to_string(), "I_top".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(out.get("I_child"), Some(&100));
+        assert!(!out.contains_key("I_top"), "parentless issue omitted");
     }
 
     // Already-correct order issues no reprioritize (and no add/remove).

--- a/src/engine/gh_subissue.rs
+++ b/src/engine/gh_subissue.rs
@@ -46,9 +46,9 @@ const SUB_ISSUES_BATCH_QUERY: &str =
 /// GitHub caps a single `nodes(ids:)` selection at 100 ids.
 pub const SUB_ISSUE_BATCH_MAX: usize = 100;
 
-const ADD_SUB_ISSUE_MUTATION: &str = "mutation($issueId: ID!, $subIssueId: ID!) { addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) { issue { id } } }";
+pub(crate) const ADD_SUB_ISSUE_MUTATION: &str = "mutation($issueId: ID!, $subIssueId: ID!) { addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) { issue { id } } }";
 
-const REMOVE_SUB_ISSUE_MUTATION: &str = "mutation($issueId: ID!, $subIssueId: ID!) { removeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) { issue { id } } }";
+pub(crate) const REMOVE_SUB_ISSUE_MUTATION: &str = "mutation($issueId: ID!, $subIssueId: ID!) { removeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) { issue { id } } }";
 
 const REPRIORITIZE_SUB_ISSUE_MUTATION: &str = "mutation($issueId: ID!, $subIssueId: ID!, $afterId: ID!) { reprioritizeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId, afterId: $afterId}) { issue { id } } }";
 

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -858,25 +858,42 @@ fn parse_issue(
         return (meta, body);
     }
 
-    let status = if issue.state.eq_ignore_ascii_case("open") {
-        Status::new(open_status)
+    let mut meta = fallback_meta(issue, &ctx);
+    insert_issue_type(&mut meta, issue);
+    inject_milestone_target(&mut meta, issue, milestone_rel, issue_map);
+    inject_assignee(&mut meta, issue);
+
+    (meta, issue.body.clone())
+}
+
+/// Meta synthesized from the remote issue's own fields, for bodies that carry
+/// no lazyspec HTML comment (e.g. GitHub-authored issues): labels drive type +
+/// tags, open/closed state drives the lifecycle status, and `related` starts
+/// empty.
+pub(crate) fn fallback_meta(issue: &GhIssue, ctx: &IssueContext) -> DocMeta {
+    let status = if ctx.is_open {
+        Status::new(&ctx.open_status)
     } else {
-        Status::new(closed_status)
+        Status::new(&ctx.closed_status)
     };
 
     let (doc_type, tags) = issue_body::extract_type_and_tags(
         &ctx.labels,
-        known_types,
+        &ctx.known_types,
         issue.issue_type.as_deref(),
-        type_name,
+        &ctx.default_type,
     );
 
-    let mut meta = DocMeta {
+    DocMeta {
         path: PathBuf::new(),
         title: issue.title.clone(),
         doc_type,
         status,
-        author: author.clone(),
+        author: issue
+            .author
+            .as_ref()
+            .map(|a| format!("@{}", a.login))
+            .unwrap_or_else(|| "unknown".to_string()),
         date: parse_created_date(&issue.created_at),
         tags,
         provenance: vec![],
@@ -886,12 +903,7 @@ fn parse_issue(
         assignee: None,
         attributes: Default::default(),
         id: String::new(),
-    };
-    insert_issue_type(&mut meta, issue);
-    inject_milestone_target(&mut meta, issue, milestone_rel, issue_map);
-    inject_assignee(&mut meta, issue);
-
-    (meta, issue.body.clone())
+    }
 }
 
 /// Surface an issue's native GitHub milestone as a forward relation (the

--- a/src/engine/issue_cache.rs
+++ b/src/engine/issue_cache.rs
@@ -414,11 +414,25 @@ impl IssueCache {
             parsed.push(Parsed { id, meta, body });
         }
 
+        // Native sub-issue edges split by this type's shape. A flat (non-subdir)
+        // type with a sub-issue-native relationship reads the edge back as that
+        // relation (child holds the forward name toward its parent) instead of
+        // nesting; every other type keeps materializing nested docs
+        // (ITERATION-224). The two are mutually exclusive, so nesting is skipped
+        // entirely in relation-injection mode.
+        let subissue_rel = config.relationship_by_github_native("sub-issue");
+        let inject_subissue_relation = subissue_rel.is_some() && !type_def.subdirectory;
+
         // Best-effort: learn remote native sub-issue parentage so we can write
         // the nested cache layout. A GraphQL failure warns and falls back to a
         // flat layout for the affected parent; it never aborts the fetch.
-        let (parentage, subissue_warnings) = fetch_subissue_parentage(gh_graphql, &node_to_doc);
-        warnings.extend(subissue_warnings);
+        let parentage = if inject_subissue_relation {
+            ParentageMap::new()
+        } else {
+            let (parentage, subissue_warnings) = fetch_subissue_parentage(gh_graphql, &node_to_doc);
+            warnings.extend(subissue_warnings);
+            parentage
+        };
 
         // Best-effort: read each issue's native blocked-by dependencies and
         // inject the declared inverse relation (`blocked-by`) toward each
@@ -462,6 +476,42 @@ impl IssueCache {
                             target,
                         });
                     }
+                }
+            }
+        }
+
+        // Flat-doc read-back: inject the sub-issue-native relation on each child
+        // toward its remote parent (the forward name; the parent's inverse is
+        // derived in the graph, never stored -- mirrors the dependency path). A
+        // dropped remote edge simply yields no parent on re-fetch, so the
+        // relation vanishes with the authoritative rebuild, no duplicates.
+        if let Some(rel) = subissue_rel.filter(|_| inject_subissue_relation) {
+            let (parent_by_child, parent_warnings) =
+                fetch_subissue_parent_numbers(gh_graphql, &node_to_doc);
+            warnings.extend(parent_warnings);
+            // number -> doc id for the in-flight batch, so a same-type parent
+            // resolves before the batch is written into the issue map; cross-type
+            // parents resolve via the map once their type has fetched (the same
+            // ordering caveat milestones and dependencies carry).
+            let batch: std::collections::HashMap<u64, String> = issues
+                .iter()
+                .zip(parsed.iter())
+                .map(|(issue, p)| (issue.number, p.id.clone()))
+                .collect();
+            for (issue, p) in issues.iter().zip(parsed.iter_mut()) {
+                let Some(parent_number) = parent_by_child.get(&issue.id) else {
+                    continue;
+                };
+                let target = batch.get(parent_number).cloned().or_else(|| {
+                    issue_map
+                        .shorthand_for_number(*parent_number)
+                        .map(String::from)
+                });
+                if let Some(target) = target {
+                    p.meta.related.push(Relation {
+                        rel_type: RelationType::new(&rel.name),
+                        target,
+                    });
                 }
             }
         }
@@ -685,6 +735,32 @@ fn fetch_subissue_parentage(
             if !children.is_empty() {
                 map.insert(parent_doc.clone(), children);
             }
+        }
+    }
+    (map, warnings)
+}
+
+/// Best-effort batched read of each fetched issue's native sub-issue parent
+/// number, keyed by the child's node id. Chunked to `SUB_ISSUE_BATCH_MAX`; a
+/// chunk's GraphQL failure warns and skips that chunk rather than aborting the
+/// fetch. Feeds the flat-doc relation read-back, mirroring the dependency path.
+fn fetch_subissue_parent_numbers(
+    gh_graphql: &dyn GhGraphql,
+    node_to_doc: &std::collections::HashMap<String, String>,
+) -> (std::collections::HashMap<String, u64>, Vec<RefreshWarning>) {
+    let mut map = std::collections::HashMap::new();
+    let mut warnings = Vec::new();
+    let child_nodes: Vec<String> = node_to_doc.keys().cloned().collect();
+    for chunk in child_nodes.chunks(gh_subissue::SUB_ISSUE_BATCH_MAX) {
+        match gh_subissue::fetch_sub_issue_parent_numbers_batch(gh_graphql, chunk) {
+            Ok(m) => map.extend(m),
+            Err(e) => warnings.push(RefreshWarning {
+                message: format!(
+                    "could not read sub-issue parents for {} issues, skipping relation injection: {}",
+                    chunk.len(),
+                    e
+                ),
+            }),
         }
     }
     (map, warnings)
@@ -3687,6 +3763,291 @@ mod tests {
         let mut ids = cache.list_cached("story");
         ids.sort();
         assert_eq!(ids, vec!["STORY-100", "STORY-11"]);
+    }
+
+    // --- STORY-245: relationship read-back for flat (non-subdir) docs ---
+
+    /// GhIssueReader + GhGraphql fake for the flat-doc relation read-back path.
+    /// Answers the batched `parent { number }` query, mapping each requested
+    /// child node to its remote parent's issue number; a query without an `ids`
+    /// var is the schema-snapshot refresh and returns an empty issue-types
+    /// response. Mirrors `NestingReader` but walks the parent edge.
+    struct ParentReader {
+        issues: Vec<GhIssue>,
+        parent_number_by_node: std::collections::HashMap<String, u64>,
+    }
+
+    impl ParentReader {
+        fn new(issues: Vec<GhIssue>, parents: &[(&str, u64)]) -> Self {
+            Self {
+                issues,
+                parent_number_by_node: parents
+                    .iter()
+                    .map(|(node, num)| (node.to_string(), *num))
+                    .collect(),
+            }
+        }
+    }
+
+    impl GhIssueReader for ParentReader {
+        fn issue_list(
+            &self,
+            _repo: &str,
+            _labels: &[String],
+            _json_fields: &[String],
+            _limit: Option<u64>,
+        ) -> Result<Vec<GhIssue>> {
+            Ok(self.issues.clone())
+        }
+        fn issue_view(&self, _repo: &str, _number: u64) -> Result<GhIssue> {
+            unimplemented!()
+        }
+        fn issue_comments(
+            &self,
+            _repo: &str,
+            _number: u64,
+        ) -> Result<Vec<crate::engine::gh::GhComment>> {
+            unimplemented!()
+        }
+    }
+
+    impl GhGraphql for ParentReader {
+        fn graphql(&self, _query: &str, vars: &[(&str, GqlVar)]) -> Result<serde_json::Value> {
+            let ids = vars
+                .iter()
+                .find(|(k, _)| *k == "ids")
+                .and_then(|(_, v)| match v {
+                    GqlVar::StrList(l) => Some(l.clone()),
+                    _ => None,
+                });
+            let Some(ids) = ids else {
+                return Ok(empty_issue_types_response());
+            };
+            let nodes: Vec<serde_json::Value> = ids
+                .iter()
+                .map(|node| match self.parent_number_by_node.get(node) {
+                    Some(num) => serde_json::json!({"id": node, "parent": {"number": num}}),
+                    None => serde_json::json!({"id": node, "parent": null}),
+                })
+                .collect();
+            Ok(serde_json::json!({"data": {"nodes": nodes}}))
+        }
+        fn project_item_fields(
+            &self,
+            _repo: &str,
+            _content_node_id: &str,
+        ) -> Result<Vec<crate::engine::gh::ProjectFieldValue>> {
+            Ok(vec![])
+        }
+        fn update_project_v2_item_field_value(
+            &self,
+            _project_id: &str,
+            _item_id: &str,
+            _field_id: &str,
+            _value: &crate::engine::gh::GhFieldValueInput,
+        ) -> Result<()> {
+            Ok(())
+        }
+        fn clear_project_field(
+            &self,
+            _project_id: &str,
+            _item_id: &str,
+            _field_id: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    impl GhIssueDependencyApi for ParentReader {
+        fn list_blocked_by(&self, _repo: &str, _blocked_number: u64) -> Result<Vec<u64>> {
+            Ok(vec![])
+        }
+        fn add_blocked_by(&self, _repo: &str, _blocked: u64, _blocking: u64) -> Result<()> {
+            unimplemented!()
+        }
+        fn remove_blocked_by(&self, _repo: &str, _blocked: u64, _blocking: u64) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    fn subissue_relationship() -> crate::engine::config::RelationshipDef {
+        crate::engine::config::RelationshipDef {
+            name: "implements".to_string(),
+            inverse: Some("implemented-by".to_string()),
+            github_native: Some("sub-issue".to_string()),
+            traversal: None,
+        }
+    }
+
+    fn subdir_story_type_def() -> TypeDef {
+        TypeDef {
+            subdirectory: true,
+            ..story_type_def()
+        }
+    }
+
+    fn config_with_subissue_rel(type_def: TypeDef) -> Config {
+        let mut config = Config::default();
+        config.documents.types = vec![type_def];
+        config.relationships = vec![subissue_relationship()];
+        config
+    }
+
+    fn fetch_typed<R>(
+        cache: &IssueCache,
+        tmp: &TempDir,
+        gh: &R,
+        issue_map: &mut IssueMap,
+        type_def: TypeDef,
+        config: &Config,
+    ) -> FetchResult
+    where
+        R: GhIssueReader + GhGraphql + GhIssueDependencyApi,
+    {
+        cache
+            .fetch_all(
+                tmp.path(),
+                &type_def,
+                gh,
+                gh,
+                gh,
+                "owner/repo",
+                issue_map,
+                &[story_match_rule()],
+                config,
+            )
+            .unwrap()
+    }
+
+    // AC4: a native sub-issue edge between two flat docs reads back as the
+    // configured relation on the child (forward name toward its parent), and the
+    // docs stay flat -- no subdir nesting.
+    #[test]
+    fn fetch_injects_subissue_relation_on_flat_child_instead_of_nesting() {
+        let (cache, tmp) = make_cache();
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        // STORY-11 (I_a) is a native sub-issue of STORY-100 (#100).
+        let gh = ParentReader::new(
+            vec![issue_with_node(100, "I_parent"), issue_with_node(11, "I_a")],
+            &[("I_a", 100)],
+        );
+        let config = config_with_subissue_rel(story_type_def());
+        fetch_typed(&cache, &tmp, &gh, &mut issue_map, story_type_def(), &config);
+
+        let story_dir = tmp.path().join(".lazyspec/cache/story");
+        assert!(story_dir.join("STORY-11.md").is_file(), "child stays flat");
+        assert!(
+            story_dir.join("STORY-100.md").is_file(),
+            "parent stays flat"
+        );
+        assert!(
+            !story_dir.join("STORY-100").exists(),
+            "no nesting folder is created"
+        );
+
+        // The child carries the forward relation toward its parent.
+        let child = std::fs::read_to_string(story_dir.join("STORY-11.md")).unwrap();
+        assert!(
+            child.contains("implements: STORY-100"),
+            "child must carry the forward sub-issue relation, got:\n{child}"
+        );
+        // The parent stores nothing: its `implemented-by` inverse is virtual.
+        let parent = std::fs::read_to_string(story_dir.join("STORY-100.md")).unwrap();
+        assert!(
+            !parent.contains("implemented-by") && !parent.contains("implements:"),
+            "parent must not store the relation, got:\n{parent}"
+        );
+    }
+
+    // AC5: a subdir-type parent keeps materializing nested docs even when a
+    // sub-issue-native relationship is configured -- the subdir path wins.
+    #[test]
+    fn fetch_subdir_type_still_nests_even_with_subissue_relation() {
+        let (cache, tmp) = make_cache();
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let gh = NestingReader::new(
+            vec![issue_with_node(100, "I_parent"), issue_with_node(11, "I_a")],
+            &[("I_parent", &["I_a"])],
+        );
+        let config = config_with_subissue_rel(subdir_story_type_def());
+        fetch_typed(
+            &cache,
+            &tmp,
+            &gh,
+            &mut issue_map,
+            subdir_story_type_def(),
+            &config,
+        );
+
+        let story_dir = tmp.path().join(".lazyspec/cache/story");
+        assert!(
+            story_dir.join("STORY-100/index.md").is_file(),
+            "parent index.md materialized"
+        );
+        assert!(
+            story_dir.join("STORY-100/00-STORY-11.md").is_file(),
+            "child nested under parent"
+        );
+        // Nested, not related: no injected relation on the child.
+        let child = std::fs::read_to_string(story_dir.join("STORY-100/00-STORY-11.md")).unwrap();
+        assert!(
+            !child.contains("implements:"),
+            "subdir child must not carry an injected relation, got:\n{child}"
+        );
+    }
+
+    // AC4 (drop case): a native sub-issue edge removed on the remote drops the
+    // injected relation on re-fetch, with no duplicate cache entries.
+    #[test]
+    fn refetch_drops_subissue_relation_when_edge_removed_no_duplicates() {
+        let (cache, tmp) = make_cache();
+        let mut issue_map = IssueMap::load(tmp.path()).unwrap();
+        let config = config_with_subissue_rel(story_type_def());
+        let story_dir = tmp.path().join(".lazyspec/cache/story");
+
+        // First fetch: STORY-11 is a native sub-issue of STORY-100.
+        let first = ParentReader::new(
+            vec![issue_with_node(100, "I_parent"), issue_with_node(11, "I_a")],
+            &[("I_a", 100)],
+        );
+        fetch_typed(
+            &cache,
+            &tmp,
+            &first,
+            &mut issue_map,
+            story_type_def(),
+            &config,
+        );
+        assert!(std::fs::read_to_string(story_dir.join("STORY-11.md"))
+            .unwrap()
+            .contains("implements: STORY-100"));
+
+        // Second fetch: the edge is gone on the remote.
+        let second = ParentReader::new(
+            vec![issue_with_node(100, "I_parent"), issue_with_node(11, "I_a")],
+            &[],
+        );
+        fetch_typed(
+            &cache,
+            &tmp,
+            &second,
+            &mut issue_map,
+            story_type_def(),
+            &config,
+        );
+
+        let child = std::fs::read_to_string(story_dir.join("STORY-11.md")).unwrap();
+        assert!(
+            !child.contains("implements"),
+            "relation dropped on re-fetch, got:\n{child}"
+        );
+        let mut ids = cache.list_cached("story");
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["STORY-100", "STORY-11"],
+            "no duplicate cache entries"
+        );
     }
 
     // --- STORY-209: crash-safe persistence ---

--- a/src/engine/ops/link.rs
+++ b/src/engine/ops/link.rs
@@ -7,6 +7,7 @@ use crate::engine::fs::FileSystem;
 use crate::engine::gh::{
     GhCli, GhGraphql, GhIssueDependencyApi, GhIssueReader, GhIssueWriter, GhMilestoneApi, GqlVar,
 };
+use crate::engine::gh_subissue::{ADD_SUB_ISSUE_MUTATION, REMOVE_SUB_ISSUE_MUTATION};
 use crate::engine::git_ref_store::GitRefStore;
 use crate::engine::issue_cache::IssueCache;
 use crate::engine::issue_map::IssueMap;
@@ -101,9 +102,10 @@ fn link_inner<
         &to_id,
         true,
         milestone_factory,
-    )? || apply_native_membership(
+    )? || apply_native_graphql_edge(
         root,
         config,
+        store,
         &rel_str,
         &from_id,
         &to_id,
@@ -405,6 +407,177 @@ fn apply_native_dependency<D: GhIssueDependencyApi>(
     Ok(true)
 }
 
+const SUB_ISSUE_PARENT_QUERY: &str =
+    "query($id: ID!) { node(id: $id) { ... on Issue { parent { id number } } } }";
+
+/// Route a GraphQL-only native edge (`membership` / `sub-issue`) to its writer,
+/// consuming the single `GhGraphql` factory exactly once. Both relations use the
+/// same seam and are mutually exclusive per relationship, so the dispatch is by
+/// the relation's declared `github_native`. A no-op (`Ok(false)`) for any other
+/// relation, leaving the factory unused.
+#[allow(clippy::too_many_arguments)]
+fn apply_native_graphql_edge<P: GhGraphql + 'static>(
+    root: &Path,
+    config: &Config,
+    store: &Store,
+    rel_str: &str,
+    source_id: &str,
+    target_id: &str,
+    set: bool,
+    projects_factory: impl FnOnce() -> P,
+) -> Result<bool> {
+    match config
+        .relationship_by_name(rel_str)
+        .and_then(|r| r.github_native.as_deref())
+    {
+        Some("membership") => apply_native_membership(
+            root,
+            config,
+            rel_str,
+            source_id,
+            target_id,
+            set,
+            projects_factory,
+        ),
+        Some("sub-issue") => apply_native_subissue(
+            root,
+            config,
+            store,
+            rel_str,
+            source_id,
+            target_id,
+            set,
+            projects_factory,
+        ),
+        _ => Ok(false),
+    }
+}
+
+/// If `rel_str` declares `github_native = "sub-issue"`, opportunistically write
+/// the native GitHub sub-issue edge. Like `blocks`/dependency, this is a
+/// universal semantic relation that gains an *optional* native edge: it fires
+/// only when BOTH endpoints resolve to github-issues docs (necessarily the same
+/// repo under lazyspec's one-repo-per-store model). Otherwise — filesystem,
+/// cross-store, or a non-sub-issue relation — it is a no-op with no error, and
+/// the relation stays comment/graph-backed as before.
+///
+/// Direction: `source implements target` makes `source` the child and `target`
+/// the parent, i.e. `addSubIssue(issueId: target-node, subIssueId: source-node)`.
+/// `set` true adds the edge (link), false removes it (unlink). Node ids come
+/// from the issue map; an empty node id (legacy map) is a clear error telling the
+/// user to re-fetch, with no mutation. Before adding, the child's existing native
+/// parent is queried: if it already has a *different* parent the link fails
+/// naming it (single-parent; reparenting is explicit unlink+link).
+///
+/// Returns `true` when a native sub-issue mutation was performed (so the caller
+/// routes the cache mirror through the conflict-free resync), `false` for the
+/// opportunistic no-op.
+#[allow(clippy::too_many_arguments)]
+fn apply_native_subissue<P: GhGraphql>(
+    root: &Path,
+    config: &Config,
+    store: &Store,
+    rel_str: &str,
+    source_id: &str,
+    target_id: &str,
+    set: bool,
+    subissue_factory: impl FnOnce() -> P,
+) -> Result<bool> {
+    let is_subissue_rel = config
+        .relationship_by_name(rel_str)
+        .and_then(|r| r.github_native.as_deref())
+        == Some("sub-issue");
+    if !is_subissue_rel {
+        return Ok(false);
+    }
+
+    // Opportunistic: the native edge fires only when both endpoints are
+    // github-issues docs. A filesystem, cross-store, or cross-repo endpoint
+    // falls through to the ordinary comment/graph-backed record.
+    let both_issues = store_of(config, store, source_id) == Some(StoreBackend::GithubIssues)
+        && store_of(config, store, target_id) == Some(StoreBackend::GithubIssues);
+    if !both_issues {
+        return Ok(false);
+    }
+
+    let issue_map = IssueMap::load(root)?;
+    let child_node = issue_map
+        .get(source_id)
+        .map(|e| e.node_id.clone())
+        .filter(|n| !n.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "source '{}' has no GitHub issue node id in the issue map; \
+                 run `lazyspec fetch` to populate it before linking sub-issues",
+                source_id
+            )
+        })?;
+    let parent_node = issue_map
+        .get(target_id)
+        .map(|e| e.node_id.clone())
+        .filter(|n| !n.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "target '{}' has no GitHub issue node id in the issue map; \
+                 run `lazyspec fetch` to populate it before linking sub-issues",
+                target_id
+            )
+        })?;
+
+    let client = subissue_factory();
+
+    if set {
+        // Single-parent: a child already nested under a different parent must be
+        // unlinked first; we never silently reparent.
+        let resp = client.graphql(
+            SUB_ISSUE_PARENT_QUERY,
+            &[("id", GqlVar::Str(child_node.clone()))],
+        )?;
+        if let Some(parent) = resp.pointer("/data/node/parent").filter(|p| !p.is_null()) {
+            let existing_node = parent
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if existing_node != parent_node {
+                let existing_name = parent
+                    .get("number")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|n| issue_map.shorthand_for_number(n).map(str::to_string))
+                    .or_else(|| {
+                        parent
+                            .get("number")
+                            .and_then(|v| v.as_u64())
+                            .map(|n| format!("#{n}"))
+                    })
+                    .unwrap_or_else(|| existing_node.to_string());
+                return Err(anyhow!(
+                    "'{}' is already a native sub-issue of '{}'; unlink it before linking to '{}' \
+                     (reparenting is an explicit unlink + link)",
+                    source_id,
+                    existing_name,
+                    target_id
+                ));
+            }
+        }
+        client.graphql(
+            ADD_SUB_ISSUE_MUTATION,
+            &[
+                ("issueId", GqlVar::Str(parent_node)),
+                ("subIssueId", GqlVar::Str(child_node)),
+            ],
+        )?;
+    } else {
+        client.graphql(
+            REMOVE_SUB_ISSUE_MUTATION,
+            &[
+                ("issueId", GqlVar::Str(parent_node)),
+                ("subIssueId", GqlVar::Str(child_node)),
+            ],
+        )?;
+    }
+    Ok(true)
+}
+
 /// The store a document id resolves to, via its type's `[[types]]` declaration.
 /// `None` when the id resolves to no doc or its type is undeclared -- the caller
 /// treats an unresolved store as non-milestone (the guard only fires on the
@@ -532,9 +705,10 @@ fn unlink_inner<
         &to_id,
         false,
         milestone_factory,
-    )? || apply_native_membership(
+    )? || apply_native_graphql_edge(
         root,
         config,
+        store,
         &rel_str,
         &from_id,
         &to_id,
@@ -3338,5 +3512,539 @@ mod tests {
 
         assert!(!fired, "a non-issue endpoint must not fire the native edge");
         assert!(recorder.added.borrow().is_empty());
+    }
+
+    // --- github_native = "sub-issue" (STORY-245 / ITERATION-347) ---
+
+    // Two github-issues types (story = child, feature = parent) and one filesystem
+    // type, with `implements` bound to the native sub-issue edge and an ordinary
+    // `mentions` alongside it (to prove the guard only fires for the sub-issue
+    // relation).
+    fn subissue_config() -> Config {
+        let issue = |name: &str, store: StoreBackend| TypeDef::test_fixture(name, store);
+        let mut config = Config::default();
+        config.documents.types = vec![
+            issue("story", StoreBackend::GithubIssues),
+            issue("feature", StoreBackend::GithubIssues),
+            issue("spec", StoreBackend::Filesystem),
+        ];
+        config.documents.github = Some(GithubConfig {
+            repo: Some("owner/repo".to_string()),
+            cache_ttl: 60,
+        });
+        config.relationships = vec![
+            crate::engine::config::RelationshipDef {
+                name: "implements".to_string(),
+                inverse: Some("implemented-by".to_string()),
+                github_native: Some("sub-issue".to_string()),
+                traversal: None,
+            },
+            crate::engine::config::RelationshipDef {
+                name: "mentions".to_string(),
+                inverse: Some("mentioned-by".to_string()),
+                github_native: None,
+                traversal: None,
+            },
+        ];
+        config
+    }
+
+    fn no_parent() -> serde_json::Value {
+        serde_json::json!({"data": {"node": {"parent": null}}})
+    }
+
+    fn parent_ref(node: &str, number: u64) -> serde_json::Value {
+        serde_json::json!({"data": {"node": {"parent": {"id": node, "number": number}}}})
+    }
+
+    fn subissue_mutation_ok() -> serde_json::Value {
+        serde_json::json!({"data": {"addSubIssue": {"issue": {"id": "I_x"}}}})
+    }
+
+    // AC1: linking two same-repo github-issues docs via a github_native="sub-issue"
+    // relation writes addSubIssue with the PARENT as issueId and the CHILD as
+    // subIssueId (source = child, target = parent), records the relation on the
+    // child, and fires the resync (proven by the issue-map baseline reconciling to
+    // the remote's fresh updated_at).
+    #[test]
+    fn link_subissue_writes_native_edge_and_resyncs() {
+        let root = tmp_root("link_subissue");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Parent",
+            "feature",
+        );
+
+        // STORY-7 last fetched at 10:00; remote (returned by the resync view) 11:00.
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "2026-06-26T10:00:00Z", "I_node7");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.save(&root).unwrap();
+
+        let store = Store::load(&root, &config).unwrap();
+        let fs = RealFileSystem;
+        // The graphql seam: first the parent lookup (no existing parent), then the
+        // addSubIssue mutation.
+        let recorder = std::rc::Rc::new(
+            MockGhClient::new().with_graphql_responses(vec![no_parent(), subissue_mutation_ok()]),
+        );
+
+        link_inner(
+            &root,
+            &store,
+            "STORY-7",
+            "implements",
+            "FEATURE-3",
+            &fs,
+            Some(&config),
+            || MockGhClient::new().with_view_issue(view_issue_at(7, "2026-06-26T11:00:00Z")),
+            MockGhMilestoneClient::new,
+            || recorder.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect("native sub-issue link must succeed");
+
+        let calls = recorder.graphql_calls.borrow();
+        let adds: Vec<_> = calls
+            .iter()
+            .filter(|(q, _)| q.contains("addSubIssue"))
+            .collect();
+        assert_eq!(adds.len(), 1, "one addSubIssue, got: {:?}", *calls);
+        let (_, vars) = adds[0];
+        assert!(
+            vars.contains(&("issueId".to_string(), GqlVar::Str("I_node3".to_string()))),
+            "parent (FEATURE-3) is the issueId, got: {vars:?}"
+        );
+        assert!(
+            vars.contains(&("subIssueId".to_string(), GqlVar::Str("I_node7".to_string()))),
+            "child (STORY-7) is the subIssueId, got: {vars:?}"
+        );
+
+        // The relation is recorded on the child's frontmatter.
+        let updated =
+            std::fs::read_to_string(root.join(".lazyspec/cache/story/STORY-7.md")).unwrap();
+        assert!(
+            updated.contains("implements: FEATURE-3"),
+            "frontmatter should carry the relation, got:\n{updated}"
+        );
+
+        // Resync fired: the baseline reconciled to the remote's fresh timestamp.
+        let reloaded = IssueMap::load(&root).unwrap();
+        assert_eq!(
+            reloaded.get("STORY-7").unwrap().updated_at,
+            "2026-06-26T11:00:00Z",
+            "resync_after_native_edge should record the remote's current updated_at"
+        );
+    }
+
+    // AC2: unlink removes the native sub-issue edge (removeSubIssue, same
+    // parent/child direction) and drops the relation from the cache frontmatter.
+    // No parent lookup on unlink.
+    #[test]
+    fn unlink_subissue_removes_native_edge() {
+        let root = tmp_root("unlink_subissue");
+        let config = subissue_config();
+
+        std::fs::create_dir_all(root.join(".lazyspec/cache/story")).unwrap();
+        let content = "---\ntitle: My Story\ntype: story\nstatus: draft\nauthor: a\ndate: 2026-03-27\ntags: []\nrelated:\n- implements: FEATURE-3\n---\nbody\n";
+        std::fs::write(root.join(".lazyspec/cache/story/STORY-7.md"), content).unwrap();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Parent",
+            "feature",
+        );
+
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "2026-06-26T10:00:00Z", "I_node7");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.save(&root).unwrap();
+
+        let store = Store::load(&root, &config).unwrap();
+        let fs = RealFileSystem;
+        let recorder = std::rc::Rc::new(
+            MockGhClient::new().with_graphql_responses(vec![subissue_mutation_ok()]),
+        );
+
+        unlink_inner(
+            &root,
+            &store,
+            "STORY-7",
+            "implements",
+            "FEATURE-3",
+            &fs,
+            Some(&config),
+            || MockGhClient::new().with_view_issue(view_issue_at(7, "2026-06-26T11:00:00Z")),
+            MockGhMilestoneClient::new,
+            || recorder.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect("native sub-issue unlink must succeed");
+
+        let calls = recorder.graphql_calls.borrow();
+        let removes: Vec<_> = calls
+            .iter()
+            .filter(|(q, _)| q.contains("removeSubIssue"))
+            .collect();
+        assert_eq!(removes.len(), 1, "one removeSubIssue, got: {:?}", *calls);
+        let (_, vars) = removes[0];
+        assert!(vars.contains(&("issueId".to_string(), GqlVar::Str("I_node3".to_string()))));
+        assert!(vars.contains(&("subIssueId".to_string(), GqlVar::Str("I_node7".to_string()))));
+        assert!(
+            calls.iter().all(|(q, _)| !q.contains("addSubIssue")),
+            "unlink must not add"
+        );
+
+        let updated =
+            std::fs::read_to_string(root.join(".lazyspec/cache/story/STORY-7.md")).unwrap();
+        assert!(
+            !updated.contains("implements: FEATURE-3"),
+            "cache relation should be removed, got:\n{updated}"
+        );
+    }
+
+    // AC3: linking a child that already has a DIFFERENT native parent fails with an
+    // error naming the existing parent, and no addSubIssue mutation fires.
+    #[test]
+    fn link_subissue_single_parent_conflict_rejected() {
+        let root = tmp_root("link_subissue_conflict");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Old Parent",
+            "feature",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-9.md",
+            "New Parent",
+            "feature",
+        );
+
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "", "I_node7");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.insert("FEATURE-9", 9, "", "I_node9");
+        issue_map.save(&root).unwrap();
+
+        let store = Store::load(&root, &config).unwrap();
+        let fs = RealFileSystem;
+        // The parent lookup returns FEATURE-3 (node I_node3, number 3) as the
+        // existing parent -- different from the requested FEATURE-9.
+        let recorder = std::rc::Rc::new(
+            MockGhClient::new().with_graphql_responses(vec![parent_ref("I_node3", 3)]),
+        );
+
+        let err = link_inner(
+            &root,
+            &store,
+            "STORY-7",
+            "implements",
+            "FEATURE-9",
+            &fs,
+            Some(&config),
+            MockGhClient::new,
+            MockGhMilestoneClient::new,
+            || recorder.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect_err("linking a child with a different existing parent must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("STORY-7"), "names the child, got: {msg}");
+        assert!(
+            msg.contains("FEATURE-3"),
+            "names the existing parent, got: {msg}"
+        );
+
+        let calls = recorder.graphql_calls.borrow();
+        assert!(
+            calls.iter().all(|(q, _)| !q.contains("addSubIssue")),
+            "no addSubIssue on a single-parent conflict, got: {:?}",
+            *calls
+        );
+        // Cache untouched.
+        let updated =
+            std::fs::read_to_string(root.join(".lazyspec/cache/story/STORY-7.md")).unwrap();
+        assert!(
+            !updated.contains("implements: FEATURE-9"),
+            "cache must be unchanged after a rejected link, got:\n{updated}"
+        );
+    }
+
+    // Re-linking to the SAME parent is idempotent: the parent lookup returns the
+    // requested parent, so the addSubIssue still fires (GitHub treats it as a
+    // no-op) and no single-parent error is raised.
+    #[test]
+    fn link_subissue_same_parent_is_allowed() {
+        let root = tmp_root("link_subissue_same");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Parent",
+            "feature",
+        );
+
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "2026-06-26T10:00:00Z", "I_node7");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.save(&root).unwrap();
+
+        let store = Store::load(&root, &config).unwrap();
+        let fs = RealFileSystem;
+        let recorder = std::rc::Rc::new(
+            MockGhClient::new()
+                .with_graphql_responses(vec![parent_ref("I_node3", 3), subissue_mutation_ok()]),
+        );
+
+        link_inner(
+            &root,
+            &store,
+            "STORY-7",
+            "implements",
+            "FEATURE-3",
+            &fs,
+            Some(&config),
+            || MockGhClient::new().with_view_issue(view_issue_at(7, "2026-06-26T11:00:00Z")),
+            MockGhMilestoneClient::new,
+            || recorder.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect("re-linking to the same parent must succeed");
+
+        let calls = recorder.graphql_calls.borrow();
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|(q, _)| q.contains("addSubIssue"))
+                .count(),
+            1,
+            "addSubIssue fires when the parent already matches, got: {:?}",
+            *calls
+        );
+    }
+
+    // AC6 regression: a filesystem-only `implements` link/unlink makes ZERO native
+    // calls -- the opportunistic guard sees non-issue endpoints and records the
+    // relation comment/graph-backed exactly as before, with no error.
+    #[test]
+    fn link_subissue_filesystem_only_makes_no_native_call() {
+        let root = tmp_root("link_subissue_fs");
+        let config = subissue_config();
+
+        let dir = root.join("docs/spec");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SPEC-1.md"),
+            "---\ntitle: A\ntype: spec\nstatus: draft\nauthor: a\ndate: 2026-03-27\ntags: []\n---\nbody\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("SPEC-2.md"),
+            "---\ntitle: B\ntype: spec\nstatus: draft\nauthor: a\ndate: 2026-03-27\ntags: []\n---\nbody\n",
+        )
+        .unwrap();
+
+        let store = Store::load(&root, &config).unwrap();
+        let fs = RealFileSystem;
+        // No graphql responses seeded: any graphql call would panic ("no canned
+        // response"), proving none fires.
+        let recorder = std::rc::Rc::new(MockGhClient::new());
+
+        link_inner(
+            &root,
+            &store,
+            "SPEC-1",
+            "implements",
+            "SPEC-2",
+            &fs,
+            Some(&config),
+            MockGhClient::new,
+            MockGhMilestoneClient::new,
+            || recorder.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect("filesystem implements link must succeed");
+
+        let updated = std::fs::read_to_string(dir.join("SPEC-1.md")).unwrap();
+        assert!(
+            updated.contains("implements: SPEC-2"),
+            "filesystem relation should be recorded, got:\n{updated}"
+        );
+        assert!(
+            recorder.graphql_calls.borrow().is_empty(),
+            "no native call for a filesystem endpoint"
+        );
+
+        // Unlink is symmetric: still no native call.
+        let store = Store::load(&root, &config).unwrap();
+        let recorder2 = std::rc::Rc::new(MockGhClient::new());
+        unlink_inner(
+            &root,
+            &store,
+            "SPEC-1",
+            "implements",
+            "SPEC-2",
+            &fs,
+            Some(&config),
+            MockGhClient::new,
+            MockGhMilestoneClient::new,
+            || recorder2.clone(),
+            MockGhDependencyClient::new,
+        )
+        .expect("filesystem implements unlink must succeed");
+        assert!(
+            recorder2.graphql_calls.borrow().is_empty(),
+            "no native call for a filesystem endpoint on unlink"
+        );
+    }
+
+    // An ordinary relation (no github_native) between two github-issues docs makes
+    // no sub-issue call: the native edge is opportunistic on the RELATION too.
+    #[test]
+    fn apply_native_subissue_non_subissue_relation_returns_false() {
+        let root = tmp_root("subissue_guard_rel");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Parent",
+            "feature",
+        );
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "", "I_node7");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.save(&root).unwrap();
+        let store = Store::load(&root, &config).unwrap();
+        let recorder = std::rc::Rc::new(MockGhClient::new());
+
+        let fired = apply_native_subissue(
+            &root,
+            &config,
+            &store,
+            "mentions",
+            "STORY-7",
+            "FEATURE-3",
+            true,
+            || recorder.clone(),
+        )
+        .unwrap();
+
+        assert!(!fired, "a non-sub-issue relation must not fire the edge");
+        assert!(recorder.graphql_calls.borrow().is_empty());
+    }
+
+    // Opportunistic guard: a non-issue (filesystem) endpoint returns false with no
+    // native call and no error, even though the relation IS the sub-issue one.
+    #[test]
+    fn apply_native_subissue_non_issue_endpoint_returns_false() {
+        let root = tmp_root("subissue_guard_endpoint");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        let dir = root.join("docs/spec");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SPEC-1.md"),
+            "---\ntitle: A\ntype: spec\nstatus: draft\nauthor: a\ndate: 2026-03-27\ntags: []\n---\nbody\n",
+        )
+        .unwrap();
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "", "I_node7");
+        issue_map.save(&root).unwrap();
+        let store = Store::load(&root, &config).unwrap();
+        let recorder = std::rc::Rc::new(MockGhClient::new());
+
+        let fired = apply_native_subissue(
+            &root,
+            &config,
+            &store,
+            "implements",
+            "STORY-7",
+            "SPEC-1",
+            true,
+            || recorder.clone(),
+        )
+        .unwrap();
+
+        assert!(!fired, "a non-issue endpoint must not fire the edge");
+        assert!(recorder.graphql_calls.borrow().is_empty());
+    }
+
+    // An empty node id in the issue map (legacy map) is a clear error telling the
+    // user to re-fetch, and no mutation fires.
+    #[test]
+    fn link_subissue_empty_node_id_errors_without_mutation() {
+        let root = tmp_root("subissue_empty_node");
+        let config = subissue_config();
+        write_cache_doc(
+            &root.join(".lazyspec/cache/story"),
+            "STORY-7.md",
+            "My Story",
+            "story",
+        );
+        write_cache_doc(
+            &root.join(".lazyspec/cache/feature"),
+            "FEATURE-3.md",
+            "Parent",
+            "feature",
+        );
+        // STORY-7 has a REST number but an EMPTY node id (legacy map).
+        let mut issue_map = IssueMap::load(&root).unwrap();
+        issue_map.insert("STORY-7", 7, "", "");
+        issue_map.insert("FEATURE-3", 3, "", "I_node3");
+        issue_map.save(&root).unwrap();
+        let store = Store::load(&root, &config).unwrap();
+        let recorder = std::rc::Rc::new(MockGhClient::new());
+
+        let err = apply_native_subissue(
+            &root,
+            &config,
+            &store,
+            "implements",
+            "STORY-7",
+            "FEATURE-3",
+            true,
+            || recorder.clone(),
+        )
+        .expect_err("an empty node id must be a clear error");
+        let msg = err.to_string();
+        assert!(msg.contains("STORY-7"), "names the doc, got: {msg}");
+        assert!(
+            msg.contains("fetch"),
+            "tells the user to re-fetch, got: {msg}"
+        );
+        assert!(recorder.graphql_calls.borrow().is_empty());
     }
 }

--- a/src/engine/store_dispatch.rs
+++ b/src/engine/store_dispatch.rs
@@ -11,7 +11,7 @@ use crate::engine::document::{compose_frontmatter, AttrValue, DocMeta, DocType, 
 use crate::engine::gh::{self, GhClient, GhGraphql, GhMilestoneClient, GhProjectsClient, GqlVar};
 use crate::engine::gh_schema::{try_org_then_user, GhSchemaSnapshot};
 use crate::engine::issue_body;
-use crate::engine::issue_cache::IssueCache;
+use crate::engine::issue_cache::{self, IssueCache};
 use crate::engine::issue_map::IssueMap;
 use crate::engine::store::{self, Store};
 use crate::engine::task_map::TaskMap;
@@ -688,7 +688,16 @@ impl GithubIssuesStore {
                 .to_string(),
             closed_status: type_def.effective_lifecycle().terminal_status().to_string(),
         };
-        let (mut remote_meta, remote_prose) = issue_body::deserialize(&remote_issue.body, &ctx)?;
+        // A body without a lazyspec comment (GitHub-authored issue) is adopted:
+        // synthesize meta from the issue's own fields and keep the whole body
+        // as prose, so this write plants the comment.
+        let (mut remote_meta, remote_prose) = issue_body::deserialize(&remote_issue.body, &ctx)
+            .unwrap_or_else(|_| {
+                (
+                    issue_cache::fallback_meta(&remote_issue, &ctx),
+                    remote_issue.body.clone(),
+                )
+            });
 
         let rel_type = crate::engine::document::RelationType::new(rel_str);
         let already_present = remote_meta
@@ -5275,6 +5284,245 @@ mod tests {
         assert!(
             gh_store.mock().last_edit_body.borrow().is_none(),
             "already-present relation must not trigger an issue_edit"
+        );
+    }
+
+    // BUG-014 / AC1: a remote issue whose body has NO lazyspec comment (empty /
+    // null body, e.g. a GitHub-authored issue) must still accept an ordinary
+    // relation link -- the merge synthesizes meta from the remote issue fields
+    // and pushes a body carrying the lazyspec comment plus the relation.
+    #[test]
+    fn merge_relation_to_remote_empty_body_gains_comment_and_relation() {
+        let root = tmp_root("merge_rel_empty_body");
+        let view_issue = GhIssue {
+            number: 42,
+            id: "I_node42".to_string(),
+            url: String::new(),
+            title: "My RFC".to_string(),
+            body: String::new(),
+            labels: vec![GhLabel {
+                name: "lazyspec:rfc".to_string(),
+                color: String::new(),
+            }],
+            state: "OPEN".to_string(),
+            updated_at: "2026-03-27T11:00:00Z".to_string(),
+            created_at: "2026-03-27T10:00:00Z".to_string(),
+            author: None,
+            issue_type: None,
+            milestone: None,
+            assignees: vec![],
+        };
+
+        let client = MockGhClient::new().with_view_issue(view_issue);
+        let mut map = IssueMap::load(&root).unwrap();
+        map.insert("RFC-001", 42, "2026-03-27T10:00:00Z", "I_node42");
+
+        let mut gh_store = GithubIssuesStore {
+            client: Box::new(client),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: map,
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let td = test_type_def(StoreBackend::GithubIssues);
+        gh_store
+            .merge_relation_to_remote(&td, "RFC-001", "related-to", "STORY-001", true)
+            .expect("merge must not fail on a body without a lazyspec comment");
+
+        let pushed = gh_store.mock().last_edit_body.borrow();
+        let pushed = pushed.as_ref().expect("issue_edit should run");
+        assert!(pushed.contains("<!-- lazyspec"), "got:\n{pushed}");
+        assert!(pushed.contains("- related-to: STORY-001"), "got:\n{pushed}");
+    }
+
+    // BUG-014 / AC3: a remote issue whose body is plain prose with NO lazyspec
+    // comment must still accept an ordinary relation link -- the merge pushes a
+    // body carrying the lazyspec comment plus the relation, with the original
+    // prose preserved verbatim beneath the new comment.
+    #[test]
+    fn merge_relation_to_remote_prose_only_body_keeps_prose_under_comment() {
+        let root = tmp_root("merge_rel_prose_only");
+        let prose = "This issue was filed straight on GitHub.\n\nIt has two prose paragraphs and zero lazyspec markers.";
+        let view_issue = GhIssue {
+            number: 42,
+            id: "I_node42".to_string(),
+            url: String::new(),
+            title: "My RFC".to_string(),
+            body: prose.to_string(),
+            labels: vec![GhLabel {
+                name: "lazyspec:rfc".to_string(),
+                color: String::new(),
+            }],
+            state: "OPEN".to_string(),
+            updated_at: "2026-03-27T11:00:00Z".to_string(),
+            created_at: "2026-03-27T10:00:00Z".to_string(),
+            author: None,
+            issue_type: None,
+            milestone: None,
+            assignees: vec![],
+        };
+
+        let client = MockGhClient::new().with_view_issue(view_issue);
+        let mut map = IssueMap::load(&root).unwrap();
+        map.insert("RFC-001", 42, "2026-03-27T10:00:00Z", "I_node42");
+
+        let mut gh_store = GithubIssuesStore {
+            client: Box::new(client),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: map,
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let td = test_type_def(StoreBackend::GithubIssues);
+        gh_store
+            .merge_relation_to_remote(&td, "RFC-001", "related-to", "STORY-001", true)
+            .expect("merge must not fail on a prose-only body without a lazyspec comment");
+
+        let pushed = gh_store.mock().last_edit_body.borrow();
+        let pushed = pushed.as_ref().expect("issue_edit should run");
+        assert!(pushed.contains("<!-- lazyspec"), "got:\n{pushed}");
+        assert!(pushed.contains("- related-to: STORY-001"), "got:\n{pushed}");
+
+        let comment_end = pushed
+            .find("-->")
+            .expect("pushed body should carry a closed lazyspec comment");
+        let prose_start = pushed
+            .find(prose)
+            .unwrap_or_else(|| panic!("prose not preserved verbatim, got:\n{pushed}"));
+        assert!(
+            prose_start > comment_end,
+            "prose must sit beneath the lazyspec comment, got:\n{pushed}"
+        );
+    }
+
+    // BUG-014 / AC2: unlinking a relation on an adopted issue (body already
+    // carries the lazyspec comment with the relation) removes the relation from
+    // the pushed comment.
+    #[test]
+    fn merge_relation_to_remote_unlink_removes_relation_from_comment() {
+        use crate::engine::document::{Relation, RelationType};
+        let root = tmp_root("merge_rel_unlink_adopted");
+        let meta = DocMeta {
+            path: PathBuf::new(),
+            title: "My RFC".to_string(),
+            doc_type: DocType::new("rfc"),
+            status: Status::new("draft"),
+            author: "agent-7".to_string(),
+            date: chrono::NaiveDate::from_ymd_opt(2026, 3, 27).unwrap(),
+            tags: vec![],
+            provenance: vec![],
+            related: vec![Relation {
+                rel_type: RelationType::new("related-to"),
+                target: "STORY-001".to_string(),
+            }],
+            validate_ignore: false,
+            virtual_doc: false,
+            assignee: None,
+            attributes: Default::default(),
+            id: "RFC-001".to_string(),
+        };
+        let body = issue_body::serialize(&meta, "ADOPTED PROSE LINE");
+        let view_issue = GhIssue {
+            number: 42,
+            id: "I_node42".to_string(),
+            url: String::new(),
+            title: "My RFC".to_string(),
+            body,
+            labels: vec![GhLabel {
+                name: "lazyspec:rfc".to_string(),
+                color: String::new(),
+            }],
+            state: "OPEN".to_string(),
+            updated_at: "2026-03-27T11:00:00Z".to_string(),
+            created_at: "2026-03-27T10:00:00Z".to_string(),
+            author: None,
+            issue_type: None,
+            milestone: None,
+            assignees: vec![],
+        };
+
+        let client = MockGhClient::new().with_view_issue(view_issue);
+        let mut map = IssueMap::load(&root).unwrap();
+        map.insert("RFC-001", 42, "2026-03-27T10:00:00Z", "I_node42");
+
+        let mut gh_store = GithubIssuesStore {
+            client: Box::new(client),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: map,
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let td = test_type_def(StoreBackend::GithubIssues);
+        gh_store
+            .merge_relation_to_remote(&td, "RFC-001", "related-to", "STORY-001", false)
+            .expect("unlink on an adopted issue must succeed");
+
+        let pushed = gh_store.mock().last_edit_body.borrow();
+        let pushed = pushed.as_ref().expect("issue_edit should run");
+        assert!(pushed.contains("<!-- lazyspec"), "got:\n{pushed}");
+        assert!(
+            !pushed.contains("- related-to: STORY-001"),
+            "relation must be removed from the pushed comment, got:\n{pushed}"
+        );
+        assert!(pushed.contains("ADOPTED PROSE LINE"), "got:\n{pushed}");
+    }
+
+    // BUG-014 / AC2 (comment-less remote): unlink rides the same merge path, so
+    // a remote body with NO lazyspec comment (relation only in the local cache)
+    // must not hard-fail -- the merge synthesizes meta from the remote issue
+    // fields and pushes a comment-bearing body without the relation.
+    #[test]
+    fn merge_relation_to_remote_unlink_comment_less_body_succeeds() {
+        let root = tmp_root("merge_rel_unlink_no_comment");
+        let view_issue = GhIssue {
+            number: 42,
+            id: "I_node42".to_string(),
+            url: String::new(),
+            title: "My RFC".to_string(),
+            body: "Filed straight on GitHub, no lazyspec markers.".to_string(),
+            labels: vec![GhLabel {
+                name: "lazyspec:rfc".to_string(),
+                color: String::new(),
+            }],
+            state: "OPEN".to_string(),
+            updated_at: "2026-03-27T11:00:00Z".to_string(),
+            created_at: "2026-03-27T10:00:00Z".to_string(),
+            author: None,
+            issue_type: None,
+            milestone: None,
+            assignees: vec![],
+        };
+
+        let client = MockGhClient::new().with_view_issue(view_issue);
+        let mut map = IssueMap::load(&root).unwrap();
+        map.insert("RFC-001", 42, "2026-03-27T10:00:00Z", "I_node42");
+
+        let mut gh_store = GithubIssuesStore {
+            client: Box::new(client),
+            root: root.clone(),
+            repo: "owner/repo".to_string(),
+            config: Config::default(),
+            issue_map: map,
+            issue_cache: IssueCache::new(&root),
+        };
+
+        let td = test_type_def(StoreBackend::GithubIssues);
+        gh_store
+            .merge_relation_to_remote(&td, "RFC-001", "related-to", "STORY-001", false)
+            .expect("unlink must not fail on a body without a lazyspec comment");
+
+        let pushed = gh_store.mock().last_edit_body.borrow();
+        let pushed = pushed.as_ref().expect("issue_edit should run");
+        assert!(pushed.contains("<!-- lazyspec"), "got:\n{pushed}");
+        assert!(
+            !pushed.contains("- related-to: STORY-001"),
+            "unlinked relation must not appear in the pushed comment, got:\n{pushed}"
         );
     }
 

--- a/src/tui/state/app.rs
+++ b/src/tui/state/app.rs
@@ -2320,10 +2320,11 @@ impl App {
     /// engine [`resolve_chain`](crate::engine::context::resolve_chain) so the
     /// navigable list and the rendered list share one source of truth.
     pub fn relation_sections(&self, doc: &DocMeta) -> RelationSections {
-        let resolved = match crate::engine::context::resolve_chain(&self.store, &doc.id, 1) {
+        let mut resolved = match crate::engine::context::resolve_chain(&self.store, &doc.id, 1) {
             Ok(r) => r,
             Err(_) => return RelationSections::default(),
         };
+        crate::engine::context::merge_declared_related(&self.store, &mut resolved);
 
         let chain = resolved
             .nodes
@@ -5162,13 +5163,17 @@ mod tests {
     /// Build an `App` wrapping a real `Store` loaded from in-memory files under
     /// a fresh TempDir. The TempDir is returned so it outlives the store.
     fn app_with_store(files: &[(&str, &str)]) -> (tempfile::TempDir, App) {
+        app_with_store_config(files, &Config::default())
+    }
+
+    fn app_with_store_config(files: &[(&str, &str)], config: &Config) -> (tempfile::TempDir, App) {
         let tmp = tempfile::TempDir::new().unwrap();
         for (rel_path, contents) in files {
             let full = tmp.path().join(rel_path);
             std::fs::create_dir_all(full.parent().unwrap()).unwrap();
             std::fs::write(&full, contents).unwrap();
         }
-        let store = Store::load(tmp.path(), &Config::default()).unwrap();
+        let store = Store::load(tmp.path(), config).unwrap();
         let mut app = make_test_app(0);
         app.store = store;
         (tmp, app)
@@ -5530,6 +5535,72 @@ mod tests {
                 .collect();
         assert!(item_ids.contains("RFC-002"));
         assert!(!item_ids.contains("RFC-003"));
+    }
+
+    // AC (BUG-013): a related-to relation declared in frontmatter surfaces in
+    // the Relations tab even when the config's `related-to` entry carries no
+    // `traversal = "related"` marker.
+    #[test]
+    fn relation_sections_includes_related_without_traversal_marker() {
+        let mut config = Config::default();
+        config
+            .relationships
+            .iter_mut()
+            .find(|r| r.name == "related-to")
+            .unwrap()
+            .traversal = None;
+
+        let (_tmp, app) = app_with_store_config(
+            &[
+                (
+                    "docs/rfcs/RFC-001-anchor.md",
+                    &relations_doc_md("Anchor", "rfc", "- related-to: RFC-002"),
+                ),
+                (
+                    "docs/rfcs/RFC-002-near.md",
+                    &relations_doc_md("Near", "rfc", "[]"),
+                ),
+            ],
+            &config,
+        );
+
+        let doc = doc_by_id(&app, "RFC-001");
+        let sections = app.relation_sections(&doc);
+        let ids: std::collections::BTreeSet<String> =
+            ids_for_paths(&app, &sections.related).into_iter().collect();
+
+        assert!(
+            ids.contains("RFC-002"),
+            "declared related-to must appear without the traversal marker, got {ids:?}"
+        );
+    }
+
+    // AC (BUG-013 guard): with the default config's `traversal = "related"`
+    // marker in place, a declared related-to relation must appear exactly once
+    // in the related section -- merging the declared list must not duplicate
+    // what the related BFS already found.
+    #[test]
+    fn relation_sections_related_with_traversal_marker_appears_once() {
+        let (_tmp, app) = app_with_store(&[
+            (
+                "docs/rfcs/RFC-001-anchor.md",
+                &relations_doc_md("Anchor", "rfc", "- related-to: RFC-002"),
+            ),
+            (
+                "docs/rfcs/RFC-002-near.md",
+                &relations_doc_md("Near", "rfc", "[]"),
+            ),
+        ]);
+
+        let doc = doc_by_id(&app, "RFC-001");
+        let sections = app.relation_sections(&doc);
+        let ids = ids_for_paths(&app, &sections.related);
+
+        let occurrences = ids.iter().filter(|id| *id == "RFC-002").count();
+        assert_eq!(
+            occurrences, 1,
+            "related-to target must appear exactly once in related, got {ids:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/cli_context_test.rs
+++ b/tests/integration/cli_context_test.rs
@@ -353,6 +353,60 @@ fn json_related_empty() {
     );
 }
 
+fn setup_with_unmarked_relation() -> TestFixture {
+    // `blocks` carries no traversal marker in the starter config, so the
+    // related BFS drops it (BUG-013); the declared relation must still surface.
+    let fixture = TestFixture::new();
+    fixture.write_doc(
+        "docs/rfcs/RFC-001-anchor.md",
+        "---\ntitle: \"Anchor RFC\"\ntype: rfc\nstatus: accepted\nauthor: jkaloger\ndate: 2026-03-01\ntags: []\nrelated:\n- blocks: docs/rfcs/RFC-002-near.md\n---\n\nbody\n",
+    );
+    fixture.write_doc(
+        "docs/rfcs/RFC-002-near.md",
+        "---\ntitle: \"Near RFC\"\ntype: rfc\nstatus: accepted\nauthor: jkaloger\ndate: 2026-03-01\ntags: []\nrelated: []\n---\n\nbody\n",
+    );
+    fixture
+}
+
+#[test]
+fn json_related_includes_unmarked_declared_relation() {
+    let fixture = setup_with_unmarked_relation();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_json(&store, "RFC-001", 1).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    let related = parsed["related"].as_array().unwrap();
+    let entry = related
+        .iter()
+        .find(|e| e["title"] == "Near RFC")
+        .unwrap_or_else(|| panic!("unmarked declared relation should surface; got: {}", output));
+    assert_eq!(entry["relation"], "blocks");
+    assert_eq!(entry["distance"], 1);
+    assert_eq!(
+        entry["via"].as_str().unwrap(),
+        "docs/rfcs/RFC-001-anchor.md",
+        "declared relation is reached through the target"
+    );
+}
+
+#[test]
+fn human_related_includes_unmarked_declared_relation() {
+    let fixture = setup_with_unmarked_relation();
+    let store = fixture.store();
+    let output = lazyspec::cli::context::run_human(&store, "RFC-001", 1).unwrap();
+
+    assert!(
+        output.contains("related"),
+        "output should contain the related section header; got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("Near RFC"),
+        "output should contain the unmarked-relation target title; got:\n{}",
+        output
+    );
+}
+
 #[test]
 fn no_forward_children_for_leaf() {
     let fixture = setup();


### PR DESCRIPTION
## Why

GitHub sub-issue nesting only ever bound to subdir parent/child file layout, so a flat two-type model (e.g. story `implements` feature) got no native GitHub hierarchy at all even though `github_native = "sub-issue"` already parsed and round-tripped through config unused. Separately, linking an ordinary relation (`related-to`, etc.) on a github-issues doc whose remote issue was authored directly on GitHub (no lazyspec HTML comment in the body) hard-failed, and a relationship with no `traversal` marker was invisible in both the CLI `context` output and the TUI Relations tab even when explicitly declared on the doc.

## What this enables

`link`/`unlink` on a relationship marked `github_native = "sub-issue"` now write/remove the native GitHub sub-issue edge (child → `addSubIssue`/`removeSubIssue` on parent) for same-repo github-issues docs, and `fetch` reads native sub-issue edges back as the configured relation for flat (non-subdir) parents, alongside the existing subdir nesting behaviour. Config rejects more than one relationship claiming `github_native = "sub-issue"` at load time. Linking an ordinary relation on a comment-less GitHub-authored issue body now succeeds by adopting the issue (prose preserved) instead of erroring. Any declared relation — chain or not — now surfaces one hop out in `context` (CLI and TUI Relations tab), matching what the web view already showed.

## Related

Implements STORY-245, STORY-246, BUG-013, BUG-014 (ITERATION-347, ITERATION-348, ITERATION-349, ITERATION-350)
