### PR TITLE
fix: quote reserved frontmatter values that yaml would reject

### DIFF
--- a/docs/bugs/BUG-027-update-assignee-writes-unquoted-yaml-silently-unloading-the-document.md
+++ b/docs/bugs/BUG-027-update-assignee-writes-unquoted-yaml-silently-unloading-the-document.md
@@ -1,0 +1,56 @@
+---
+title: "update --assignee writes unquoted YAML, silently unloading the document"
+type: bug
+status: fixed
+author: "Jack Kaloger"
+date: 2026-09-10
+tags: []
+related: []
+reviewed: 39b82c4e540035ce7009c18fef3a3f64e9eb4d86
+---
+
+## Expected
+
+`lazyspec update <ID> --assignee "@jkaloger"` writes a frontmatter line that is valid YAML, so the document keeps loading in `list`, `show`, `tag` and the TUI.
+
+## Actual
+
+The value is written raw and unquoted:
+
+```yaml
+assignee: @jkaloger
+```
+
+`@` is a YAML reserved indicator, so the frontmatter no longer parses. The document silently disappears from `list`, and `show`/`tag` report `document not found` — the store drops docs it cannot parse rather than surfacing them. Only `validate` names the real error, and only if the caller thinks to run it.
+
+## Repro
+
+```bash
+lazyspec create rfc "Repro" --json
+lazyspec update RFC-001 --assignee "@jkaloger"
+lazyspec show RFC-001     # Error: document not found: RFC-001
+lazyspec validate         # parse error ... found character that cannot start any token at line 8 column 11
+```
+
+Confirmed on 0.11.3. `--title 'Plan: phase 2'` breaks the same way — any value carrying a YAML indicator character does.
+
+## Root cause
+
+`update_document_with_type` in `src/engine/fs_ops.rs` edits frontmatter as text lines, not as YAML. Both branches that write a reserved key interpolate the value verbatim:
+
+- `src/engine/fs_ops.rs:376` / `:378` — the `INSERTED_WHEN_MISSING` branch (`assignee`, `reviewed`): `format!("{}: {}", key, value)`
+- `src/engine/fs_ops.rs:388` — the `RESERVED_UPDATE_KEYS` branch (`status`, `title`, …): same
+
+Custom attributes on the same path are safe: `src/engine/fs_ops.rs:350` routes their values through `serde_yaml::to_string`, which quotes when it must. Reserved keys skip that step.
+
+This is the surviving instance of a bug already fixed elsewhere. `git_ref_store.rs:352` round-trips its whole frontmatter through `serde_yaml` for exactly this reason, citing AUDIT-018 C3: *"YAML-significant values (`Plan: phase 2`) come out properly quoted"*. The filesystem backend never got the same treatment.
+
+## Fix
+
+Emit reserved-key values through `serde_yaml` instead of `format!`, the way `coerced_attrs` already does — one scalar-serialising helper used by both branches. A whole-frontmatter round-trip (matching `git_ref_store`) would also work but reorders and reflows keys the line-editing path deliberately preserves.
+
+Two callers, one helper. A regression test asserting `update --assignee "@x"` round-trips through `Store::load` covers the class.
+
+## Also flagged, no action
+
+`--body-file -` swallowing the newline after the closing `---` was reported alongside this. It does not reproduce on 0.11.3 — `create` and `update`, with and without `--assignee`, all emit the separator correctly. That was [[BUG-016]], fixed by `body_section` in 61c1d20. Whatever the reporter saw is either an older binary or a knock-on of the frontmatter damage above.

--- a/src/engine/fs_ops.rs
+++ b/src/engine/fs_ops.rs
@@ -305,6 +305,25 @@ const RESERVED_UPDATE_KEYS: &[&str] =
 /// `reviewed` (RFC-069) is only ever written with a sha.
 const INSERTED_WHEN_MISSING: &[&str] = &["assignee", "reviewed"];
 
+/// Render one reserved-key frontmatter line, quoting the value when YAML needs
+/// it (BUG-027).
+///
+/// The line-editing update path writes reserved keys as text, so a value opening
+/// with an indicator character (`@jkaloger`) or carrying one (`Plan: phase 2`)
+/// would otherwise produce frontmatter that no longer parses -- and an
+/// unparseable document is dropped from the store rather than reported, so it
+/// vanishes from `list`/`show` with only `validate` naming the cause. Deferring
+/// to `serde_yaml` quotes exactly when required and leaves plain values bare.
+/// The same reasoning drives the whole-frontmatter round-trip in
+/// `git_ref_store::update` (AUDIT-018 C3); the two paths differ only in that
+/// this one preserves key order and formatting by editing in place.
+fn reserved_line(key: &str, value: &str) -> String {
+    let scalar = serde_yaml::to_string(&serde_yaml::Value::String(value.to_string()))
+        .map(|s| s.trim_end().to_string())
+        .unwrap_or_else(|_| value.to_string());
+    format!("{}: {}", key, scalar)
+}
+
 /// Update a filesystem document's frontmatter. Reserved keys (status/title/body/
 /// author) follow the in-place replace path; any other key is a declared custom
 /// attribute, coerced and validated via [`apply_attrs`] against `type_def` and
@@ -373,9 +392,9 @@ pub fn update_document_with_type(
                 (Some(i), true) => {
                     lines.remove(i);
                 }
-                (Some(i), false) => lines[i] = format!("{}: {}", key, value),
+                (Some(i), false) => lines[i] = reserved_line(key, value),
                 (None, true) => {}
-                (None, false) => lines.push(format!("{}: {}", key, value)),
+                (None, false) => lines.push(reserved_line(key, value)),
             }
             continue;
         }
@@ -385,7 +404,7 @@ pub fn update_document_with_type(
                 .iter_mut()
                 .find(|l| l.trim_start().starts_with(&prefix))
             {
-                *line = format!("{}: {}", key, value);
+                *line = reserved_line(key, value);
             }
         }
     }
@@ -657,6 +676,39 @@ mod tests {
         let (_, before_body) = split_frontmatter(&before).unwrap();
         let (_, after_body) = split_frontmatter(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(before_body, after_body);
+    }
+
+    /// BUG-027: a reserved value carrying a YAML indicator character has to
+    /// survive the write as data, not break the frontmatter. Asserted by
+    /// reloading through `Store`, because an unparseable document is silently
+    /// dropped there -- the symptom that made the original bug invisible to
+    /// everything but `validate`.
+    #[test]
+    fn update_quotes_reserved_values_that_yaml_would_otherwise_choke_on() {
+        for (key, value) in [("assignee", "@jkaloger"), ("title", "Plan: phase 2")] {
+            let tmp = TempDir::new().unwrap();
+            let config = Config::default();
+            rfc_with_body(tmp.path(), "body");
+            let store = Store::load(tmp.path(), &config).unwrap();
+
+            update_document(
+                tmp.path(),
+                &store,
+                "docs/rfcs/RFC-001-test.md",
+                &[(key, value)],
+            )
+            .unwrap();
+
+            let reloaded = Store::load(tmp.path(), &config).unwrap();
+            let doc = reloaded
+                .resolve_shorthand("RFC-001")
+                .unwrap_or_else(|e| panic!("{key} = {value:?} unloaded the document: {e}"));
+            let actual = match key {
+                "assignee" => doc.assignee.clone().unwrap(),
+                _ => doc.title.clone(),
+            };
+            assert_eq!(actual, value);
+        }
     }
 
     /// `reviewed` reaching `update_document_with_type` as an ordinary key would


### PR DESCRIPTION
## Why

`update_document_with_type` wrote reserved frontmatter keys (`assignee`, `title`, `status`, …) as raw interpolated text. A value carrying a YAML indicator character — `@jkaloger`, `Plan: phase 2` — produced frontmatter that no longer parses, and the store silently drops documents it can't parse rather than reporting the error, so the document vanished from `list`/`show` with only `validate` naming the real cause (BUG-027).

## What this enables

Reserved-key updates now route through the same `serde_yaml` scalar quoting that custom attributes already used, via a shared `reserved_line` helper. `update --assignee "@jkaloger"` and similar values round-trip correctly instead of corrupting the document.

## Related

Implements BUG-027.

🤖 PR Description generated using an LLM: Claude Sonnet 5 / Claude Code
